### PR TITLE
fix: HTTP Stream Transport Buffering

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -514,6 +514,76 @@ test("tracks tool progress", async () => {
   });
 });
 
+test("reports multiple progress updates without buffering (fixes issue #90)", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const progressCalls: Array<{ progress: number; total: number }> = [];
+      const onProgress = vi.fn((data) => {
+        progressCalls.push(data);
+      });
+
+      await client.callTool(
+        {
+          arguments: {
+            steps: 3,
+          },
+          name: "progress-test",
+        },
+        undefined,
+        {
+          onprogress: onProgress,
+        },
+      );
+
+      expect(onProgress).toHaveBeenCalledTimes(4);
+      expect(progressCalls).toEqual([
+        { progress: 0, total: 100 },
+        { progress: 50, total: 100 },
+        { progress: 90, total: 100 },
+        { progress: 100, total: 100 }, // This was previously lost due to buffering
+      ]);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Test tool for progress buffering fix",
+        execute: async (args, { reportProgress }) => {
+          const { steps } = args;
+
+          // Initial
+          await reportProgress({ progress: 0, total: 100 });
+
+          for (let i = 1; i <= steps; i++) {
+            await delay(50); // Small delay to simulate work
+
+            if (i === 1) {
+              await reportProgress({ progress: 50, total: 100 });
+            } else if (i === 2) {
+              await reportProgress({ progress: 90, total: 100 });
+            }
+          }
+
+          // This was the critical test case that failed before the fix
+          // because there's no await after it, causing it to be buffered
+          await reportProgress({ progress: 100, total: 100 });
+
+          return "Progress test completed";
+        },
+        name: "progress-test",
+        parameters: z.object({
+          steps: z.number(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
 test("sets logging levels", async () => {
   await runWithTestServer({
     run: async ({ client, session }) => {

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -514,7 +514,7 @@ test("tracks tool progress", async () => {
   });
 });
 
-test("reports multiple progress updates without buffering (fixes issue #90)", async () => {
+test("reports multiple progress updates without buffering", async () => {
   await runWithTestServer({
     run: async ({ client }) => {
       const progressCalls: Array<{ progress: number; total: number }> = [];

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1369,6 +1369,8 @@ export class FastMCPSession<
               progressToken,
             },
           });
+
+          await new Promise((resolve) => setImmediate(resolve));
         };
 
         const log = {
@@ -1423,6 +1425,8 @@ export class FastMCPSession<
               toolName: request.params.name,
             },
           });
+
+          await new Promise((resolve) => setImmediate(resolve));
         };
 
         const executeToolPromise = tool.execute(args, {

--- a/src/examples/addition.ts
+++ b/src/examples/addition.ts
@@ -155,6 +155,35 @@ server.addTool({
   }),
 });
 
+server.addTool({
+  annotations: {
+    openWorldHint: false,
+    readOnlyHint: false,
+  },
+  description: "Test progress reporting without buffering delays",
+  execute: async (args, { reportProgress }) => {
+    console.log("Testing progress reporting fix for HTTP Stream buffering...");
+
+    await reportProgress({ progress: 0, total: 100 });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    await reportProgress({ progress: 25, total: 100 });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    await reportProgress({ progress: 75, total: 100 });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // This progress should be received immediately
+    await reportProgress({ progress: 100, total: 100 });
+
+    return `Buffering test completed for ${args.testCase}`;
+  },
+  name: "test-buffering-fix",
+  parameters: z.object({
+    testCase: z.string().describe("Test case description"),
+  }),
+});
+
 server.addPrompt({
   arguments: [
     {


### PR DESCRIPTION
When using FastMCP with HTTP Stream transport, progress notifications (`reportProgress`) and streaming content (`streamContent`) were not sent immediately to clients. Instead, they were buffered by the HTTP transport layer and only flushed when the next async operation occurred. So, we're added automatic flush behavior to both `reportProgress` and `streamContent` functions by inserting a minimal async operation after each notification:

```ts
// Force flush for HTTP stream transport to prevent buffering delays
await new Promise((resolve) => setImmediate(resolve));
```

- `setImmediate` schedules the callback for the next iteration of the event loop
- This gives Node.js time to flush any buffered HTTP responses
- The operation is lightweight and doesn't introduce significant delay
- It's transport-agnostic and works for both HTTP Stream and stdio

CLOSE #90 