### PR TITLE
Throw ErrorCode.InvalidParams if tool params do not match zod schema

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -1269,3 +1269,47 @@ test("makes a sampling request", async () => {
     },
   });
 });
+
+test("throws ErrorCode.InvalidParams if tool parameters do not match zod schema", async () => {
+  await runWithTestServer({
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        name: "add",
+        description: "Add two numbers",
+        parameters: z.object({
+          a: z.number(),
+          b: z.number(),
+        }),
+        execute: async (args) => {
+          return String(args.a + args.b);
+        },
+      });
+
+      return server;
+    },
+    run: async ({ client }) => {
+      try {
+        await client.callTool({
+          name: "add",
+          arguments: {
+            a: 1,
+            b: "invalid",
+          },
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(McpError);
+
+        // @ts-expect-error - we know that error is an McpError
+        expect(error.code).toBe(ErrorCode.InvalidParams);
+
+        // @ts-expect-error - we know that error is an McpError
+        expect(error.message).toBe("Invalid add parameters");
+      }
+    },
+  });
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -722,8 +722,8 @@ export class FastMCPSession extends FastMCPSessionEventEmitter {
 
         if (!parsed.success) {
           throw new McpError(
-            ErrorCode.InvalidRequest,
-            `Invalid ${request.params.name} arguments`,
+            ErrorCode.InvalidParams,
+            `Invalid ${request.params.name} parameters`,
           );
         }
 


### PR DESCRIPTION
Fixes #1

Update `setupToolHandlers` method to throw `ErrorCode.InvalidParams` if tool parameters do not match the zod schema.

* **src/FastMCP.ts**
  - Change error code from `ErrorCode.InvalidRequest` to `ErrorCode.InvalidParams`.
  - Update error message to "Invalid {tool name} parameters".

* **src/FastMCP.test.ts**
  - Add test to check for `ErrorCode.InvalidParams` when tool parameters do not match the zod schema.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/punkpeye/fastmcp/pull/5?shareId=48b23eae-bbe2-4c68-8f79-eed7ffaa13a1).