### PR TITLE
feat: Add support to change http server endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ server.start({
 
 This will start the server and listen for HTTP streaming connections on `http://localhost:8080/mcp`.
 
+> **Note:** You can also customize the endpoint path using the `httpStream.endpoint` option (default is `/mcp`).
+
 You can connect to these servers using the appropriate client transport.
 
 For HTTP streaming connections:
@@ -1441,11 +1443,11 @@ Follow the guide https://modelcontextprotocol.io/quickstart/user and add the fol
 
 - [apinetwork/piapi-mcp-server](https://github.com/apinetwork/piapi-mcp-server) - generate media using Midjourney/Flux/Kling/LumaLabs/Udio/Chrip/Trellis
 - [domdomegg/computer-use-mcp](https://github.com/domdomegg/computer-use-mcp) - controls your computer
-- [LiterallyBlah/Dradis-MCP](https://github.com/LiterallyBlah/Dradis-MCP) – manages projects and vulnerabilities in Dradis
+- [LiterallyBlah/Dradis-MCP](https://github.com/LiterallyBlah/Dradis-MCP) – manages projects and vulnerabilities in Dradis
 - [Meeting-Baas/meeting-mcp](https://github.com/Meeting-Baas/meeting-mcp) - create meeting bots, search transcripts, and manage recording data
-- [drumnation/unsplash-smart-mcp-server](https://github.com/drumnation/unsplash-smart-mcp-server) – enables AI agents to seamlessly search, recommend, and deliver professional stock photos from Unsplash
+- [drumnation/unsplash-smart-mcp-server](https://github.com/drumnation/unsplash-smart-mcp-server) – enables AI agents to seamlessly search, recommend, and deliver professional stock photos from Unsplash
 - [ssmanji89/halopsa-workflows-mcp](https://github.com/ssmanji89/halopsa-workflows-mcp) - HaloPSA Workflows integration with AI assistants
-- [aiamblichus/mcp-chat-adapter](https://github.com/aiamblichus/mcp-chat-adapter) – provides a clean interface for LLMs to use chat completion
+- [aiamblichus/mcp-chat-adapter](https://github.com/aiamblichus/mcp-chat-adapter) – provides a clean interface for LLMs to use chat completion
 - [eyaltoledano/claude-task-master](https://github.com/eyaltoledano/claude-task-master) – advanced AI project/task manager powered by FastMCP
 - [cswkim/discogs-mcp-server](https://github.com/cswkim/discogs-mcp-server) - connects to the Discogs API for interacting with your music collection
 - [Panzer-Jack/feuse-mcp](https://github.com/Panzer-Jack/feuse-mcp) - Frontend Useful MCP Tools - Essential utilities for web developers to automate API integration and code generation

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -1556,6 +1556,84 @@ test("lists resource templates", async () => {
   });
 });
 
+test("HTTP Stream: custom endpoint works with /another-mcp", { timeout: 20000 }, async () => {
+  const port = await getRandomPort();
+
+  // Create server with custom endpoint
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  server.addTool({
+    description: "Add two numbers",
+    execute: async (args) => {
+      return String(args.a + args.b);
+    },
+    name: "add",
+    parameters: z.object({
+      a: z.number(),
+      b: z.number(),
+    }),
+  });
+
+  await server.start({
+    httpStream: {
+      port,
+      endpoint: "/another-mcp",
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    // Create client
+    const client = new Client(
+      {
+        name: "example-client",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${port}/another-mcp`),
+    );
+
+    // Connect client to server and wait for session to be ready
+    const sessionPromise = new Promise<FastMCPSession>((resolve) => {
+      server.on("connect", async (event) => {
+        await event.session.waitForReady();
+        resolve(event.session);
+      });
+    });
+
+    await client.connect(transport);
+    await sessionPromise;
+
+    // Call tool
+    const result = await client.callTool({
+      arguments: {
+        a: 5,
+        b: 7,
+      },
+      name: "add",
+    });
+
+    // Check result
+    expect(result).toEqual({
+      content: [{ text: "12", type: "text" }],
+    });
+
+    // Clean up connection
+    await transport.terminateSession();
+    await client.close();
+  } finally {
+    await server.stop();
+  }
+});
+
 test("clients reads a resource accessed via a resource template", async () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const loadSpy = vi.fn((_args) => {

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -1556,83 +1556,87 @@ test("lists resource templates", async () => {
   });
 });
 
-test("HTTP Stream: custom endpoint works with /another-mcp", { timeout: 20000 }, async () => {
-  const port = await getRandomPort();
+test(
+  "HTTP Stream: custom endpoint works with /another-mcp",
+  { timeout: 20000 },
+  async () => {
+    const port = await getRandomPort();
 
-  // Create server with custom endpoint
-  const server = new FastMCP({
-    name: "Test",
-    version: "1.0.0",
-  });
-
-  server.addTool({
-    description: "Add two numbers",
-    execute: async (args) => {
-      return String(args.a + args.b);
-    },
-    name: "add",
-    parameters: z.object({
-      a: z.number(),
-      b: z.number(),
-    }),
-  });
-
-  await server.start({
-    httpStream: {
-      port,
-      endpoint: "/another-mcp",
-    },
-    transportType: "httpStream",
-  });
-
-  try {
-    // Create client
-    const client = new Client(
-      {
-        name: "example-client",
-        version: "1.0.0",
-      },
-      {
-        capabilities: {},
-      },
-    );
-
-    const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/another-mcp`),
-    );
-
-    // Connect client to server and wait for session to be ready
-    const sessionPromise = new Promise<FastMCPSession>((resolve) => {
-      server.on("connect", async (event) => {
-        await event.session.waitForReady();
-        resolve(event.session);
-      });
+    // Create server with custom endpoint
+    const server = new FastMCP({
+      name: "Test",
+      version: "1.0.0",
     });
 
-    await client.connect(transport);
-    await sessionPromise;
-
-    // Call tool
-    const result = await client.callTool({
-      arguments: {
-        a: 5,
-        b: 7,
+    server.addTool({
+      description: "Add two numbers",
+      execute: async (args) => {
+        return String(args.a + args.b);
       },
       name: "add",
+      parameters: z.object({
+        a: z.number(),
+        b: z.number(),
+      }),
     });
 
-    // Check result
-    expect(result).toEqual({
-      content: [{ text: "12", type: "text" }],
+    await server.start({
+      httpStream: {
+        endpoint: "/another-mcp",
+        port,
+      },
+      transportType: "httpStream",
     });
 
-    // Clean up connection
-    await transport.terminateSession();
-    await client.close();
-  } finally {
-    await server.stop();
-  }
-});
+    try {
+      // Create client
+      const client = new Client(
+        {
+          name: "example-client",
+          version: "1.0.0",
+        },
+        {
+          capabilities: {},
+        },
+      );
+
+      const transport = new StreamableHTTPClientTransport(
+        new URL(`http://localhost:${port}/another-mcp`),
+      );
+
+      // Connect client to server and wait for session to be ready
+      const sessionPromise = new Promise<FastMCPSession>((resolve) => {
+        server.on("connect", async (event) => {
+          await event.session.waitForReady();
+          resolve(event.session);
+        });
+      });
+
+      await client.connect(transport);
+      await sessionPromise;
+
+      // Call tool
+      const result = await client.callTool({
+        arguments: {
+          a: 5,
+          b: 7,
+        },
+        name: "add",
+      });
+
+      // Check result
+      expect(result).toEqual({
+        content: [{ text: "12", type: "text" }],
+      });
+
+      // Clean up connection
+      await transport.terminateSession();
+      await client.close();
+    } finally {
+      await server.stop();
+    }
+  },
+);
 
 test("clients reads a resource accessed via a resource template", async () => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1686,7 +1686,7 @@ export class FastMCP<
   public async start(
     options:
       | {
-          httpStream: { port: number };
+          httpStream: { port: number; endpoint?: `/${string}` };
           transportType: "httpStream";
         }
       | { transportType: "stdio" } = {
@@ -1718,6 +1718,7 @@ export class FastMCP<
       });
     } else if (options.transportType === "httpStream") {
       this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
+        streamEndpoint: options.httpStream.endpoint ?? "/mcp",
         createServer: async (request) => {
           let auth: T | undefined;
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1686,7 +1686,7 @@ export class FastMCP<
   public async start(
     options:
       | {
-          httpStream: { port: number; endpoint?: `/${string}` };
+          httpStream: { endpoint?: `/${string}`; port: number };
           transportType: "httpStream";
         }
       | { transportType: "stdio" } = {
@@ -1718,7 +1718,6 @@ export class FastMCP<
       });
     } else if (options.transportType === "httpStream") {
       this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
-        streamEndpoint: options.httpStream.endpoint ?? "/mcp",
         createServer: async (request) => {
           let auth: T | undefined;
 
@@ -1808,6 +1807,7 @@ export class FastMCP<
           res.writeHead(404).end();
         },
         port: options.httpStream.port,
+        streamEndpoint: options.httpStream.endpoint ?? "/mcp",
       });
 
       console.info(


### PR DESCRIPTION
Add optional endpoint attribute to specific which endpoint to use for mcp server (default to "/mcp")

#95 

```typescript
await server.start({
  httpStream: {
    port: 8080,
    endpoint: "/custom-mcp",
  },
  transportType: "httpStream",
});
```