### PR TITLE
fix: change onConnect to synchronous function in FastMCP

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1718,7 +1718,7 @@ export class FastMCP<
             session,
           });
         },
-        onConnect: async (session) => {
+        onConnect: (session) => {
           this.#sessions.push(session);
 
           this.emit("connect", {


### PR DESCRIPTION
## Related issue
This fix is relevant to issue #103 
## Potential solutions:
### Add `await` before each `onConnect` in `startHTTPServer.ts` in `mcp-proxy`
```typescript
// For example, in startHTTPServer.ts line 128
await onConnect?.(server);
```
However, this requires a PR to `mcp-proxy` 🤦🏻‍♂️.

In `fastmcp`, currently we don't have async operations in `onConnect` handler:
```typescript
 onConnect: (session) => {
          this.#sessions.push(session);

          this.emit("connect", {
            session,
          });
        },
 ```
 It is more reasonable to simply remove `async` keywords to avoid any confusions. 
 
 ❓ Not sure if we need to introduce any test cases for this. 