### PR TITLE
feat: add support for `ajv` validation of parameters

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,7 +1,7 @@
-import eslint from '@eslint/js';
+import eslint from "@eslint/js";
 import eslintConfigPrettier from "eslint-config-prettier/flat";
 import perfectionist from "eslint-plugin-perfectionist";
-import tseslint from 'typescript-eslint';
+import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -10,5 +10,5 @@ export default tseslint.config(
   eslintConfigPrettier,
   {
     ignores: ["**/*.js"],
-  }
+  },
 );

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
     "zod": "^3.24.3",
     "zod-to-json-schema": "^3.24.5"
   },
+  "peerDependencies": {
+    "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1"
+  },
   "repository": {
     "url": "https://github.com/punkpeye/fastmcp"
   },
@@ -59,6 +63,8 @@
     "@types/uri-templates": "^0.1.34",
     "@types/yargs": "^17.0.33",
     "@valibot/to-json-schema": "^1.0.0",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "arktype": "^2.1.20",
     "eslint": "^9.25.1",
     "eslint-config-prettier": "^10.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,12 @@ importers:
       '@valibot/to-json-schema':
         specifier: ^1.0.0
         version: 1.0.0(valibot@1.0.0(typescript@5.8.3))
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       arktype:
         specifier: ^2.1.20
         version: 2.1.20
@@ -984,8 +990,19 @@ packages:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
@@ -1468,6 +1485,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.0.6:
+    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
 
@@ -1832,6 +1852,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2370,6 +2393,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
@@ -3697,12 +3724,23 @@ snapshots:
       clean-stack: 5.2.0
       indent-string: 5.0.0
 
+  ajv-formats@3.0.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.0.6
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.0.0:
     dependencies:
@@ -4258,6 +4296,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.0.6: {}
+
   fastq@1.19.0:
     dependencies:
       reusify: 1.0.4
@@ -4597,6 +4637,8 @@ snapshots:
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4999,6 +5041,8 @@ snapshots:
       '@pnpm/npm-conf': 2.3.1
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 

--- a/src/examples/addition.ts
+++ b/src/examples/addition.ts
@@ -97,6 +97,32 @@ server.addTool({
   parameters: AddParamsValibot,
 });
 
+// --- JSON Schema Example ---
+server.addTool({
+  annotations: {
+    openWorldHint: false,
+    readOnlyHint: true,
+    title: "Addition (JSON Schema)",
+  },
+  description: "Add two numbers (using direct JSON Schema object)",
+  execute: async (args) => {
+    // Cast args to the expected type since we know JSON Schema will validate it
+    const typedArgs = args as { a: number; b: number };
+    console.log(`[JSON Schema] Adding ${typedArgs.a} and ${typedArgs.b}`);
+    return String(typedArgs.a + typedArgs.b);
+  },
+  name: "add-jsonschema",
+  parameters: {
+    additionalProperties: false,
+    properties: {
+      a: { type: "number" },
+      b: { type: "number" },
+    },
+    required: ["a", "b"],
+    type: "object",
+  },
+});
+
 server.addResource({
   async load() {
     return {


### PR DESCRIPTION
### Add Support for JSON Schema (via AJV)

This PR adds support for using plain JSON Schema objects in the `parameters` field when defining tools—just like you can already do with Zod, ArkType, and Valibot.

### What’s new

You can now write tools like this using raw JSON Schema:

```ts
server.addTool({
  name: "add",
  description: "Add two numbers",
  parameters: {
    type: "object",
    properties: {
      a: { type: "number" },
      b: { type: "number" },
    },
    required: ["a", "b"],
    additionalProperties: false,
  },
  execute: async (args) => String(args.a + args.b),
});
```

- Behind the scenes, this uses AJV for validation.
- AJV and `ajv-formats` are added as peer dependencies.
- The implementation plugs into the existing validation system without changing the overall shape of how things work.
- Usage is optional and won’t impact folks sticking with Zod or others.

### Under the hood

- Detects JSON Schema objects with a type guard (`isJsonSchema`)
- Wraps them in a simple adapter so they look like a `StandardSchemaV1` validator internally
- Loads AJV dynamically, so it only kicks in if you’re actually using JSON Schema
- Keeps type safety intact, including through the dynamic import
- Errors from AJV are converted into the same format used elsewhere in FastMCP

### Other updates

- Added tests to confirm behavior and edge cases
- Updated the docs with examples
- Implementation stays lightweight—no new files or folders, just fits into the current structure

This is one step toward better support for OpenAPI-style workflows (see #54), and should make it easier to bring your own schemas without needing to convert them into validator-specific formats.
