### PR TITLE
feat: support passing session context in stdio mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,23 @@ server.addTool({
 });
 ```
 
+> If you are using Stdio transport, you can determine the returned content based on whether the request parameter exists, allowing you to access authenticated session data in your tools.
+> ```ts
+> const server = new FastMCP({
+>   name: "My Server",
+>   version: "1.0.0",
+>   authenticate: (request) => {
+>     if (!request) {
+>       // Stdio transport does not provide request object
+>       return { 
+>         id: process.env.USER_ID
+>       };
+>     }
+>     // ...
+>   },
+> });
+> ```
+
 #### OAuth Support
 
 FastMCP includes built-in support for OAuth discovery endpoints, supporting both **MCP Specification 2025-03-26** and **MCP Specification 2025-06-18** for OAuth integration. This makes it easy to integrate with OAuth authorization flows by providing standard discovery endpoints that comply with RFC 8414 (OAuth 2.0 Authorization Server Metadata) and RFC 9470 (OAuth 2.0 Protected Resource Metadata):

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -744,7 +744,7 @@ const FastMCPSessionEventEmitterBase: {
   new (): StrictEventEmitter<EventEmitter, FastMCPSessionEvents>;
 } = EventEmitter;
 
-type Authenticate<T> = (request: http.IncomingMessage) => Promise<T>;
+type Authenticate<T> = (request?: http.IncomingMessage) => Promise<T>;
 
 type FastMCPSessionAuth = Record<string, unknown> | undefined;
 
@@ -1863,6 +1863,7 @@ export class FastMCP<
     if (config.transportType === "stdio") {
       const transport = new StdioServerTransport();
       const session = new FastMCPSession<T>({
+        auth: await this.#authenticate?.(),
         instructions: this.#options.instructions,
         name: this.#options.name,
         ping: this.#options.ping,
@@ -1887,14 +1888,8 @@ export class FastMCP<
 
       this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
         createServer: async (request) => {
-          let auth: T | undefined;
-
-          if (this.#authenticate) {
-            auth = await this.#authenticate(request);
-          }
-
           return new FastMCPSession<T>({
-            auth,
+            auth: await this.#authenticate?.(request),
             name: this.#options.name,
             ping: this.#options.ping,
             prompts: this.#prompts,


### PR DESCRIPTION
> Closes #144

My idea is as follows: when the user executes `new FastMCP()`, it is possible to judge the current transport based on whether the `authenticate` function has been passed parameters, and then pass the session.


```ts
const server = new FastMCP<{ token: string }>({
  name,
  version,
  instructions: "",
  authenticate: async (request) => {
    // local
    if (!request) {
      return { token: process.env.USER_TOKEN };
    }
    // remote
    const token = request.headers["authorization"] as string;
    return { token };
  },
});
```