### PR TITLE
feat: Allow ResourceTemplate to return array of resources.

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -1518,8 +1518,6 @@ test("completes template resource arguments", async () => {
 test("lists resource templates", async () => {
   await runWithTestServer({
     run: async ({ client }) => {
-      const result = await client.listResourceTemplates();
-      console.log(result);
       expect(await client.listResourceTemplates()).toEqual({
         resourceTemplates: [
           {

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -1518,9 +1518,12 @@ test("completes template resource arguments", async () => {
 test("lists resource templates", async () => {
   await runWithTestServer({
     run: async ({ client }) => {
+      const result = await client.listResourceTemplates();
+      console.log(result);
       expect(await client.listResourceTemplates()).toEqual({
         resourceTemplates: [
           {
+            mimeType: "text/plain",
             name: "Application Logs",
             uriTemplate: "file:///logs/{name}.log",
           },

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -490,7 +490,6 @@ type ResourceTemplateArgumentsToObject<T extends { name: string }[]> = {
   [K in T[number]["name"]]: string;
 };
 
-
 type ServerOptions<T extends FastMCPSessionAuth> = {
   authenticate?: Authenticate<T>;
   /**

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1193,12 +1193,12 @@ export class FastMCPSession<
       ReadResourceRequestSchema,
       async (request) => {
         if ("uri" in request.params) {
-          const resourceDef = resources.find(
+          const resource = resources.find(
             (resource) =>
               "uri" in resource && resource.uri === request.params.uri,
           );
 
-          if (!resourceDef) {
+          if (!resource) {
             for (const resourceTemplate of this.#resourceTemplates) {
               const uriTemplate = parseURITemplate(
                 resourceTemplate.uriTemplate,
@@ -1234,22 +1234,22 @@ export class FastMCPSession<
             );
           }
 
-          if (!("uri" in resourceDef)) {
+          if (!("uri" in resource)) {
             throw new UnexpectedStateError("Resource does not support reading");
           }
 
           let maybeArrayResult: Awaited<ReturnType<Resource["load"]>>;
 
           try {
-            maybeArrayResult = await resourceDef.load();
+            maybeArrayResult = await resource.load();
           } catch (error) {
             const errorMessage =
               error instanceof Error ? error.message : String(error);
             throw new McpError(
               ErrorCode.InternalError,
-              `Failed to load resource '${resourceDef.name}' (${resourceDef.uri}): ${errorMessage}`,
+              `Failed to load resource '${resource.name}' (${resource.uri}): ${errorMessage}`,
               {
-                uri: resourceDef.uri,
+                uri: resource.uri,
               },
             );
           }
@@ -1261,9 +1261,9 @@ export class FastMCPSession<
           return {
             contents: resourceResults.map((result) => ({
               ...result,
-              mimeType: result.mimeType ?? resourceDef.mimeType,
-              name: resourceDef.name,
-              uri: result.uri ?? resourceDef.uri,
+              mimeType: result.mimeType ?? resource.mimeType,
+              name: resource.name,
+              uri: result.uri ?? resource.uri,
             })),
           };
         }


### PR DESCRIPTION
Makes a few changes:

- `addResourceTemplate.load` allows returning an array of resources (similar to `addResource.load`)
- Allows `ResourceTemplate.load` resource results to specify optional mimeType and uri
  - useful when ResourceTemplate will return a list of different resources, e.g. returning all files in a directory
- uses `satisfies` keyword to type-check return types of ResourceTemplates/Resources against the types of the MCP SDK

