### PR TITLE
feat: add support for passing options to requestSampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1368,26 +1368,27 @@ await session.requestSampling(
     onprogress: (progress) => {
       console.log(`Progress: ${progress.progress}/${progress.total}`);
     },
-    
+
     // Abort signal for cancelling the request
     signal: abortController.signal,
-    
+
     // Request timeout in milliseconds (default: DEFAULT_REQUEST_TIMEOUT_MSEC)
     timeout: 30000,
-    
+
     // Whether progress notifications reset the timeout (default: false)
     resetTimeoutOnProgress: true,
-    
+
     // Maximum total timeout regardless of progress (no default)
     maxTotalTimeout: 60000,
-  }
+  },
 );
 ```
 
 **Options:**
+
 - `onprogress?: (progress: Progress) => void` - Callback for progress notifications from the remote end
 - `signal?: AbortSignal` - Abort signal to cancel the request
-- `timeout?: number` - Request timeout in milliseconds  
+- `timeout?: number` - Request timeout in milliseconds
 - `resetTimeoutOnProgress?: boolean` - Whether progress notifications reset the timeout
 - `maxTotalTimeout?: number` - Maximum total timeout regardless of progress notifications
 

--- a/README.md
+++ b/README.md
@@ -1343,6 +1343,54 @@ await session.requestSampling({
 });
 ```
 
+#### Options
+
+`requestSampling` accepts an optional second parameter for request options:
+
+```ts
+await session.requestSampling(
+  {
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: "What files are in the current directory?",
+        },
+      },
+    ],
+    systemPrompt: "You are a helpful file system assistant.",
+    includeContext: "thisServer",
+    maxTokens: 100,
+  },
+  {
+    // Progress callback - called when progress notifications are received
+    onprogress: (progress) => {
+      console.log(`Progress: ${progress.progress}/${progress.total}`);
+    },
+    
+    // Abort signal for cancelling the request
+    signal: abortController.signal,
+    
+    // Request timeout in milliseconds (default: DEFAULT_REQUEST_TIMEOUT_MSEC)
+    timeout: 30000,
+    
+    // Whether progress notifications reset the timeout (default: false)
+    resetTimeoutOnProgress: true,
+    
+    // Maximum total timeout regardless of progress (no default)
+    maxTotalTimeout: 60000,
+  }
+);
+```
+
+**Options:**
+- `onprogress?: (progress: Progress) => void` - Callback for progress notifications from the remote end
+- `signal?: AbortSignal` - Abort signal to cancel the request
+- `timeout?: number` - Request timeout in milliseconds  
+- `resetTimeoutOnProgress?: boolean` - Whether progress notifications reset the timeout
+- `maxTotalTimeout?: number` - Maximum total timeout regardless of progress notifications
+
 ### `clientCapabilities`
 
 The `clientCapabilities` property contains the client capabilities.

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1,5 +1,6 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   CallToolRequestSchema,
@@ -486,6 +487,13 @@ type ResourceTemplateArgumentsToObject<T extends { name: string }[]> = {
   [K in T[number]["name"]]: string;
 };
 
+type SamplingResponse = {
+  content: AudioContent | ImageContent | TextContent;
+  model: string;
+  role: "assistant" | "user";
+  stopReason?: "endTurn" | "maxTokens" | "stopSequence" | string;
+};
+
 type ServerOptions<T extends FastMCPSessionAuth> = {
   authenticate?: Authenticate<T>;
   /**
@@ -870,35 +878,8 @@ export class FastMCPSession<
 
   public async requestSampling(
     message: z.infer<typeof CreateMessageRequestSchema>["params"],
-    options?: {
-      /**
-       * If set, requests progress notifications from the remote end (if supported). When progress notifications are received, this callback will be invoked.
-       */
-      onprogress?: (progress: Progress) => void;
-      /**
-       * Can be used to cancel an in-flight request. This will cause an AbortError to be raised from request().
-       */
-      signal?: AbortSignal;
-      /**
-       * A timeout (in milliseconds) for this request. If exceeded, an McpError with code `RequestTimeout` will be raised from request().
-       *
-       * If not specified, `DEFAULT_REQUEST_TIMEOUT_MSEC` will be used as the timeout.
-       */
-      timeout?: number;
-      /**
-       * If true, receiving a progress notification will reset the request timeout.
-       * This is useful for long-running operations that send periodic progress updates.
-       * Default: false
-       */
-      resetTimeoutOnProgress?: boolean;
-      /**
-       * Maximum total time (in milliseconds) to wait for a response.
-       * If exceeded, an McpError with code `RequestTimeout` will be raised, regardless of progress notifications.
-       * If not specified, there is no maximum total timeout.
-       */
-      maxTotalTimeout?: number;
-    },
-  ) {
+    options?: RequestOptions,
+  ): Promise<SamplingResponse> {
     return this.#server.createMessage(message, options);
   }
 


### PR DESCRIPTION
Solves https://github.com/punkpeye/fastmcp/issues/122

Note: for some reason I wasn't able to import the RequestOptions from the protocol file