### PR TITLE
fix [#37] :  roots capability check to prevent listing roots when server doesn't support it

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -859,6 +859,47 @@ test("session knows about roots", async () => {
   });
 });
 
+test("doesn't attempt to list roots when server explicitly disables roots capability", async () => {
+  await runWithTestServer({
+    server: {
+      capabilities: {
+        roots: null  
+      }
+    },
+    client: async () => {
+      const client = new Client(
+        {
+          name: "example-client",
+          version: "1.0.0",
+        },
+        {
+          capabilities: {
+            roots: {
+              listChanged: true,
+            },
+          },
+        }
+      );
+      
+      client.setRequestHandler(ListRootsRequestSchema, () => {
+        return {
+          roots: [
+            {
+              name: "Frontend Repository",
+              uri: "file:///home/user/projects/frontend",
+            },
+          ],
+        };
+      });
+      
+      return client;
+    },
+    run: async ({ session }) => {
+      expect(session.roots).toEqual([]);
+    },
+  });
+});
+
 test("session listens to roots changes", async () => {
   const clientRoots: Root[] = [
     {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -592,7 +592,7 @@ export class FastMCPSession<
       console.warn("[FastMCP warning] could not infer client capabilities");
     }
 
-    if (this.#clientCapabilities?.roots?.listChanged && this.#capabilities.roots) {
+    if (this.#clientCapabilities?.roots?.listChanged && this.#capabilities.roots !== null) {
       try {
         const roots = await this.#server.listRoots();
         this.#roots = roots.roots;

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -592,7 +592,7 @@ export class FastMCPSession<
       console.warn("[FastMCP warning] could not infer client capabilities");
     }
 
-    if (this.#clientCapabilities?.roots?.listChanged) {
+    if (this.#clientCapabilities?.roots?.listChanged && this.#capabilities.roots) {
       try {
         const roots = await this.#server.listRoots();
         this.#roots = roots.roots;


### PR DESCRIPTION
Hi @punkpeye ,

This change fixes #37 

With this change, the server will only try to list roots if:

1. The client supports the roots capability with list changed  notifications
2. The server itself has declared support for the roots capability

This is more robust and will prevent the error I am seeing when the server explicitly disables roots with roots: null or doesn't declare roots support at all.

Tested it on different Agent frameworks and it worked with no issues.

Let me know what you think.