### PR TITLE
feat: embedded resources API (`server.embedded(uri)` method)

### DIFF
--- a/src/examples/addition.ts
+++ b/src/examples/addition.ts
@@ -170,6 +170,62 @@ server.addPrompt({
   name: "git-commit",
 });
 
+server.addResourceTemplate({
+  arguments: [
+    {
+      description: "Documentation section to retrieve",
+      name: "section",
+      required: true,
+    },
+  ],
+  description: "Get project documentation",
+  load: async (args) => {
+    const docs = {
+      "api-reference":
+        "# API Reference\n\n## Authentication\nAll API requests require a valid API key in the Authorization header.\n\n## Endpoints\n- GET /users - List all users\n- POST /users - Create new user",
+      deployment:
+        "# Deployment Guide\n\nTo deploy this application:\n\n1. Build the project: `npm run build`\n2. Set environment variables\n3. Deploy to your hosting platform",
+      "getting-started":
+        "# Getting Started\n\nWelcome to our project! Follow these steps to set up your development environment:\n\n1. Clone the repository\n2. Install dependencies with `npm install`\n3. Run `npm start` to begin",
+    };
+
+    return {
+      text:
+        docs[args.section as keyof typeof docs] ||
+        "Documentation section not found",
+    };
+  },
+  mimeType: "text/markdown",
+  name: "Project Documentation",
+  uriTemplate: "docs://project/{section}",
+});
+
+server.addTool({
+  annotations: {
+    openWorldHint: false,
+    readOnlyHint: true,
+    title: "Get Documentation (Embedded)",
+  },
+  description:
+    "Retrieve project documentation using embedded resources - demonstrates the new embedded() feature",
+  execute: async (args) => {
+    return {
+      content: [
+        {
+          resource: await server.embedded(`docs://project/${args.section}`),
+          type: "resource",
+        },
+      ],
+    };
+  },
+  name: "get-documentation",
+  parameters: z.object({
+    section: z
+      .enum(["getting-started", "api-reference", "deployment"])
+      .describe("Documentation section to retrieve"),
+  }),
+});
+
 // Select transport type based on command line arguments
 const transportType = process.argv.includes("--http-stream")
   ? "httpStream"


### PR DESCRIPTION
Implements the embedded resources API, providing **a clean and simple way to include resources in tool responses** without ~code~ code duplication:

```ts
// Example usage
server.addTool({
  name: "get_user_data",
  execute: async (args) => {
    return {
      content: [{
        type: "resource",
        resource: await server.embedded(`user://profile/${args.userId}`)
      }]
    };
  }
});
```

Closes #85 
