### PR TITLE
feat: extend `requestSampling` to support `RequestOptions`

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1,5 +1,6 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   CallToolRequestSchema,
@@ -877,8 +878,9 @@ export class FastMCPSession<
 
   public async requestSampling(
     message: z.infer<typeof CreateMessageRequestSchema>["params"],
+    options?: RequestOptions,
   ): Promise<SamplingResponse> {
-    return this.#server.createMessage(message);
+    return this.#server.createMessage(message, options);
   }
 
   public waitForReady(): Promise<void> {


### PR DESCRIPTION
implements the feature requested in #122 by extending the `requestSampling` method to accept optional `RequestOptions`.