### PR TITLE
fix(docs): update README to use await for async functions in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,10 +587,10 @@ server.addTool({
 
   // or...
   // execute: async (args) => {
-  //   const imgContent = imageContent({
+  //   const imgContent = await imageContent({
   //     url: "https://example.com/image.png",
   //   });
-  //   const audContent = audioContent({
+  //   const audContent = await audioContent({
   //     url: "https://example.com/audio.mp3",
   //   });
   //   return {


### PR DESCRIPTION
Fix missing await when calling async function imageContent in the document 

### Reference
The type definition of `imageContent`:
```
declare const imageContent: (input: {
    buffer: Buffer;
} | {
    path: string;
} | {
    url: string;
}) => Promise<ImageContent>;
```

The type definition of `Content` (item of content list):
```
type Content = AudioContent | ImageContent | TextContent;
```
