### PR TITLE
Support for .well-known oauth discovery endpoints

### DIFF
--- a/src/FastMCP.oauth.test.ts
+++ b/src/FastMCP.oauth.test.ts
@@ -1,0 +1,177 @@
+import { getRandomPort } from "get-port-please";
+import { describe, expect, it } from "vitest";
+
+import { FastMCP } from "./FastMCP.js";
+
+describe("FastMCP OAuth Support", () => {
+  it("should serve OAuth authorization server metadata", async () => {
+    const port = await getRandomPort();
+
+    const server = new FastMCP({
+      name: "Test Server",
+      oauth: {
+        authorizationServer: {
+          authorizationEndpoint: "https://auth.example.com/oauth/authorize",
+          dpopSigningAlgValuesSupported: ["ES256", "RS256"],
+          grantTypesSupported: ["authorization_code", "refresh_token"],
+          issuer: "https://auth.example.com",
+          jwksUri: "https://auth.example.com/.well-known/jwks.json",
+          responseTypesSupported: ["code"],
+          scopesSupported: ["read", "write"],
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+        },
+        enabled: true,
+      },
+      version: "1.0.0",
+    });
+
+    await server.start({
+      httpStream: { port },
+      transportType: "httpStream",
+    });
+
+    try {
+      // Test the OAuth authorization server endpoint
+      const response = await fetch(
+        `http://localhost:${port}/.well-known/oauth-authorization-server`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+
+      const metadata = (await response.json()) as Record<string, unknown>;
+
+      // Check that camelCase was converted to snake_case
+      expect(metadata.issuer).toBe("https://auth.example.com");
+      expect(metadata.authorization_endpoint).toBe(
+        "https://auth.example.com/oauth/authorize",
+      );
+      expect(metadata.token_endpoint).toBe(
+        "https://auth.example.com/oauth/token",
+      );
+      expect(metadata.response_types_supported).toEqual(["code"]);
+      expect(metadata.jwks_uri).toBe(
+        "https://auth.example.com/.well-known/jwks.json",
+      );
+      expect(metadata.scopes_supported).toEqual(["read", "write"]);
+      expect(metadata.grant_types_supported).toEqual([
+        "authorization_code",
+        "refresh_token",
+      ]);
+      expect(metadata.dpop_signing_alg_values_supported).toEqual([
+        "ES256",
+        "RS256",
+      ]);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("should serve OAuth protected resource metadata", async () => {
+    const port = await getRandomPort();
+
+    const server = new FastMCP({
+      name: "Test Server",
+      oauth: {
+        enabled: true,
+        protectedResource: {
+          authorizationServers: ["https://auth.example.com"],
+          bearerMethodsSupported: ["header"],
+          jwksUri: "https://test-server.example.com/.well-known/jwks.json",
+          resource: "mcp://test-server",
+          resourceDocumentation: "https://docs.example.com/api",
+        },
+      },
+      version: "1.0.0",
+    });
+
+    await server.start({
+      httpStream: { port },
+      transportType: "httpStream",
+    });
+
+    try {
+      const response = await fetch(
+        `http://localhost:${port}/.well-known/oauth-protected-resource`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+
+      const metadata = (await response.json()) as Record<string, unknown>;
+
+      // Check that camelCase was converted to snake_case
+      expect(metadata.resource).toBe("mcp://test-server");
+      expect(metadata.authorization_servers).toEqual([
+        "https://auth.example.com",
+      ]);
+      expect(metadata.jwks_uri).toBe(
+        "https://test-server.example.com/.well-known/jwks.json",
+      );
+      expect(metadata.bearer_methods_supported).toEqual(["header"]);
+      expect(metadata.resource_documentation).toBe(
+        "https://docs.example.com/api",
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("should return 404 for OAuth endpoints when disabled", async () => {
+    const port = await getRandomPort();
+
+    const server = new FastMCP({
+      name: "Test Server",
+      oauth: {
+        enabled: false,
+      },
+      version: "1.0.0",
+    });
+
+    await server.start({
+      httpStream: { port },
+      transportType: "httpStream",
+    });
+
+    try {
+      const authServerResponse = await fetch(
+        `http://localhost:${port}/.well-known/oauth-authorization-server`,
+      );
+      expect(authServerResponse.status).toBe(404);
+
+      const protectedResourceResponse = await fetch(
+        `http://localhost:${port}/.well-known/oauth-protected-resource`,
+      );
+      expect(protectedResourceResponse.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("should return 404 for OAuth endpoints when not configured", async () => {
+    const port = await getRandomPort();
+
+    const server = new FastMCP({
+      name: "Test Server",
+      version: "1.0.0",
+      // No oauth configuration
+    });
+
+    await server.start({
+      httpStream: { port },
+      transportType: "httpStream",
+    });
+
+    try {
+      const authServerResponse = await fetch(
+        `http://localhost:${port}/.well-known/oauth-authorization-server`,
+      );
+      expect(authServerResponse.status).toBe(404);
+
+      const protectedResourceResponse = await fetch(
+        `http://localhost:${port}/.well-known/oauth-protected-resource`,
+      );
+      expect(protectedResourceResponse.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -540,6 +540,75 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
   instructions?: string;
   name: string;
 
+  /**
+   * Configuration for OAuth well-known discovery endpoints that can be exposed
+   * when the server is running using HTTP-based transports (SSE or HTTP Stream).
+   * When enabled, the server will respond to requests for OAuth discovery endpoints
+   * with the configured metadata.
+   *
+   * The endpoints are only added when the server is started with
+   * `transportType: "httpStream"` – they are ignored for the stdio transport.
+   * Both SSE and HTTP Stream transports support OAuth endpoints.
+   */
+  oauth?: {
+    /**
+     * OAuth Authorization Server metadata for /.well-known/oauth-authorization-server
+     *
+     * This endpoint follows RFC 8414 (OAuth 2.0 Authorization Server Metadata)
+     * and provides metadata about the OAuth 2.0 authorization server.
+     *
+     * Required by MCP Specification 2025-03-26
+     */
+    authorizationServer?: {
+      authorizationEndpoint: string;
+      codeChallengeMethodsSupported?: string[];
+      // DPoP support
+      dpopSigningAlgValuesSupported?: string[];
+      grantTypesSupported?: string[];
+
+      introspectionEndpoint?: string;
+      // Required
+      issuer: string;
+      // Common optional
+      jwksUri?: string;
+      opPolicyUri?: string;
+      opTosUri?: string;
+      registrationEndpoint?: string;
+      responseModesSupported?: string[];
+      responseTypesSupported: string[];
+      revocationEndpoint?: string;
+      scopesSupported?: string[];
+      serviceDocumentation?: string;
+      tokenEndpoint: string;
+      tokenEndpointAuthMethodsSupported?: string[];
+      tokenEndpointAuthSigningAlgValuesSupported?: string[];
+
+      uiLocalesSupported?: string[];
+    };
+
+    /**
+     * Whether OAuth discovery endpoints should be enabled.
+     */
+    enabled: boolean;
+
+    /**
+     * OAuth Protected Resource metadata for /.well-known/oauth-protected-resource
+     *
+     * This endpoint follows RFC 9470 (OAuth 2.0 Protected Resource Metadata)
+     * and provides metadata about the OAuth 2.0 protected resource.
+     *
+     * Required by MCP Specification 2025-06-18
+     */
+    protectedResource?: {
+      authorizationServers: string[];
+      bearerMethodsSupported?: string[];
+      jwksUri?: string;
+      resource: string;
+      resourceDocumentation?: string;
+      resourcePolicyUri?: string;
+    };
+  };
+
   ping?: {
     /**
      * Whether ping should be enabled by default.
@@ -1562,6 +1631,29 @@ export class FastMCPSession<
   }
 }
 
+/**
+ * Converts camelCase to snake_case for OAuth endpoint responses
+ */
+function camelToSnakeCase(str: string): string {
+  return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}
+
+/**
+ * Converts an object with camelCase keys to snake_case keys
+ */
+function convertObjectToSnakeCase(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    const snakeKey = camelToSnakeCase(key);
+    result[snakeKey] = value;
+  }
+
+  return result;
+}
+
 const FastMCPEventEmitterBase: {
   new (): StrictEventEmitter<EventEmitter, FastMCPEvents<FastMCPSessionAuth>>;
 } = EventEmitter;
@@ -1828,6 +1920,42 @@ export class FastMCP<
               }
             } catch (error) {
               console.error("[FastMCP error] health endpoint error", error);
+            }
+          }
+
+          // Handle OAuth well-known endpoints
+          const oauthConfig = this.#options.oauth;
+          if (oauthConfig?.enabled && req.method === "GET") {
+            const url = new URL(req.url || "", "http://localhost");
+
+            if (
+              url.pathname === "/.well-known/oauth-authorization-server" &&
+              oauthConfig.authorizationServer
+            ) {
+              const metadata = convertObjectToSnakeCase(
+                oauthConfig.authorizationServer,
+              );
+              res
+                .writeHead(200, {
+                  "Content-Type": "application/json",
+                })
+                .end(JSON.stringify(metadata));
+              return;
+            }
+
+            if (
+              url.pathname === "/.well-known/oauth-protected-resource" &&
+              oauthConfig.protectedResource
+            ) {
+              const metadata = convertObjectToSnakeCase(
+                oauthConfig.protectedResource,
+              );
+              res
+                .writeHead(200, {
+                  "Content-Type": "application/json",
+                })
+                .end(JSON.stringify(metadata));
+              return;
             }
           }
 

--- a/src/examples/oauth-server.ts
+++ b/src/examples/oauth-server.ts
@@ -1,0 +1,101 @@
+/**
+ * Example FastMCP server demonstrating OAuth well-known endpoint support.
+ *
+ * This example shows how to configure FastMCP to serve OAuth discovery endpoints
+ * for both authorization server metadata and protected resource metadata.
+ *
+ * Run with: node dist/examples/oauth-server.js --transport http-stream --port 4111
+ * Then visit:
+ * - http://localhost:4111/.well-known/oauth-authorization-server
+ * - http://localhost:4111/.well-known/oauth-protected-resource
+ */
+
+import { FastMCP } from "../FastMCP.js";
+
+const server = new FastMCP({
+  name: "OAuth Example Server",
+  oauth: {
+    authorizationServer: {
+      authorizationEndpoint: "https://auth.example.com/oauth/authorize",
+      codeChallengeMethodsSupported: ["S256"],
+      // DPoP support
+      dpopSigningAlgValuesSupported: ["ES256", "RS256"],
+      grantTypesSupported: ["authorization_code", "refresh_token"],
+
+      introspectionEndpoint: "https://auth.example.com/oauth/introspect",
+      // Required fields
+      issuer: "https://auth.example.com",
+      // Optional fields
+      jwksUri: "https://auth.example.com/.well-known/jwks.json",
+      opPolicyUri: "https://example.com/policy",
+      opTosUri: "https://example.com/terms",
+      registrationEndpoint: "https://auth.example.com/oauth/register",
+      responseModesSupported: ["query", "fragment"],
+      responseTypesSupported: ["code"],
+      revocationEndpoint: "https://auth.example.com/oauth/revoke",
+      scopesSupported: ["read", "write", "admin"],
+      serviceDocumentation: "https://docs.example.com/oauth",
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      tokenEndpointAuthMethodsSupported: [
+        "client_secret_basic",
+        "client_secret_post",
+      ],
+      tokenEndpointAuthSigningAlgValuesSupported: ["RS256", "ES256"],
+
+      uiLocalesSupported: ["en-US", "es-ES"],
+    },
+    enabled: true,
+    protectedResource: {
+      authorizationServers: ["https://auth.example.com"],
+      bearerMethodsSupported: ["header"],
+      jwksUri: "https://oauth-example-server.example.com/.well-known/jwks.json",
+      resource: "mcp://oauth-example-server",
+      resourceDocumentation: "https://docs.example.com/mcp-api",
+      resourcePolicyUri: "https://example.com/resource-policy",
+    },
+  },
+  version: "1.0.0",
+});
+
+// Add a simple tool to demonstrate the server functionality
+server.addTool({
+  description: "Get information about this OAuth-enabled MCP server",
+  execute: async () => {
+    return {
+      content: [
+        {
+          text: `This is an OAuth-enabled FastMCP server!
+
+OAuth Discovery Endpoints:
+- Authorization Server: /.well-known/oauth-authorization-server
+- Protected Resource: /.well-known/oauth-protected-resource
+
+The server demonstrates how to configure OAuth metadata for MCP servers
+that need to integrate with OAuth 2.0 authorization flows.`,
+          type: "text",
+        },
+      ],
+    };
+  },
+  name: "get-server-info",
+});
+
+// Start the server
+await server.start({
+  httpStream: { port: 4111 },
+  transportType: "httpStream",
+});
+
+console.log(`
+🚀 OAuth Example Server is running!
+
+Try these endpoints:
+- MCP (HTTP Stream): http://localhost:4111/mcp
+- MCP (SSE): http://localhost:4111/sse
+- Health: http://localhost:4111/health
+- OAuth Authorization Server: http://localhost:4111/.well-known/oauth-authorization-server
+- OAuth Protected Resource: http://localhost:4111/.well-known/oauth-protected-resource
+
+The OAuth endpoints work with both SSE and HTTP Stream transports and return
+JSON metadata following RFC 8414 standards.
+`);


### PR DESCRIPTION
## Summary

This allows protecting a fastmcp server behind an oauth server.

This is done by adding support for OAuth 2.1 well-known discovery endpoints to FastMCP, enabling MCP servers to serve OAuth metadata for authorization flows as required by MCP Specifications 2025-03-26 and 2025-06-18.

Note that additional features could be built on top of this like token verification, scope checks, and so on. This PR adds the minimum to allow mcp developers to add support for oauth auth.

## Configuration

```
const server = new FastMCP({
  name: "My Server",
  version: "1.0.0",
  oauth: {
    enabled: true,
    authorizationServer: {
      issuer: "https://auth.example.com",
      authorizationEndpoint: "https://auth.example.com/oauth/authorize",
      tokenEndpoint: "https://auth.example.com/oauth/token",
      responseTypesSupported: ["code"],
    },
    protectedResource: {
      resource: "mcp://my-server",
      authorizationServers: ["https://auth.example.com"],
      bearerMethodsSupported: ["header"]
    }
  }
});
```

