### PR TITLE
feat: add support for health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,15 +417,12 @@ const server = new FastMCP({
   health: {
     // Enable / disable (default: true)
     enabled: true,
-
-    // Path that should respond (default: '/health')
-    path: "/healthz",
-
-    // HTTP status code to return (default: 200)
-    status: 200,
-
     // Body returned by the endpoint (default: 'ok')
     message: "healthy",
+    // Path that should respond (default: '/health')
+    path: "/healthz",
+    // HTTP status code to return (default: 200)
+    status: 200,
   },
 });
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A TypeScript framework for building [MCP](https://glama.ai/mcp) servers capable 
 - [Prompt argument auto-completion](#prompt-argument-auto-completion)
 - [Sampling](#requestsampling)
 - [Configurable ping behavior](#configurable-ping-behavior)
+- [Health-check endpoint](#health-check-endpoint)
 - [Roots](#roots-management)
 - CLI for [testing](#test-with-mcp-cli) and [debugging](#inspect-with-mcp-inspector)
 
@@ -400,6 +401,50 @@ By default, ping behavior is optimized for each transport type:
 - Disabled for `stdio` connections (where pings are typically unnecessary)
 
 This configurable approach helps reduce log verbosity and optimize performance for different usage scenarios.
+
+### Health-check Endpoint
+
+When you run FastMCP with the `httpStream` transport you can optionally expose a
+simple HTTP endpoint that returns a plain-text response useful for load-balancer
+or container orchestration liveness checks.
+
+Enable (or customise) the endpoint via the `health` key in the server options:
+
+```ts
+const server = new FastMCP({
+  name: "My Server",
+  version: "1.0.0",
+  health: {
+    // Enable / disable (default: true)
+    enabled: true,
+
+    // Path that should respond (default: '/health')
+    path: "/healthz",
+
+    // HTTP status code to return (default: 200)
+    status: 200,
+
+    // Body returned by the endpoint (default: 'ok')
+    message: "healthy",
+  },
+});
+
+await server.start({
+  transportType: "httpStream",
+  httpStream: { port: 8080 },
+});
+```
+
+Now a request to `http://localhost:8080/healthz` will return:
+
+```
+HTTP/1.1 200 OK
+content-type: text/plain
+
+healthy
+```
+
+The endpoint is ignored when the server is started with the `stdio` transport.
 
 #### Roots Management
 

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { createEventSource, EventSourceClient } from "eventsource-client";
 import { getRandomPort } from "get-port-please";
+import { fetch } from "undici";
 import { setTimeout as delay } from "timers/promises";
 import { expect, test, vi } from "vitest";
 import { z } from "zod";
@@ -134,6 +135,29 @@ test("adds tools", async () => {
       return server;
     },
   });
+});
+
+test("health endpoint returns ok", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    health: { path: "/healthz", message: "healthy" },
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  await server.start({
+    httpStream: { port },
+    transportType: "httpStream",
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/healthz`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("healthy");
+  } finally {
+    await server.stop();
+  }
 });
 
 test("calls a tool", async () => {

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -12,8 +12,8 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { createEventSource, EventSourceClient } from "eventsource-client";
 import { getRandomPort } from "get-port-please";
-import { fetch } from "undici";
 import { setTimeout as delay } from "timers/promises";
+import { fetch } from "undici";
 import { expect, test, vi } from "vitest";
 import { z } from "zod";
 
@@ -141,7 +141,7 @@ test("health endpoint returns ok", async () => {
   const port = await getRandomPort();
 
   const server = new FastMCP({
-    health: { path: "/healthz", message: "healthy" },
+    health: { message: "healthy", path: "/healthz" },
     name: "Test",
     version: "1.0.0",
   });

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -467,6 +467,41 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
     logLevel?: LoggingLevel;
   };
   /**
+   * Configuration for the health-check endpoint that can be exposed when the
+   * server is running using the HTTP Stream transport. When enabled, the
+   * server will respond to an HTTP GET request with the configured path (by
+   * default "/health") rendering a plain-text response (by default "ok") and
+   * the configured status code (by default 200).
+   *
+   * The endpoint is only added when the server is started with
+   * `transportType: "httpStream"` – it is ignored for the stdio transport.
+   */
+  health?: {
+    /**
+     * When set to `false` the health-check endpoint is disabled.
+     * @default true
+     */
+    enabled?: boolean;
+
+    /**
+     * HTTP path that should be handled.
+     * @default "/health"
+     */
+    path?: string;
+
+    /**
+     * HTTP response status that will be returned.
+     * @default 200
+     */
+    status?: number;
+
+    /**
+     * Plain-text body returned by the endpoint.
+     * @default "ok"
+     */
+    message?: string;
+  };
+  /**
    * Configuration for roots capability
    */
   roots?: {
@@ -1481,6 +1516,36 @@ export class FastMCP<
           this.emit("connect", {
             session,
           });
+        },
+        onUnhandledRequest: async (req, res) => {
+          const healthConfig = this.#options.health ?? {};
+
+          const enabled =
+            healthConfig.enabled === undefined ? true : healthConfig.enabled;
+
+          if (enabled) {
+            const path = healthConfig.path ?? "/health";
+
+            try {
+              if (
+                req.method === "GET" &&
+                new URL(req.url || "", "http://localhost").pathname === path
+              ) {
+                res
+                  .writeHead(healthConfig.status ?? 200, {
+                    "Content-Type": "text/plain",
+                  })
+                  .end(healthConfig.message ?? "ok");
+
+                return;
+              }
+            } catch (error) {
+              console.error("[FastMCP error] health endpoint error", error);
+            }
+          }
+
+          // If the request was not handled above, return 404
+          res.writeHead(404).end();
         },
         port: options.httpStream.port,
       });

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -446,26 +446,6 @@ type ResourceTemplateArgumentsToObject<T extends { name: string }[]> = {
 
 type ServerOptions<T extends FastMCPSessionAuth> = {
   authenticate?: Authenticate<T>;
-  instructions?: string;
-  name: string;
-  ping?: {
-    /**
-     * Whether ping should be enabled by default.
-     * - true for SSE or HTTP Stream
-     * - false for stdio
-     */
-    enabled?: boolean;
-    /**
-     * Interval
-     * @default 5000 (5s)
-     */
-    intervalMs?: number;
-    /**
-     * Logging level for ping-related messages.
-     * @default 'debug'
-     */
-    logLevel?: LoggingLevel;
-  };
   /**
    * Configuration for the health-check endpoint that can be exposed when the
    * server is running using the HTTP Stream transport. When enabled, the
@@ -484,6 +464,12 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
     enabled?: boolean;
 
     /**
+     * Plain-text body returned by the endpoint.
+     * @default "ok"
+     */
+    message?: string;
+
+    /**
      * HTTP path that should be handled.
      * @default "/health"
      */
@@ -494,12 +480,27 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
      * @default 200
      */
     status?: number;
+  };
+  instructions?: string;
+  name: string;
 
+  ping?: {
     /**
-     * Plain-text body returned by the endpoint.
-     * @default "ok"
+     * Whether ping should be enabled by default.
+     * - true for SSE or HTTP Stream
+     * - false for stdio
      */
-    message?: string;
+    enabled?: boolean;
+    /**
+     * Interval
+     * @default 5000 (5s)
+     */
+    intervalMs?: number;
+    /**
+     * Logging level for ping-related messages.
+     * @default 'debug'
+     */
+    logLevel?: LoggingLevel;
   };
   /**
    * Configuration for roots capability


### PR DESCRIPTION
## Summary
- Add a configurable health check endpoint for HTTP Stream transport
- Add comprehensive documentation for the health check feature in README.md

## Details
This PR adds a new feature to FastMCP that enables a configurable health check endpoint when using the HTTP Stream transport. This is useful for load balancers, container orchestration systems, and monitoring tools to verify the server's health.

### Implementation
- Added a new `health` configuration option to `ServerOptions` with the following customizable parameters:
  - `enabled`: Toggle the health endpoint (default: true)
  - `path`: HTTP path to respond to (default: "/health")
  - `status`: HTTP status code to return (default: 200)
  - `message`: Plain-text response body (default: "ok")
- Implemented the endpoint handler in the HTTP Stream transport's `onUnhandledRequest` callback
- Added a test to verify the health endpoint functionality
- The endpoint is ignored when using the stdio transport

### Documentation
- Added "Health-check endpoint" to the feature list in README.md
- Created a new "Health-check Endpoint" section with detailed documentation
- Included a complete code example showing how to configure the endpoint
- Documented the expected HTTP response format

## Test plan
- Added unit test that verifies the health endpoint returns the expected status code and message
- Manually tested with different configuration options
- Verified that the endpoint is ignored when using stdio transport

This description provides a clear overview of the changes, explains the implementation details, documents the additions to the README, and outlines the testing approach. You can use this as a template for your pull request.
