### PR TITLE
Fix/update doc for progress report

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,10 +587,10 @@ server.addTool({
 
   // or...
   // execute: async (args) => {
-  //   const imgContent = imageContent({
+  //   const imgContent = await imageContent({
   //     url: "https://example.com/image.png",
   //   });
-  //   const audContent = audioContent({
+  //   const audContent = await audioContent({
   //     url: "https://example.com/audio.mp3",
   //   });
   //   return {

--- a/README.md
+++ b/README.md
@@ -700,14 +700,14 @@ server.addTool({
     url: z.string(),
   }),
   execute: async (args, { reportProgress }) => {
-    reportProgress({
+    await reportProgress({
       progress: 0,
       total: 100,
     });
 
     // ...
 
-    reportProgress({
+    await reportProgress({
       progress: 100,
       total: 100,
     });


### PR DESCRIPTION
### Summary

This PR updates the documentation to clarify the correct usage of the reportProgress function, especially in light of recent changes affecting HTTP streaming transport behavior.

### Background

In [PR #91](https://github.com/punkpeye/fastmcp/pull/91), we addressed an issue related to HTTP stream transport buffering. This fix altered how progress notifications are handled depending on the transport method used.

- **stdio Transport**: When using the stdio transport, invoking reportProgress with or without await functions correctly. Both approaches successfully send progress notifications.
- **HTTP Streaming Transport**: With HTTP streaming, it’s imperative to use await when calling reportProgress. Omitting await may result in progress notifications not being sent, due to the asynchronous nature of HTTP streaming and the need to ensure the notification is flushed properly.

### Changes
- Documentation Update: Clarified the necessity of using await when calling reportProgress. Regardless of the transport mechanism—whether it’s stdio, or HTTP streaming—it’s recommended to use await when calling reportProgress.