### PR TITLE
Switch from Zod to Standard Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install fastmcp
 
 ```ts
 import { FastMCP } from "fastmcp";
-import { z } from "zod";
+import { z } from "zod"; // Zod is one option, see below for ArkType and Valibot
 
 const server = new FastMCP({
   name: "My Server",
@@ -48,12 +48,14 @@ const server = new FastMCP({
 server.addTool({
   name: "add",
   description: "Add two numbers",
-  parameters: z.object({
+  // Define parameters using a schema library that implements Standard Schema (Zod, ArkType, Valibot, etc.)
+  parameters: z.object({ // Zod example
     a: z.number(),
     b: z.number(),
   }),
+  // 'args' will be typed according to the schema definition
   execute: async (args) => {
-    return String(args.a + args.b);
+    return String(args.a + args.b); // args is { a: number, b: number }
   },
 });
 
@@ -120,12 +122,54 @@ await client.connect(transport);
 
 [Tools](https://modelcontextprotocol.io/docs/concepts/tools) in MCP allow servers to expose executable functions that can be invoked by clients and used by LLMs to perform actions.
 
-```js
+FastMCP uses the [Standard Schema](https://standardschema.dev) specification for defining tool parameters. This allows you to use your preferred schema validation library (like Zod, ArkType, or Valibot) as long as it implements the spec.
+
+**Zod Example:**
+
+```typescript
+import { z } from "zod";
+
 server.addTool({
-  name: "fetch",
-  description: "Fetch the content of a url",
+  name: "fetch-zod",
+  description: "Fetch the content of a url (using Zod)",
   parameters: z.object({
     url: z.string(),
+  }),
+  execute: async (args) => {
+    return await fetchWebpageContent(args.url);
+  },
+});
+```
+
+**ArkType Example:**
+
+```typescript
+import { type } from "arktype";
+
+server.addTool({
+  name: "fetch-arktype",
+  description: "Fetch the content of a url (using ArkType)",
+  parameters: type({
+    url: "string",
+  }),
+  execute: async (args) => {
+    return await fetchWebpageContent(args.url);
+  },
+});
+```
+
+**Valibot Example:**
+
+Valibot requires the peer dependency @valibot/to-json-schema.
+
+```typescript
+import * as v from "valibot";
+
+server.addTool({
+  name: "fetch-valibot",
+  description: "Fetch the content of a url (using Valibot)",
+  parameters: v.object({
+    url: v.string(),
   }),
   execute: async (args) => {
     return await fetchWebpageContent(args.url);

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install fastmcp
 
 ```ts
 import { FastMCP } from "fastmcp";
-import { z } from "zod"; // Zod is one option, see below for ArkType and Valibot
+import { z } from "zod"; // Or any validation library that supports Standard Schema
 
 const server = new FastMCP({
   name: "My Server",
@@ -48,14 +48,12 @@ const server = new FastMCP({
 server.addTool({
   name: "add",
   description: "Add two numbers",
-  // Define parameters using a schema library that implements Standard Schema (Zod, ArkType, Valibot, etc.)
-  parameters: z.object({ // Zod example
+  parameters: z.object({
     a: z.number(),
     b: z.number(),
   }),
-  // 'args' will be typed according to the schema definition
   execute: async (args) => {
-    return String(args.a + args.b); // args is { a: number, b: number }
+    return String(args.a + args.b);
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "@types/node": "^22.13.5",
     "@types/uri-templates": "^0.1.34",
     "@types/yargs": "^17.0.33",
+    "@valibot/to-json-schema": "^1.0.0",
+    "arktype": "^2.1.16",
     "eslint": "^9.21.0",
     "eslint-plugin-perfectionist": "^4.9.0",
     "eventsource-client": "^1.1.3",
@@ -66,6 +68,7 @@
     "semantic-release": "^24.2.3",
     "tsup": "^8.4.0",
     "typescript": "^5.7.3",
+    "valibot": "^1.0.0",
     "vitest": "^3.0.7"
   },
   "tsup": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "types": "dist/FastMCP.d.ts",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.6.0",
+    "@standard-schema/spec": "^1.0.0",
     "execa": "^9.5.2",
     "file-type": "^20.3.0",
     "fuse.js": "^7.1.0",
@@ -29,9 +30,10 @@
     "strict-event-emitter-types": "^2.0.0",
     "undici": "^7.4.0",
     "uri-templates": "^0.2.0",
+    "xsschema": "0.2.0-beta.2",
     "yargs": "^17.7.2",
     "zod": "^3.24.2",
-    "zod-to-json-schema": "^3.24.3"
+    "zod-to-json-schema": "^3.24.5"
   },
   "repository": {
     "url": "https://github.com/punkpeye/fastmcp"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.6.0
         version: 1.6.0
+      '@standard-schema/spec':
+        specifier: ^1.0.0
+        version: 1.0.0
       execa:
         specifier: ^9.5.2
         version: 9.5.2
@@ -32,6 +35,9 @@ importers:
       uri-templates:
         specifier: ^0.2.0
         version: 0.2.0
+      xsschema:
+        specifier: 0.2.0-beta.2
+        version: 0.2.0-beta.2(zod-to-json-schema@3.24.5(zod@3.24.2))
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -39,8 +45,8 @@ importers:
         specifier: ^3.24.2
         version: 3.24.2
       zod-to-json-schema:
-        specifier: ^3.24.3
-        version: 3.24.3(zod@3.24.2)
+        specifier: ^3.24.5
+        version: 3.24.5(zod@3.24.2)
     devDependencies:
       '@sebbo2002/semantic-release-jsr':
         specifier: ^2.0.4
@@ -549,6 +555,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -2559,6 +2568,23 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xsschema@0.2.0-beta.2:
+    resolution: {integrity: sha512-yaU1SLQVQNboZHHK7iXpCoHzF+sbWvkygAKG6qMKvnpbNdm0SMWAIIj1uasDpCQ21HspPTdEYGg0c0qZYXVQFg==}
+    peerDependencies:
+      '@valibot/to-json-schema': ^1.0.0
+      arktype: ^2.1.13
+      effect: ^3.14.2
+      zod-to-json-schema: ^3.24.5
+    peerDependenciesMeta:
+      '@valibot/to-json-schema':
+        optional: true
+      arktype:
+        optional: true
+      effect:
+        optional: true
+      zod-to-json-schema:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -2591,8 +2617,8 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
-  zod-to-json-schema@3.24.3:
-    resolution: {integrity: sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A==}
+  zod-to-json-schema@3.24.5:
+    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
     peerDependencies:
       zod: ^3.24.1
 
@@ -2778,7 +2804,7 @@ snapshots:
       pkce-challenge: 4.1.0
       raw-body: 3.0.0
       zod: 3.24.2
-      zod-to-json-schema: 3.24.3(zod@3.24.2)
+      zod-to-json-schema: 3.24.5(zod@3.24.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -3007,6 +3033,8 @@ snapshots:
   '@sindresorhus/merge-streams@2.3.0': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.0.0': {}
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
@@ -4946,6 +4974,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  xsschema@0.2.0-beta.2(zod-to-json-schema@3.24.5(zod@3.24.2)):
+    optionalDependencies:
+      zod-to-json-schema: 3.24.5(zod@3.24.2)
+
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -4978,7 +5010,7 @@ snapshots:
 
   yoctocolors@2.1.1: {}
 
-  zod-to-json-schema@3.24.3(zod@3.24.2):
+  zod-to-json-schema@3.24.5(zod@3.24.2):
     dependencies:
       zod: 3.24.2
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 0.2.0
       xsschema:
         specifier: 0.2.0-beta.2
-        version: 0.2.0-beta.2(zod-to-json-schema@3.24.5(zod@3.24.2))
+        version: 0.2.0-beta.2(@valibot/to-json-schema@1.0.0(valibot@1.0.0(typescript@5.7.3)))(arktype@2.1.16)(zod-to-json-schema@3.24.5(zod@3.24.2))
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -63,6 +63,12 @@ importers:
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.33
+      '@valibot/to-json-schema':
+        specifier: ^1.0.0
+        version: 1.0.0(valibot@1.0.0(typescript@5.7.3))
+      arktype:
+        specifier: ^2.1.16
+        version: 2.1.16
       eslint:
         specifier: ^9.21.0
         version: 9.21.0
@@ -90,11 +96,20 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
+      valibot:
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.7.3)
       vitest:
         specifier: ^3.0.7
         version: 3.0.7(@types/node@22.13.5)
 
 packages:
+
+  '@ark/schema@0.45.6':
+    resolution: {integrity: sha512-uI/z6kAabOKeFxbJK2w26dD0FZLutL0LTw0o3EZsX+UC4exc34YUVkm7/wuUMvc5Z27IVDjoaZp9o7X4jOFAbg==}
+
+  '@ark/util@0.45.6':
+    resolution: {integrity: sha512-eI8Y1X0+271Q1p8qU39tkyrzIVMZIuymzixzVD0UL7k+HJaPhbbrjuKW/1CZzQ64tc+ugl7z2kP01YlAMA5h7A==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -615,6 +630,11 @@ packages:
     resolution: {integrity: sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@valibot/to-json-schema@1.0.0':
+    resolution: {integrity: sha512-/9crJgPptVsGCL6X+JPDQyaJwkalSZ/52WuF8DiRUxJgcmpNdzYRfZ+gqMEP8W3CTVfuMWPqqvIgfwJ97f9Etw==}
+    peerDependencies:
+      valibot: ^1.0.0
+
   '@vitest/expect@3.0.7':
     resolution: {integrity: sha512-QP25f+YJhzPfHrHfYHtvRn+uvkCFCqFtW9CktfBxmB+25QqWsx7VB2As6f4GmwllHLDhXNHvqedwhvMmSnNmjw==}
 
@@ -701,6 +721,9 @@ packages:
 
   argv-formatter@1.0.0:
     resolution: {integrity: sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==}
+
+  arktype@2.1.16:
+    resolution: {integrity: sha512-KEuoEtpmbNVAIZqyLE+ox4Ga/6ED7Oe3Ra90sxGe4ZnufLz8AH49Xqis0i6oNEq23KmpduRLZRfS+iTAkjnfDw==}
 
   array-ify@1.0.0:
     resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
@@ -2454,6 +2477,14 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  valibot@1.0.0:
+    resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
@@ -2626,6 +2657,12 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
 snapshots:
+
+  '@ark/schema@0.45.6':
+    dependencies:
+      '@ark/util': 0.45.6
+
+  '@ark/util@0.45.6': {}
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -3103,6 +3140,10 @@ snapshots:
       '@typescript-eslint/types': 8.24.1
       eslint-visitor-keys: 4.2.0
 
+  '@valibot/to-json-schema@1.0.0(valibot@1.0.0(typescript@5.7.3))':
+    dependencies:
+      valibot: 1.0.0(typescript@5.7.3)
+
   '@vitest/expect@3.0.7':
     dependencies:
       '@vitest/spy': 3.0.7
@@ -3191,6 +3232,11 @@ snapshots:
   argparse@2.0.1: {}
 
   argv-formatter@1.0.0: {}
+
+  arktype@2.1.16:
+    dependencies:
+      '@ark/schema': 0.45.6
+      '@ark/util': 0.45.6
 
   array-ify@1.0.0: {}
 
@@ -4864,6 +4910,10 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  valibot@1.0.0(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -4974,8 +5024,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  xsschema@0.2.0-beta.2(zod-to-json-schema@3.24.5(zod@3.24.2)):
+  xsschema@0.2.0-beta.2(@valibot/to-json-schema@1.0.0(valibot@1.0.0(typescript@5.7.3)))(arktype@2.1.16)(zod-to-json-schema@3.24.5(zod@3.24.2)):
     optionalDependencies:
+      '@valibot/to-json-schema': 1.0.0(valibot@1.0.0(typescript@5.7.3))
+      arktype: 2.1.16
       zod-to-json-schema: 3.24.5(zod@3.24.2)
 
   xtend@4.0.2: {}

--- a/src/examples/addition.ts
+++ b/src/examples/addition.ts
@@ -3,20 +3,60 @@
  */
 import { FastMCP } from "../FastMCP.js";
 import { z } from "zod";
+import { type } from "arktype";
+import * as v from "valibot";
 
 const server = new FastMCP({
   name: "Addition",
   version: "1.0.0",
 });
 
+// --- Zod Example ---
+const AddParamsZod = z.object({
+  a: z.number().describe("The first number"),
+  b: z.number().describe("The second number"),
+});
+
 server.addTool({
-  name: "add",
-  description: "Add two numbers",
-  parameters: z.object({
-    a: z.number(),
-    b: z.number(),
-  }),
+  name: "add-zod",
+  description: "Add two numbers (using Zod schema)",
+  parameters: AddParamsZod,
   execute: async (args) => {
+    // args is typed as { a: number, b: number }
+    console.log(`[Zod] Adding ${args.a} and ${args.b}`);
+    return String(args.a + args.b);
+  },
+});
+
+// --- ArkType Example ---
+const AddParamsArkType = type({
+  a: "number",
+  b: "number",
+});
+
+server.addTool({
+  name: "add-arktype",
+  description: "Add two numbers (using ArkType schema)",
+  parameters: AddParamsArkType,
+  execute: async (args) => {
+    // args is typed as { a: number, b: number } based on AddParamsArkType.infer
+    console.log(`[ArkType] Adding ${args.a} and ${args.b}`);
+    return String(args.a + args.b);
+  },
+});
+
+// --- Valibot Example ---
+const AddParamsValibot = v.object({
+  a: v.number("The first number"),
+  b: v.number("The second number"),
+});
+
+server.addTool({
+  name: "add-valibot",
+  description: "Add two numbers (using Valibot schema)",
+  parameters: AddParamsValibot,
+  execute: async (args) => {
+    console.log(`[Valibot] Adding ${args.a} and ${args.b}`);
     return String(args.a + args.b);
   },
 });


### PR DESCRIPTION
## Overview
This PR replaces direct Zod usage with Standard Schema support, allowing users to choose their preferred validation library while maintaining existing functionality.

## Changes
- Added `@standard-schema/spec` and `xsschema` dependencies
- Updated `ToolParameters` type to use `StandardSchemaV1`
- Replaced `zodToJsonSchema` with `toJsonSchema`

## Benefits
- Users can now use any schema library that implements Standard Schema (Zod, Valibot, ArkType)
- Aligns with ecosystem direction supported by schema library creators
- Follows the example of libraries like tRPC, TanStack Form, and others adopting Standard Schema

## Todo
- [x] Implement Standard Schema support
- [x] Update README with examples
- [x] Add usage examples for different schema libraries

## Related Issues
Resolves #26