### PR TITLE
feat: allow custom friendlyErrors message on parameters validation error

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -670,6 +670,14 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
      */
     enabled?: boolean;
   };
+  /**
+   * General utilities
+   */
+  utils?: {
+    formatInvalidParamsErrorMessage?: (
+      issues: readonly StandardSchemaV1.Issue[],
+    ) => string;
+  };
   version: `${number}.${number}.${number}`;
 };
 
@@ -790,6 +798,8 @@ export class FastMCPSession<
 
   #server: Server;
 
+  #utils?: ServerOptions<T>["utils"];
+
   constructor({
     auth,
     instructions,
@@ -801,6 +811,7 @@ export class FastMCPSession<
     roots,
     tools,
     transportType,
+    utils,
     version,
   }: {
     auth?: T;
@@ -813,6 +824,7 @@ export class FastMCPSession<
     roots?: ServerOptions<T>["roots"];
     tools: Tool<T>[];
     transportType?: "httpStream" | "stdio";
+    utils?: ServerOptions<T>["utils"];
     version: string;
   }) {
     super();
@@ -844,6 +856,8 @@ export class FastMCPSession<
       { name: name, version: version },
       { capabilities: this.#capabilities, instructions: instructions },
     );
+
+    this.#utils = utils;
 
     this.setupErrorHandling();
     this.setupLoggingHandlers();
@@ -1487,12 +1501,14 @@ export class FastMCPSession<
         );
 
         if (parsed.issues) {
-          const friendlyErrors = parsed.issues
-            .map((issue) => {
-              const path = issue.path?.join(".") || "root";
-              return `${path}: ${issue.message}`;
-            })
-            .join(", ");
+          const friendlyErrors = this.#utils?.formatInvalidParamsErrorMessage
+            ? this.#utils.formatInvalidParamsErrorMessage(parsed.issues)
+            : parsed.issues
+                .map((issue) => {
+                  const path = issue.path?.join(".") || "root";
+                  return `${path}: ${issue.message}`;
+                })
+                .join(", ");
 
           throw new McpError(
             ErrorCode.InvalidParams,
@@ -1872,6 +1888,7 @@ export class FastMCP<
         roots: this.#options.roots,
         tools: this.#tools,
         transportType: "stdio",
+        utils: this.#options.utils,
         version: this.#options.version,
       });
 
@@ -1903,6 +1920,7 @@ export class FastMCP<
             roots: this.#options.roots,
             tools: this.#tools,
             transportType: "httpStream",
+            utils: this.#options.utils,
             version: this.#options.version,
           });
         },


### PR DESCRIPTION
### Improve Validation Error Messaging via Custom Formatter

In some cases, validation errors are too vague to generate helpful responses for users.
For example, when using Zod schemas with union types, the default error message is often just "Invalid input", which lacks useful detail.

This PR introduces a new utils field to the server constructor, currently supporting a formatInvalidParamsErrorMessage callback. This allows developers to intercept and customize the validation error message based on the raw Zod issues.

By enabling this customization, agents can better understand what went wrong and return clearer, more informative error messages to users.