### PR TITLE
feat: configurable ping behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A TypeScript framework for building [MCP](https://glama.ai/mcp) servers capable 
 - [Typed server events](#typed-server-events)
 - [Prompt argument auto-completion](#prompt-argument-auto-completion)
 - [Sampling](#requestsampling)
-- Automated SSE pings
+- [Configurable ping behavior](#configurable-ping-behavior)
 - Roots
 - CLI for [testing](#test-with-mcp-cli) and [debugging](#inspect-with-mcp-inspector)
 
@@ -354,7 +354,32 @@ server.addTool({
 });
 ```
 
-#### Returning an audio
+#### Configurable Ping Behavior
+
+FastMCP includes a configurable ping mechanism to maintain connection health. The ping behavior can be customized through server options:
+
+```ts
+const server = new FastMCP({
+  name: "My Server",
+  version: "1.0.0",
+  ping: {
+    // Explicitly enable or disable pings (defaults vary by transport)
+    enabled: true,
+    // Configure ping interval in milliseconds (default: 5000ms)
+    intervalMs: 10000,
+    // Set log level for ping-related messages (default: 'debug')
+    logLevel: 'debug'
+  }
+});
+```
+
+By default, ping behavior is optimized for each transport type:
+- Enabled for SSE and HTTP streaming connections (which benefit from keep-alive)
+- Disabled for `stdio` connections (where pings are typically unnecessary)
+
+This configurable approach helps reduce log verbosity and optimize performance for different usage scenarios.
+
+### Returning an audio
 
 Use the `audioContent` to create a content object for an audio:
 
@@ -790,7 +815,7 @@ import { AuthError } from "fastmcp";
 const server = new FastMCP({
   name: "My Server",
   version: "1.0.0",
-  authenticate: (request) => {
+  authenticate: ({ request }) => {
     const apiKey = request.headers["x-api-key"];
 
     if (apiKey !== "123") {

--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ import { AuthError } from "fastmcp";
 const server = new FastMCP({
   name: "My Server",
   version: "1.0.0",
-  authenticate: ({ request }) => {
+  authenticate: (request) => {
     const apiKey = request.headers["x-api-key"];
 
     if (apiKey !== "123") {

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -1004,6 +1004,17 @@ test("session listens to roots changes", async () => {
 
 test("session sends pings to the client", async () => {
   await runWithTestServer({
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+        ping: {
+          enabled: true,
+          intervalMs: 1000,
+        },
+      });
+      return server;
+    },
     run: async ({ client }) => {
       const onPing = vi.fn().mockReturnValue({});
 
@@ -1011,7 +1022,8 @@ test("session sends pings to the client", async () => {
 
       await delay(2000);
 
-      expect(onPing).toHaveBeenCalledTimes(1);
+      expect(onPing.mock.calls.length).toBeGreaterThanOrEqual(1);
+      expect(onPing.mock.calls.length).toBeLessThanOrEqual(3);
     },
   });
 });

--- a/src/examples/addition.ts
+++ b/src/examples/addition.ts
@@ -1,10 +1,19 @@
 import { type } from "arktype";
 import * as v from "valibot";
 import { z } from "zod";
+
 import { FastMCP } from "../FastMCP.js";
 
 const server = new FastMCP({
   name: "Addition",
+  ping: {
+    // enabled: undefined,
+    // Automatically enabled/disabled based on transport type
+    // Using a longer interval to reduce log noise
+    intervalMs: 10000, // default is 5000ms
+    // Reduce log verbosity
+    logLevel: "debug", // default
+  },
   version: "1.0.0",
 });
 
@@ -156,9 +165,19 @@ if (transportType === "httpStream") {
   
   await client.connect(transport);
   `);
-} else {
-  // Default to stdio transport
+} else if (process.argv.includes("--explicit-ping-config")) {
   server.start({
     transportType: "stdio",
   });
+
+  console.log(
+    "Started stdio transport with explicit ping configuration from server options",
+  );
+} else {
+  // Disable by default for:
+  server.start({
+    transportType: "stdio",
+  });
+
+  console.log("Started stdio transport with ping disabled by default");
 }


### PR DESCRIPTION
Add ping configuration to `ServerOptions` to reduce excessive logging and improve connection handling. Enable pings by default for SSE/HTTP Streaming while disabling for `stdio`. Allow customization of ping interval and log level

Close #50 