### PR TITLE
Fix/upgrade mcp proxy and add async to on close

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "execa": "^9.6.0",
     "file-type": "^21.0.0",
     "fuse.js": "^7.1.0",
-    "mcp-proxy": "^4.0.0",
+    "mcp-proxy": "^5.0.0",
     "strict-event-emitter-types": "^2.0.0",
     "undici": "^7.10.0",
     "uri-templates": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0
       mcp-proxy:
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^5.0.0
+        version: 5.0.0
       strict-event-emitter-types:
         specifier: ^2.0.0
         version: 2.0.0
@@ -2297,8 +2297,8 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  mcp-proxy@4.0.0:
-    resolution: {integrity: sha512-AeSQW7DJr3XhhqlctWfSYOJIlI1TpQEEIVHdFW9/0xfYwtIo2ueOS9dHpBOJJWmER0kvE5rZnSw6o+yK8lk9OA==}
+  mcp-proxy@5.0.0:
+    resolution: {integrity: sha512-qQPGiV2iJnaaBErWpdy//NAdbYVzR5GCo9NDqj/zvQGKNb6IZWMaN/hdVoXaIxQx15REmKuTsfclVwU+/+FDyA==}
     hasBin: true
 
   media-typer@1.1.0:
@@ -5713,7 +5713,7 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mcp-proxy@4.0.0:
+  mcp-proxy@5.0.0:
     dependencies:
       '@modelcontextprotocol/sdk': 1.12.1
       eventsource: 4.0.0

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -1060,8 +1060,8 @@ test("uses events to notify server of client connect/disconnect", async () => {
     version: "1.0.0",
   });
 
-  const onConnect = vi.fn();
-  const onDisconnect = vi.fn();
+  const onConnect = vi.fn().mockResolvedValue(undefined);
+  const onDisconnect = vi.fn().mockResolvedValue(undefined);
 
   server.on("connect", onConnect);
   server.on("disconnect", onDisconnect);

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1713,7 +1713,7 @@ export class FastMCP<
             version: this.#options.version,
           });
         },
-        onClose: (session) => {
+        onClose: async (session) => {
           this.emit("disconnect", {
             session,
           });


### PR DESCRIPTION
## Background
Please check this issue #103 
As mentioned by @punkpeye, "this is a bug in mcp-proxy – those methods should have been awaited."

This has been fixed in v5 of mcp-proxy:
https://github.com/punkpeye/mcp-proxy/releases/tag/v5.0.0

## What has this PR done
1. Update the `mcp-proxy` to latest version 5.0.0
2. Add `async` keywords to the `onClose` handler of the `startHTTPServer` function (`onConnect` is already async)
3. Update the test case to use mockResolvedValue to match the async nature of the handlers.