### PR TITLE
fix: ResourceTemplate Arguments Type

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -362,6 +362,7 @@ type InputResourceTemplateArgument = Readonly<{
   complete?: ArgumentValueCompleter;
   description?: string;
   name: string;
+  required?: boolean;
 }>;
 
 type LoggingLevel =
@@ -438,6 +439,7 @@ type ResourceTemplateArgument = Readonly<{
   complete?: ArgumentValueCompleter;
   description?: string;
   name: string;
+  required?: boolean;
 }>;
 
 type ResourceTemplateArgumentsToObject<T extends { name: string }[]> = {


### PR DESCRIPTION
Resolves typing issue where `required` and `complete` properties cannot be used together in ResourceTemplate arguments, bringing type consistency with PromptArgument interface.

Closes #20 