### PR TITLE
fix: Cursor errors when listing roots

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -568,10 +568,13 @@ export class FastMCPSession<T extends FastMCPSessionAuth = FastMCPSessionAuth> e
       console.warn('[warning] FastMCP could not infer client capabilities')
     }
 
-    if (this.#clientCapabilities?.roots) {
-      const roots = await this.#server.listRoots();
-
-      this.#roots = roots.roots;
+    if (this.#clientCapabilities?.roots?.listChanged) {
+      try {
+        const roots = await this.#server.listRoots();
+        this.#roots = roots.roots;
+      } catch(e) {
+        console.error(`[error] FastMCP received error listing roots.\n\n${e instanceof Error ? e.stack : JSON.stringify(e)}`)
+      }
     }
 
     this.#pingInterval = setInterval(async () => {


### PR DESCRIPTION
Hey! I'm working on a docs MCP for Mastra.ai (https://github.com/mastra-ai/mastra/pull/2966) and ran into the issue that it doesn't work in Cursor.

Seems the issue is we need to check if the client supports listing roots changes, not just if it supports roots.
I'm not 100% sure about the change so interested to hear your thoughts. If I do a try/catch here without checking for `roots.listChanges` that also works. Any idea the difference between the client supporting roots vs the client supporting roots.listChanges?

Fixes https://github.com/punkpeye/fastmcp/issues/19