### PR TITLE
Removing endpoint from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,7 +1209,6 @@ server.addTool({
 server.start({
   transportType: "httpStream",
   httpStream: {
-    endpoint: "/mcp",
     port: 8080,
   },
 });


### PR DESCRIPTION
At some point, endpoint was deprecated from httpStream options, so I'm removing it from the documentation that was based on an older version in order to avoid confusion