### PR TITLE
Allow configuring a custom eventStore

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -23,6 +23,7 @@ import {
   ServerCapabilities,
   SetLevelRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { EventStore } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { StandardSchemaV1 } from "@standard-schema/spec";
 import { EventEmitter } from "events";
 import { readFile } from "fs/promises";
@@ -1712,7 +1713,7 @@ export class FastMCP<
    */
   public async start(
     options?: Partial<{
-      httpStream: { endpoint?: `/${string}`; port: number };
+      httpStream: { endpoint?: `/${string}`; port: number, eventStore?: EventStore };
       transportType: "httpStream" | "stdio";
     }>,
   ) {
@@ -1837,6 +1838,7 @@ export class FastMCP<
 
         port: httpConfig.port,
         streamEndpoint: httpConfig.endpoint,
+        eventStore: httpConfig.eventStore,
       });
 
       console.info(


### PR DESCRIPTION
`eventStore` can't be customized when using FastMCP, this allows passing one to `startHTTPServer`.

Maybe there are other options that should be passed along for full customizability?