### PR TITLE
feat: Support custom host path

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -70,11 +70,11 @@ const runWithTestServer = async ({
           },
           {
             capabilities: {},
-          },
+          }
         );
 
     const transport = new SSEClientTransport(
-      new URL(`http://localhost:${port}/sse`),
+      new URL(`http://localhost:${port}/sse`)
     );
 
     const session = await new Promise<FastMCPSession>((resolve) => {
@@ -220,7 +220,7 @@ test("calls a tool", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [{ text: "3", type: "text" }],
       });
@@ -258,7 +258,7 @@ test("returns a list", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [
           { text: "a", type: "text" },
@@ -304,7 +304,7 @@ test("returns an image", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [
           {
@@ -327,7 +327,7 @@ test("returns an image", async () => {
           return imageContent({
             buffer: Buffer.from(
               "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
-              "base64",
+              "base64"
             ),
           });
         },
@@ -353,7 +353,7 @@ test("returns an audio", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [
           {
@@ -376,7 +376,7 @@ test("returns an audio", async () => {
           return audioContent({
             buffer: Buffer.from(
               "UklGRhwMAABXQVZFZm10IBAAAAABAAEAgD4AAIA+AAABAAgAZGF0Ya4LAACAgICAgICAgICAgICAgICAgICAgICAgICAf3hxeH+AfXZ1eHx6dnR5fYGFgoOKi42aloubq6GOjI2Op7ythXJ0eYF5aV1AOFFib32HmZSHhpCalIiYi4SRkZaLfnhxaWptb21qaWBea2BRYmZTVmFgWFNXVVVhaGdbYGhZbXh1gXZ1goeIlot1k6yxtKaOkaWhq7KonKCZoaCjoKWuqqmurK6ztrO7tbTAvru/vb68vbW6vLGqsLOfm5yal5KKhoyBeHt2dXBnbmljVlJWUEBBPDw9Mi4zKRwhIBYaGRQcHBURGB0XFxwhGxocJSstMjg6PTc6PUxVV1lWV2JqaXN0coCHhIyPjpOenqWppK6xu72yxMu9us7Pw83Wy9nY29ve6OPr6uvs6ezu6ejk6erm3uPj3dbT1sjBzdDFuMHAt7m1r7W6qaCupJOTkpWPgHqAd3JrbGlnY1peX1hTUk9PTFRKR0RFQkRBRUVEQkdBPjs9Pzo6NT04Njs+PTxAPzo/Ojk6PEA5PUJAQD04PkRCREZLUk1KT1BRUVdXU1VRV1tZV1xgXltcXF9hXl9eY2VmZmlna3J0b3F3eHyBfX+JgIWJiouTlZCTmpybnqSgnqyrqrO3srK2uL2/u7jAwMLFxsfEv8XLzcrIy83JzcrP0s3M0dTP0drY1dPR1dzc19za19XX2dnU1NjU0dXPzdHQy8rMysfGxMLBvLu3ta+sraeioJ2YlI+MioeFfX55cnJsaWVjXVlbVE5RTktHRUVAPDw3NC8uLyknKSIiJiUdHiEeGx4eHRwZHB8cHiAfHh8eHSEhISMoJyMnKisrLCszNy8yOTg9QEJFRUVITVFOTlJVWltaXmNfX2ZqZ21xb3R3eHqAhoeJkZKTlZmhpJ6kqKeur6yxtLW1trW4t6+us7axrbK2tLa6ury7u7u9u7vCwb+/vr7Ev7y9v8G8vby6vru4uLq+tri8ubi5t7W4uLW5uLKxs7G0tLGwt7Wvs7avr7O0tLW4trS4uLO1trW1trm1tLm0r7Kyr66wramsqaKlp52bmpeWl5KQkImEhIB8fXh3eHJrbW5mYGNcWFhUUE1LRENDQUI9ODcxLy8vMCsqLCgoKCgpKScoKCYoKygpKyssLi0sLi0uMDIwMTIuLzQ0Njg4Njc8ODlBQ0A/RUdGSU5RUVFUV1pdXWFjZGdpbG1vcXJ2eXh6fICAgIWIio2OkJGSlJWanJqbnZ2cn6Kkp6enq62srbCysrO1uLy4uL+/vL7CwMHAvb/Cvbq9vLm5uba2t7Sysq+urqyqqaalpqShoJ+enZuamZqXlZWTkpGSkpCNjpCMioqLioiHhoeGhYSGg4GDhoKDg4GBg4GBgoGBgoOChISChISChIWDg4WEgoSEgYODgYGCgYGAgICAgX99f398fX18e3p6e3t7enp7fHx4e3x6e3x7fHx9fX59fn1+fX19fH19fnx9fn19fX18fHx7fHx6fH18fXx8fHx7fH1+fXx+f319fn19fn1+gH9+f4B/fn+AgICAgH+AgICAgIGAgICAgH9+f4B+f35+fn58e3t8e3p5eXh4d3Z1dHRzcXBvb21sbmxqaWhlZmVjYmFfX2BfXV1cXFxaWVlaWVlYV1hYV1hYWVhZWFlaWllbXFpbXV5fX15fYWJhYmNiYWJhYWJjZGVmZ2hqbG1ub3Fxc3V3dnd6e3t8e3x+f3+AgICAgoGBgoKDhISFh4aHiYqKi4uMjYyOj4+QkZKUlZWXmJmbm52enqCioqSlpqeoqaqrrK2ur7CxsrGys7O0tbW2tba3t7i3uLe4t7a3t7i3tre2tba1tLSzsrKysbCvrq2sq6qop6alo6OioJ+dnJqZmJeWlJKSkI+OjoyLioiIh4WEg4GBgH9+fXt6eXh3d3V0c3JxcG9ubWxsamppaWhnZmVlZGRjYmNiYWBhYGBfYF9fXl5fXl1dXVxdXF1dXF1cXF1cXF1dXV5dXV5fXl9eX19gYGFgYWJhYmFiY2NiY2RjZGNkZWRlZGVmZmVmZmVmZ2dmZ2hnaGhnaGloZ2hpaWhpamlqaWpqa2pra2xtbGxtbm1ubm5vcG9wcXBxcnFycnN0c3N0dXV2d3d4eHh5ent6e3x9fn5/f4CAgIGCg4SEhYaGh4iIiYqLi4uMjY2Oj5CQkZGSk5OUlJWWlpeYl5iZmZqbm5ybnJ2cnZ6en56fn6ChoKChoqGio6KjpKOko6SjpKWkpaSkpKSlpKWkpaSlpKSlpKOkpKOko6KioaKhoaCfoJ+enp2dnJybmpmZmJeXlpWUk5STkZGQj4+OjYyLioqJh4eGhYSEgoKBgIB/fn59fHt7enl5eHd3dnZ1dHRzc3JycXBxcG9vbm5tbWxrbGxraWppaWhpaGdnZ2dmZ2ZlZmVmZWRlZGVkY2RjZGNkZGRkZGRkZGRkZGRjZGRkY2RjZGNkZWRlZGVmZWZmZ2ZnZ2doaWhpaWpra2xsbW5tbm9ub29wcXFycnNzdHV1dXZ2d3d4eXl6enp7fHx9fX5+f4CAgIGAgYGCgoOEhISFhoWGhoeIh4iJiImKiYqLiouLjI2MjI2OjY6Pj46PkI+QkZCRkJGQkZGSkZKRkpGSkZGRkZKRkpKRkpGSkZKRkpGSkZKRkpGSkZCRkZCRkI+Qj5CPkI+Pjo+OjY6Njo2MjYyLjIuMi4qLioqJiomJiImIh4iHh4aHhoaFhoWFhIWEg4SDg4KDgoKBgoGAgYCBgICAgICAf4CAf39+f35/fn1+fX59fHx9fH18e3x7fHt6e3p7ent6e3p5enl6enl6eXp5eXl4eXh5eHl4eXh5eHl4eXh5eHh3eHh4d3h4d3h3d3h4d3l4eHd4d3h3eHd4d3h3eHh4eXh5eHl4eHl4eXh5enl6eXp5enl6eXp5ent6ent6e3x7fHx9fH18fX19fn1+fX5/fn9+f4B/gH+Af4CAgICAgIGAgYCBgoGCgYKCgoKDgoOEg4OEg4SFhIWEhYSFhoWGhYaHhoeHhoeGh4iHiIiHiImIiImKiYqJiYqJiouKi4qLiouKi4qLiouKi4qLiouKi4qLi4qLiouKi4qLiomJiomIiYiJiImIh4iIh4iHhoeGhYWGhYaFhIWEg4OEg4KDgoOCgYKBgIGAgICAgH+Af39+f359fn18fX19fHx8e3t6e3p7enl6eXp5enl6enl5eXh5eHh5eHl4eXh5eHl4eHd5eHd3eHl4d3h3eHd4d3h3eHh4d3h4d3h3d3h5eHl4eXh5eHl5eXp5enl6eXp7ent6e3p7e3t7fHt8e3x8fHx9fH1+fX59fn9+f35/gH+AgICAgICAgYGAgYKBgoGCgoKDgoOEg4SEhIWFhIWFhoWGhYaGhoaHhoeGh4aHhoeIh4iHiIeHiIeIh4iHiIeIiIiHiIeIh4iHiIiHiIeIh4iHiIeIh4eIh4eIh4aHh4aHhoeGh4aHhoWGhYaFhoWFhIWEhYSFhIWEhISDhIOEg4OCg4OCg4KDgYKCgYKCgYCBgIGAgYCBgICAgICAgICAf4B/f4B/gH+Af35/fn9+f35/fn1+fn19fn1+fX59fn19fX19fH18fXx9fH18fXx9fH18fXx8fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x8e3x7fHt8e3x7fHx8fXx9fH18fX5+fX59fn9+f35+f35/gH+Af4B/gICAgICAgICAgICAgYCBgIGAgIGAgYGBgoGCgYKBgoGCgYKBgoGCgoKDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KCgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGBgYCBgIGAgYCBgIGAgYCBgIGAgYCBgIGAgYCBgIGAgYCAgICBgIGAgYCBgIGAgYCBgIGAgYCBgExJU1RCAAAASU5GT0lDUkQMAAAAMjAwOC0wOS0yMQAASUVORwMAAAAgAAABSVNGVBYAAABTb255IFNvdW5kIEZvcmdlIDguMAAA",
-              "base64",
+              "base64"
             ),
           });
         },
@@ -402,7 +402,7 @@ test("handles UserError errors", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [{ text: "Something went wrong", type: "text" }],
         isError: true,
@@ -476,7 +476,7 @@ test("tracks tool progress", async () => {
         undefined,
         {
           onprogress: onProgress,
-        },
+        }
       );
 
       expect(onProgress).toHaveBeenCalledTimes(1);
@@ -541,7 +541,7 @@ test(
           undefined,
           {
             onprogress: onProgress,
-          },
+          }
         );
 
         expect(onProgress).toHaveBeenCalledTimes(4);
@@ -592,7 +592,7 @@ test(
         return server;
       },
     });
-  },
+  }
 );
 
 test("sets logging levels", async () => {
@@ -677,7 +677,7 @@ test("sends logging messages to the client", async () => {
               ...(message.params.data ?? {}),
             });
           }
-        },
+        }
       );
 
       await client.callTool({
@@ -780,7 +780,7 @@ test("clients reads a resource", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        }),
+        })
       ).toEqual({
         contents: [
           {
@@ -820,7 +820,7 @@ test("clients reads a resource that returns multiple resources", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        }),
+        })
       ).toEqual({
         contents: [
           {
@@ -874,7 +874,7 @@ test("embedded resources work in tools", async () => {
             userId: "123",
           },
           name: "get_user_profile",
-        }),
+        })
       ).toEqual({
         content: [
           {
@@ -919,7 +919,7 @@ test("embedded resources work in tools", async () => {
             content: [
               {
                 resource: await server.embedded(
-                  `user://profile/${args.userId}`,
+                  `user://profile/${args.userId}`
                 ),
                 type: "resource",
               },
@@ -944,7 +944,7 @@ test("embedded resources work with direct resources", async () => {
         await client.callTool({
           arguments: {},
           name: "get_logs",
-        }),
+        })
       ).toEqual({
         content: [
           {
@@ -1006,7 +1006,7 @@ test("adds prompts", async () => {
             changes: "foo",
           },
           name: "git-commit",
-        }),
+        })
       ).toEqual({
         description: "Generate a Git commit message",
         messages: [
@@ -1090,11 +1090,11 @@ test("uses events to notify server of client connect/disconnect", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client.connect(transport);
@@ -1138,11 +1138,11 @@ test("handles multiple clients", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport1 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client1.connect(transport1);
@@ -1154,11 +1154,11 @@ test("handles multiple clients", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport2 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client2.connect(transport2);
@@ -1187,7 +1187,7 @@ test("session knows about client capabilities", async () => {
               listChanged: true,
             },
           },
-        },
+        }
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1227,7 +1227,7 @@ test("session knows about roots", async () => {
               listChanged: true,
             },
           },
-        },
+        }
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1275,7 +1275,7 @@ test("session listens to roots changes", async () => {
               listChanged: true,
             },
           },
-        },
+        }
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1608,11 +1608,11 @@ test(
         },
         {
           capabilities: {},
-        },
+        }
       );
 
       const transport = new StreamableHTTPClientTransport(
-        new URL(`http://localhost:${port}/another-mcp`),
+        new URL(`http://localhost:${port}/another-mcp`)
       );
 
       // Connect client to server and wait for session to be ready
@@ -1646,7 +1646,7 @@ test(
     } finally {
       await server.stop();
     }
-  },
+  }
 );
 
 test("clients reads a resource accessed via a resource template", async () => {
@@ -1662,7 +1662,7 @@ test("clients reads a resource accessed via a resource template", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        }),
+        })
       ).toEqual({
         contents: [
           {
@@ -1727,7 +1727,7 @@ test("makes a sampling request", async () => {
           capabilities: {
             sampling: {},
           },
-        },
+        }
       );
       return client;
     },
@@ -1782,7 +1782,7 @@ test("throws ErrorCode.InvalidParams if tool parameters do not match zod schema"
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema.",
+          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema."
         );
       }
     },
@@ -1828,7 +1828,7 @@ test("server remains usable after InvalidParams error", async () => {
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema.",
+          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema."
         );
       }
 
@@ -1839,7 +1839,7 @@ test("server remains usable after InvalidParams error", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [{ text: "3", type: "text" }],
       });
@@ -1901,11 +1901,11 @@ test("allows new clients to connect after a client disconnects", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport1 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client1.connect(transport1);
@@ -1917,7 +1917,7 @@ test("allows new clients to connect after a client disconnects", async () => {
         b: 2,
       },
       name: "add",
-    }),
+    })
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -1931,11 +1931,11 @@ test("allows new clients to connect after a client disconnects", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport2 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client2.connect(transport2);
@@ -1947,7 +1947,7 @@ test("allows new clients to connect after a client disconnects", async () => {
         b: 2,
       },
       name: "add",
-    }),
+    })
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -2073,7 +2073,7 @@ test("provides auth to tools", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2090,14 +2090,14 @@ test("provides auth to tools", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
 
   expect(
     authenticate,
-    "authenticate should have been called",
+    "authenticate should have been called"
   ).toHaveBeenCalledTimes(1);
 
   expect(
@@ -2107,7 +2107,7 @@ test("provides auth to tools", async () => {
         b: 2,
       },
       name: "add",
-    }),
+    })
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -2129,7 +2129,7 @@ test("provides auth to tools", async () => {
       reportProgress: expect.any(Function),
       session: { id: 1 },
       streamContent: expect.any(Function),
-    },
+    }
   );
 });
 
@@ -2176,7 +2176,7 @@ test("provides auth to resources", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2193,7 +2193,7 @@ test("provides auth to resources", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2269,7 +2269,7 @@ test("provides auth to resource templates", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2286,7 +2286,7 @@ test("provides auth to resource templates", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2298,7 +2298,7 @@ test("provides auth to resource templates", async () => {
   expect(templateLoad).toHaveBeenCalledTimes(1);
   expect(templateLoad).toHaveBeenCalledWith(
     { resourceId: "resource-123" },
-    { permissions: ["read", "write"], userId: 99 },
+    { permissions: ["read", "write"], userId: 99 }
   );
 
   expect(result).toEqual({
@@ -2367,7 +2367,7 @@ test("provides auth to resource templates returning arrays", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2384,7 +2384,7 @@ test("provides auth to resource templates returning arrays", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2396,7 +2396,7 @@ test("provides auth to resource templates returning arrays", async () => {
   expect(templateLoad).toHaveBeenCalledTimes(1);
   expect(templateLoad).toHaveBeenCalledWith(
     { category: "reports" },
-    { accessLevel: 3, teamId: "team-alpha" },
+    { accessLevel: 3, teamId: "team-alpha" }
   );
 
   expect(result).toEqual({
@@ -2471,7 +2471,7 @@ test("provides auth to prompt argument completion", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2488,7 +2488,7 @@ test("provides auth to prompt argument completion", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2563,7 +2563,7 @@ test("provides auth to prompt load function", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2580,7 +2580,7 @@ test("provides auth to prompt load function", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2593,7 +2593,7 @@ test("provides auth to prompt load function", async () => {
   expect(promptLoad).toHaveBeenCalledTimes(1);
   expect(promptLoad).toHaveBeenCalledWith(
     { option: "dashboard" },
-    { level: "admin", username: "testuser" },
+    { level: "admin", username: "testuser" }
   );
 
   expect(result).toEqual({
@@ -2664,7 +2664,7 @@ test("provides auth to resource template argument completion", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2681,7 +2681,7 @@ test("provides auth to resource template argument completion", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2817,11 +2817,11 @@ test("blocks unauthorized requests", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   expect(async () => {
@@ -2860,7 +2860,7 @@ test("filters tools based on canAccess property", async () => {
     // Admin gets both tools
     const adminClient = new Client(
       { name: "admin", version: "1.0.0" },
-      { capabilities: {} },
+      { capabilities: {} }
     );
     const adminTransport = new SSEClientTransport(
       new URL(`http://localhost:${port}/sse`),
@@ -2872,7 +2872,7 @@ test("filters tools based on canAccess property", async () => {
               headers: { ...init?.headers, "x-role": "admin" },
             }),
         },
-      },
+      }
     );
     await adminClient.connect(adminTransport);
 
@@ -2885,7 +2885,7 @@ test("filters tools based on canAccess property", async () => {
     // User gets only public tool
     const userClient = new Client(
       { name: "user", version: "1.0.0" },
-      { capabilities: {} },
+      { capabilities: {} }
     );
     const userTransport = new SSEClientTransport(
       new URL(`http://localhost:${port}/sse`),
@@ -2897,7 +2897,7 @@ test("filters tools based on canAccess property", async () => {
               headers: { ...init?.headers, "x-role": "user" },
             }),
         },
-      },
+      }
     );
     await userClient.connect(userTransport);
 
@@ -2923,7 +2923,7 @@ test("tools without canAccess are accessible to all", async () => {
         name: "test-tool",
       });
       expect(
-        (result.content as Array<{ text: string; type: string }>)[0],
+        (result.content as Array<{ text: string; type: string }>)[0]
       ).toEqual({ text: "success", type: "text" });
     },
     server: async () => {
@@ -2962,10 +2962,10 @@ test("canAccess works without authentication", async () => {
   try {
     const client = new Client(
       { name: "test-client", version: "1.0.0" },
-      { capabilities: {} },
+      { capabilities: {} }
     );
     const transport = new SSEClientTransport(
-      new URL(`http://localhost:${port}/sse`),
+      new URL(`http://localhost:${port}/sse`)
     );
     await client.connect(transport);
 
@@ -3024,13 +3024,13 @@ test("HTTP Stream: calls a tool", { timeout: 20000 }, async () => {
       },
       {
         capabilities: {},
-      },
+      }
     );
 
     // IMPORTANT: Don't provide sessionId manually with HTTP streaming
     // The server will generate a session ID automatically
     const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`),
+      new URL(`http://localhost:${port}/mcp`)
     );
 
     // Connect client to server and wait for session to be ready
@@ -3086,7 +3086,7 @@ test("uses `formatInvalidParamsErrorMessage` callback to build ErrorCode.Invalid
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          `MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: My custom error message: Field b failed with error 'Expected number, received string'. Please check the parameter types and values according to the tool's schema.`,
+          `MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: My custom error message: Field b failed with error 'Expected number, received string'. Please check the parameter types and values according to the tool's schema.`
         );
       }
     },
@@ -3160,11 +3160,11 @@ test("stateless mode works correctly", async () => {
       },
       {
         capabilities: {},
-      },
+      }
     );
 
     const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`),
+      new URL(`http://localhost:${port}/mcp`)
     );
 
     await client.connect(transport);
@@ -3231,6 +3231,31 @@ test("stateless mode health check includes mode indicator", async () => {
       status: "ready",
       total: 1,
     });
+  } finally {
+    await server.stop();
+  }
+});
+
+test("host configuration works with 0.0.0.0", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    name: "Test server",
+    version: "1.0.0",
+  });
+
+  await server.start({
+    httpStream: {
+      host: "0.0.0.0",
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const healthResponse = await fetch(`http://0.0.0.0:${port}/health`);
+    expect(healthResponse.status).toBe(200);
+    expect(await healthResponse.text()).toBe("✓ Ok");
   } finally {
     await server.stop();
   }

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -70,11 +70,11 @@ const runWithTestServer = async ({
           },
           {
             capabilities: {},
-          }
+          },
         );
 
     const transport = new SSEClientTransport(
-      new URL(`http://localhost:${port}/sse`)
+      new URL(`http://localhost:${port}/sse`),
     );
 
     const session = await new Promise<FastMCPSession>((resolve) => {
@@ -220,7 +220,7 @@ test("calls a tool", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [{ text: "3", type: "text" }],
       });
@@ -258,7 +258,7 @@ test("returns a list", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [
           { text: "a", type: "text" },
@@ -304,7 +304,7 @@ test("returns an image", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [
           {
@@ -327,7 +327,7 @@ test("returns an image", async () => {
           return imageContent({
             buffer: Buffer.from(
               "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
-              "base64"
+              "base64",
             ),
           });
         },
@@ -353,7 +353,7 @@ test("returns an audio", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [
           {
@@ -376,7 +376,7 @@ test("returns an audio", async () => {
           return audioContent({
             buffer: Buffer.from(
               "UklGRhwMAABXQVZFZm10IBAAAAABAAEAgD4AAIA+AAABAAgAZGF0Ya4LAACAgICAgICAgICAgICAgICAgICAgICAgICAf3hxeH+AfXZ1eHx6dnR5fYGFgoOKi42aloubq6GOjI2Op7ythXJ0eYF5aV1AOFFib32HmZSHhpCalIiYi4SRkZaLfnhxaWptb21qaWBea2BRYmZTVmFgWFNXVVVhaGdbYGhZbXh1gXZ1goeIlot1k6yxtKaOkaWhq7KonKCZoaCjoKWuqqmurK6ztrO7tbTAvru/vb68vbW6vLGqsLOfm5yal5KKhoyBeHt2dXBnbmljVlJWUEBBPDw9Mi4zKRwhIBYaGRQcHBURGB0XFxwhGxocJSstMjg6PTc6PUxVV1lWV2JqaXN0coCHhIyPjpOenqWppK6xu72yxMu9us7Pw83Wy9nY29ve6OPr6uvs6ezu6ejk6erm3uPj3dbT1sjBzdDFuMHAt7m1r7W6qaCupJOTkpWPgHqAd3JrbGlnY1peX1hTUk9PTFRKR0RFQkRBRUVEQkdBPjs9Pzo6NT04Njs+PTxAPzo/Ojk6PEA5PUJAQD04PkRCREZLUk1KT1BRUVdXU1VRV1tZV1xgXltcXF9hXl9eY2VmZmlna3J0b3F3eHyBfX+JgIWJiouTlZCTmpybnqSgnqyrqrO3srK2uL2/u7jAwMLFxsfEv8XLzcrIy83JzcrP0s3M0dTP0drY1dPR1dzc19za19XX2dnU1NjU0dXPzdHQy8rMysfGxMLBvLu3ta+sraeioJ2YlI+MioeFfX55cnJsaWVjXVlbVE5RTktHRUVAPDw3NC8uLyknKSIiJiUdHiEeGx4eHRwZHB8cHiAfHh8eHSEhISMoJyMnKisrLCszNy8yOTg9QEJFRUVITVFOTlJVWltaXmNfX2ZqZ21xb3R3eHqAhoeJkZKTlZmhpJ6kqKeur6yxtLW1trW4t6+us7axrbK2tLa6ury7u7u9u7vCwb+/vr7Ev7y9v8G8vby6vru4uLq+tri8ubi5t7W4uLW5uLKxs7G0tLGwt7Wvs7avr7O0tLW4trS4uLO1trW1trm1tLm0r7Kyr66wramsqaKlp52bmpeWl5KQkImEhIB8fXh3eHJrbW5mYGNcWFhUUE1LRENDQUI9ODcxLy8vMCsqLCgoKCgpKScoKCYoKygpKyssLi0sLi0uMDIwMTIuLzQ0Njg4Njc8ODlBQ0A/RUdGSU5RUVFUV1pdXWFjZGdpbG1vcXJ2eXh6fICAgIWIio2OkJGSlJWanJqbnZ2cn6Kkp6enq62srbCysrO1uLy4uL+/vL7CwMHAvb/Cvbq9vLm5uba2t7Sysq+urqyqqaalpqShoJ+enZuamZqXlZWTkpGSkpCNjpCMioqLioiHhoeGhYSGg4GDhoKDg4GBg4GBgoGBgoOChISChISChIWDg4WEgoSEgYODgYGCgYGAgICAgX99f398fX18e3p6e3t7enp7fHx4e3x6e3x7fHx9fX59fn1+fX19fH19fnx9fn19fX18fHx7fHx6fH18fXx8fHx7fH1+fXx+f319fn19fn1+gH9+f4B/fn+AgICAgH+AgICAgIGAgICAgH9+f4B+f35+fn58e3t8e3p5eXh4d3Z1dHRzcXBvb21sbmxqaWhlZmVjYmFfX2BfXV1cXFxaWVlaWVlYV1hYV1hYWVhZWFlaWllbXFpbXV5fX15fYWJhYmNiYWJhYWJjZGVmZ2hqbG1ub3Fxc3V3dnd6e3t8e3x+f3+AgICAgoGBgoKDhISFh4aHiYqKi4uMjYyOj4+QkZKUlZWXmJmbm52enqCioqSlpqeoqaqrrK2ur7CxsrGys7O0tbW2tba3t7i3uLe4t7a3t7i3tre2tba1tLSzsrKysbCvrq2sq6qop6alo6OioJ+dnJqZmJeWlJKSkI+OjoyLioiIh4WEg4GBgH9+fXt6eXh3d3V0c3JxcG9ubWxsamppaWhnZmVlZGRjYmNiYWBhYGBfYF9fXl5fXl1dXVxdXF1dXF1cXF1cXF1dXV5dXV5fXl9eX19gYGFgYWJhYmFiY2NiY2RjZGNkZWRlZGVmZmVmZmVmZ2dmZ2hnaGhnaGloZ2hpaWhpamlqaWpqa2pra2xtbGxtbm1ubm5vcG9wcXBxcnFycnN0c3N0dXV2d3d4eHh5ent6e3x9fn5/f4CAgIGCg4SEhYaGh4iIiYqLi4uMjY2Oj5CQkZGSk5OUlJWWlpeYl5iZmZqbm5ybnJ2cnZ6en56fn6ChoKChoqGio6KjpKOko6SjpKWkpaSkpKSlpKWkpaSlpKSlpKOkpKOko6KioaKhoaCfoJ+enp2dnJybmpmZmJeXlpWUk5STkZGQj4+OjYyLioqJh4eGhYSEgoKBgIB/fn59fHt7enl5eHd3dnZ1dHRzc3JycXBxcG9vbm5tbWxrbGxraWppaWhpaGdnZ2dmZ2ZlZmVmZWRlZGVkY2RjZGNkZGRkZGRkZGRkZGRjZGRkY2RjZGNkZWRlZGVmZWZmZ2ZnZ2doaWhpaWpra2xsbW5tbm9ub29wcXFycnNzdHV1dXZ2d3d4eXl6enp7fHx9fX5+f4CAgIGAgYGCgoOEhISFhoWGhoeIh4iJiImKiYqLiouLjI2MjI2OjY6Pj46PkI+QkZCRkJGQkZGSkZKRkpGSkZGRkZKRkpKRkpGSkZKRkpGSkZKRkpGSkZCRkZCRkI+Qj5CPkI+Pjo+OjY6Njo2MjYyLjIuMi4qLioqJiomJiImIh4iHh4aHhoaFhoWFhIWEg4SDg4KDgoKBgoGAgYCBgICAgICAf4CAf39+f35/fn1+fX59fHx9fH18e3x7fHt6e3p7ent6e3p5enl6enl6eXp5eXl4eXh5eHl4eXh5eHl4eXh5eHh3eHh4d3h4d3h3d3h4d3l4eHd4d3h3eHd4d3h3eHh4eXh5eHl4eHl4eXh5enl6eXp5enl6eXp5ent6ent6e3x7fHx9fH18fX19fn1+fX5/fn9+f4B/gH+Af4CAgICAgIGAgYCBgoGCgYKCgoKDgoOEg4OEg4SFhIWEhYSFhoWGhYaHhoeHhoeGh4iHiIiHiImIiImKiYqJiYqJiouKi4qLiouKi4qLiouKi4qLiouKi4qLi4qLiouKi4qLiomJiomIiYiJiImIh4iIh4iHhoeGhYWGhYaFhIWEg4OEg4KDgoOCgYKBgIGAgICAgH+Af39+f359fn18fX19fHx8e3t6e3p7enl6eXp5enl6enl5eXh5eHh5eHl4eXh5eHl4eHd5eHd3eHl4d3h3eHd4d3h3eHh4d3h4d3h3d3h5eHl4eXh5eHl5eXp5enl6eXp7ent6e3p7e3t7fHt8e3x8fHx9fH1+fX59fn9+f35/gH+AgICAgICAgYGAgYKBgoGCgoKDgoOEg4SEhIWFhIWFhoWGhYaGhoaHhoeGh4aHhoeIh4iHiIeHiIeIh4iHiIeIiIiHiIeIh4iHiIiHiIeIh4iHiIeIh4eIh4eIh4aHh4aHhoeGh4aHhoWGhYaFhoWFhIWEhYSFhIWEhISDhIOEg4OCg4OCg4KDgYKCgYKCgYCBgIGAgYCBgICAgICAgICAf4B/f4B/gH+Af35/fn9+f35/fn1+fn19fn1+fX59fn19fX19fH18fXx9fH18fXx9fH18fXx8fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x8e3x7fHt8e3x7fHx8fXx9fH18fX5+fX59fn9+f35+f35/gH+Af4B/gICAgICAgICAgICAgYCBgIGAgIGAgYGBgoGCgYKBgoGCgYKBgoGCgoKDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KCgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGBgYCBgIGAgYCBgIGAgYCBgIGAgYCBgIGAgYCBgIGAgYCAgICBgIGAgYCBgIGAgYCBgIGAgYCBgExJU1RCAAAASU5GT0lDUkQMAAAAMjAwOC0wOS0yMQAASUVORwMAAAAgAAABSVNGVBYAAABTb255IFNvdW5kIEZvcmdlIDguMAAA",
-              "base64"
+              "base64",
             ),
           });
         },
@@ -402,7 +402,7 @@ test("handles UserError errors", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [{ text: "Something went wrong", type: "text" }],
         isError: true,
@@ -476,7 +476,7 @@ test("tracks tool progress", async () => {
         undefined,
         {
           onprogress: onProgress,
-        }
+        },
       );
 
       expect(onProgress).toHaveBeenCalledTimes(1);
@@ -541,7 +541,7 @@ test(
           undefined,
           {
             onprogress: onProgress,
-          }
+          },
         );
 
         expect(onProgress).toHaveBeenCalledTimes(4);
@@ -592,7 +592,7 @@ test(
         return server;
       },
     });
-  }
+  },
 );
 
 test("sets logging levels", async () => {
@@ -677,7 +677,7 @@ test("sends logging messages to the client", async () => {
               ...(message.params.data ?? {}),
             });
           }
-        }
+        },
       );
 
       await client.callTool({
@@ -780,7 +780,7 @@ test("clients reads a resource", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        })
+        }),
       ).toEqual({
         contents: [
           {
@@ -820,7 +820,7 @@ test("clients reads a resource that returns multiple resources", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        })
+        }),
       ).toEqual({
         contents: [
           {
@@ -874,7 +874,7 @@ test("embedded resources work in tools", async () => {
             userId: "123",
           },
           name: "get_user_profile",
-        })
+        }),
       ).toEqual({
         content: [
           {
@@ -919,7 +919,7 @@ test("embedded resources work in tools", async () => {
             content: [
               {
                 resource: await server.embedded(
-                  `user://profile/${args.userId}`
+                  `user://profile/${args.userId}`,
                 ),
                 type: "resource",
               },
@@ -944,7 +944,7 @@ test("embedded resources work with direct resources", async () => {
         await client.callTool({
           arguments: {},
           name: "get_logs",
-        })
+        }),
       ).toEqual({
         content: [
           {
@@ -1006,7 +1006,7 @@ test("adds prompts", async () => {
             changes: "foo",
           },
           name: "git-commit",
-        })
+        }),
       ).toEqual({
         description: "Generate a Git commit message",
         messages: [
@@ -1090,11 +1090,11 @@ test("uses events to notify server of client connect/disconnect", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client.connect(transport);
@@ -1138,11 +1138,11 @@ test("handles multiple clients", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport1 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client1.connect(transport1);
@@ -1154,11 +1154,11 @@ test("handles multiple clients", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport2 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client2.connect(transport2);
@@ -1187,7 +1187,7 @@ test("session knows about client capabilities", async () => {
               listChanged: true,
             },
           },
-        }
+        },
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1227,7 +1227,7 @@ test("session knows about roots", async () => {
               listChanged: true,
             },
           },
-        }
+        },
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1275,7 +1275,7 @@ test("session listens to roots changes", async () => {
               listChanged: true,
             },
           },
-        }
+        },
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1608,11 +1608,11 @@ test(
         },
         {
           capabilities: {},
-        }
+        },
       );
 
       const transport = new StreamableHTTPClientTransport(
-        new URL(`http://localhost:${port}/another-mcp`)
+        new URL(`http://localhost:${port}/another-mcp`),
       );
 
       // Connect client to server and wait for session to be ready
@@ -1646,7 +1646,7 @@ test(
     } finally {
       await server.stop();
     }
-  }
+  },
 );
 
 test("clients reads a resource accessed via a resource template", async () => {
@@ -1662,7 +1662,7 @@ test("clients reads a resource accessed via a resource template", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        })
+        }),
       ).toEqual({
         contents: [
           {
@@ -1727,7 +1727,7 @@ test("makes a sampling request", async () => {
           capabilities: {
             sampling: {},
           },
-        }
+        },
       );
       return client;
     },
@@ -1782,7 +1782,7 @@ test("throws ErrorCode.InvalidParams if tool parameters do not match zod schema"
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema."
+          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema.",
         );
       }
     },
@@ -1828,7 +1828,7 @@ test("server remains usable after InvalidParams error", async () => {
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema."
+          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema.",
         );
       }
 
@@ -1839,7 +1839,7 @@ test("server remains usable after InvalidParams error", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [{ text: "3", type: "text" }],
       });
@@ -1901,11 +1901,11 @@ test("allows new clients to connect after a client disconnects", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport1 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client1.connect(transport1);
@@ -1917,7 +1917,7 @@ test("allows new clients to connect after a client disconnects", async () => {
         b: 2,
       },
       name: "add",
-    })
+    }),
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -1931,11 +1931,11 @@ test("allows new clients to connect after a client disconnects", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport2 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client2.connect(transport2);
@@ -1947,7 +1947,7 @@ test("allows new clients to connect after a client disconnects", async () => {
         b: 2,
       },
       name: "add",
-    })
+    }),
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -2073,7 +2073,7 @@ test("provides auth to tools", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2090,14 +2090,14 @@ test("provides auth to tools", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
 
   expect(
     authenticate,
-    "authenticate should have been called"
+    "authenticate should have been called",
   ).toHaveBeenCalledTimes(1);
 
   expect(
@@ -2107,7 +2107,7 @@ test("provides auth to tools", async () => {
         b: 2,
       },
       name: "add",
-    })
+    }),
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -2129,7 +2129,7 @@ test("provides auth to tools", async () => {
       reportProgress: expect.any(Function),
       session: { id: 1 },
       streamContent: expect.any(Function),
-    }
+    },
   );
 });
 
@@ -2176,7 +2176,7 @@ test("provides auth to resources", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2193,7 +2193,7 @@ test("provides auth to resources", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2269,7 +2269,7 @@ test("provides auth to resource templates", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2286,7 +2286,7 @@ test("provides auth to resource templates", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2298,7 +2298,7 @@ test("provides auth to resource templates", async () => {
   expect(templateLoad).toHaveBeenCalledTimes(1);
   expect(templateLoad).toHaveBeenCalledWith(
     { resourceId: "resource-123" },
-    { permissions: ["read", "write"], userId: 99 }
+    { permissions: ["read", "write"], userId: 99 },
   );
 
   expect(result).toEqual({
@@ -2367,7 +2367,7 @@ test("provides auth to resource templates returning arrays", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2384,7 +2384,7 @@ test("provides auth to resource templates returning arrays", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2396,7 +2396,7 @@ test("provides auth to resource templates returning arrays", async () => {
   expect(templateLoad).toHaveBeenCalledTimes(1);
   expect(templateLoad).toHaveBeenCalledWith(
     { category: "reports" },
-    { accessLevel: 3, teamId: "team-alpha" }
+    { accessLevel: 3, teamId: "team-alpha" },
   );
 
   expect(result).toEqual({
@@ -2471,7 +2471,7 @@ test("provides auth to prompt argument completion", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2488,7 +2488,7 @@ test("provides auth to prompt argument completion", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2563,7 +2563,7 @@ test("provides auth to prompt load function", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2580,7 +2580,7 @@ test("provides auth to prompt load function", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2593,7 +2593,7 @@ test("provides auth to prompt load function", async () => {
   expect(promptLoad).toHaveBeenCalledTimes(1);
   expect(promptLoad).toHaveBeenCalledWith(
     { option: "dashboard" },
-    { level: "admin", username: "testuser" }
+    { level: "admin", username: "testuser" },
   );
 
   expect(result).toEqual({
@@ -2664,7 +2664,7 @@ test("provides auth to resource template argument completion", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2681,7 +2681,7 @@ test("provides auth to resource template argument completion", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2817,11 +2817,11 @@ test("blocks unauthorized requests", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   expect(async () => {
@@ -2860,7 +2860,7 @@ test("filters tools based on canAccess property", async () => {
     // Admin gets both tools
     const adminClient = new Client(
       { name: "admin", version: "1.0.0" },
-      { capabilities: {} }
+      { capabilities: {} },
     );
     const adminTransport = new SSEClientTransport(
       new URL(`http://localhost:${port}/sse`),
@@ -2872,7 +2872,7 @@ test("filters tools based on canAccess property", async () => {
               headers: { ...init?.headers, "x-role": "admin" },
             }),
         },
-      }
+      },
     );
     await adminClient.connect(adminTransport);
 
@@ -2885,7 +2885,7 @@ test("filters tools based on canAccess property", async () => {
     // User gets only public tool
     const userClient = new Client(
       { name: "user", version: "1.0.0" },
-      { capabilities: {} }
+      { capabilities: {} },
     );
     const userTransport = new SSEClientTransport(
       new URL(`http://localhost:${port}/sse`),
@@ -2897,7 +2897,7 @@ test("filters tools based on canAccess property", async () => {
               headers: { ...init?.headers, "x-role": "user" },
             }),
         },
-      }
+      },
     );
     await userClient.connect(userTransport);
 
@@ -2923,7 +2923,7 @@ test("tools without canAccess are accessible to all", async () => {
         name: "test-tool",
       });
       expect(
-        (result.content as Array<{ text: string; type: string }>)[0]
+        (result.content as Array<{ text: string; type: string }>)[0],
       ).toEqual({ text: "success", type: "text" });
     },
     server: async () => {
@@ -2962,10 +2962,10 @@ test("canAccess works without authentication", async () => {
   try {
     const client = new Client(
       { name: "test-client", version: "1.0.0" },
-      { capabilities: {} }
+      { capabilities: {} },
     );
     const transport = new SSEClientTransport(
-      new URL(`http://localhost:${port}/sse`)
+      new URL(`http://localhost:${port}/sse`),
     );
     await client.connect(transport);
 
@@ -3024,13 +3024,13 @@ test("HTTP Stream: calls a tool", { timeout: 20000 }, async () => {
       },
       {
         capabilities: {},
-      }
+      },
     );
 
     // IMPORTANT: Don't provide sessionId manually with HTTP streaming
     // The server will generate a session ID automatically
     const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`)
+      new URL(`http://localhost:${port}/mcp`),
     );
 
     // Connect client to server and wait for session to be ready
@@ -3086,7 +3086,7 @@ test("uses `formatInvalidParamsErrorMessage` callback to build ErrorCode.Invalid
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          `MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: My custom error message: Field b failed with error 'Expected number, received string'. Please check the parameter types and values according to the tool's schema.`
+          `MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: My custom error message: Field b failed with error 'Expected number, received string'. Please check the parameter types and values according to the tool's schema.`,
         );
       }
     },
@@ -3160,11 +3160,11 @@ test("stateless mode works correctly", async () => {
       },
       {
         capabilities: {},
-      }
+      },
     );
 
     const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`)
+      new URL(`http://localhost:${port}/mcp`),
     );
 
     await client.connect(transport);

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -70,11 +70,11 @@ const runWithTestServer = async ({
           },
           {
             capabilities: {},
-          }
+          },
         );
 
     const transport = new SSEClientTransport(
-      new URL(`http://localhost:${port}/sse`)
+      new URL(`http://localhost:${port}/sse`),
     );
 
     const session = await new Promise<FastMCPSession>((resolve) => {
@@ -220,7 +220,7 @@ test("calls a tool", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [{ text: "3", type: "text" }],
       });
@@ -258,7 +258,7 @@ test("returns a list", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [
           { text: "a", type: "text" },
@@ -304,7 +304,7 @@ test("returns an image", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [
           {
@@ -327,7 +327,7 @@ test("returns an image", async () => {
           return imageContent({
             buffer: Buffer.from(
               "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
-              "base64"
+              "base64",
             ),
           });
         },
@@ -353,7 +353,7 @@ test("returns an audio", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [
           {
@@ -376,7 +376,7 @@ test("returns an audio", async () => {
           return audioContent({
             buffer: Buffer.from(
               "UklGRhwMAABXQVZFZm10IBAAAAABAAEAgD4AAIA+AAABAAgAZGF0Ya4LAACAgICAgICAgICAgICAgICAgICAgICAgICAf3hxeH+AfXZ1eHx6dnR5fYGFgoOKi42aloubq6GOjI2Op7ythXJ0eYF5aV1AOFFib32HmZSHhpCalIiYi4SRkZaLfnhxaWptb21qaWBea2BRYmZTVmFgWFNXVVVhaGdbYGhZbXh1gXZ1goeIlot1k6yxtKaOkaWhq7KonKCZoaCjoKWuqqmurK6ztrO7tbTAvru/vb68vbW6vLGqsLOfm5yal5KKhoyBeHt2dXBnbmljVlJWUEBBPDw9Mi4zKRwhIBYaGRQcHBURGB0XFxwhGxocJSstMjg6PTc6PUxVV1lWV2JqaXN0coCHhIyPjpOenqWppK6xu72yxMu9us7Pw83Wy9nY29ve6OPr6uvs6ezu6ejk6erm3uPj3dbT1sjBzdDFuMHAt7m1r7W6qaCupJOTkpWPgHqAd3JrbGlnY1peX1hTUk9PTFRKR0RFQkRBRUVEQkdBPjs9Pzo6NT04Njs+PTxAPzo/Ojk6PEA5PUJAQD04PkRCREZLUk1KT1BRUVdXU1VRV1tZV1xgXltcXF9hXl9eY2VmZmlna3J0b3F3eHyBfX+JgIWJiouTlZCTmpybnqSgnqyrqrO3srK2uL2/u7jAwMLFxsfEv8XLzcrIy83JzcrP0s3M0dTP0drY1dPR1dzc19za19XX2dnU1NjU0dXPzdHQy8rMysfGxMLBvLu3ta+sraeioJ2YlI+MioeFfX55cnJsaWVjXVlbVE5RTktHRUVAPDw3NC8uLyknKSIiJiUdHiEeGx4eHRwZHB8cHiAfHh8eHSEhISMoJyMnKisrLCszNy8yOTg9QEJFRUVITVFOTlJVWltaXmNfX2ZqZ21xb3R3eHqAhoeJkZKTlZmhpJ6kqKeur6yxtLW1trW4t6+us7axrbK2tLa6ury7u7u9u7vCwb+/vr7Ev7y9v8G8vby6vru4uLq+tri8ubi5t7W4uLW5uLKxs7G0tLGwt7Wvs7avr7O0tLW4trS4uLO1trW1trm1tLm0r7Kyr66wramsqaKlp52bmpeWl5KQkImEhIB8fXh3eHJrbW5mYGNcWFhUUE1LRENDQUI9ODcxLy8vMCsqLCgoKCgpKScoKCYoKygpKyssLi0sLi0uMDIwMTIuLzQ0Njg4Njc8ODlBQ0A/RUdGSU5RUVFUV1pdXWFjZGdpbG1vcXJ2eXh6fICAgIWIio2OkJGSlJWanJqbnZ2cn6Kkp6enq62srbCysrO1uLy4uL+/vL7CwMHAvb/Cvbq9vLm5uba2t7Sysq+urqyqqaalpqShoJ+enZuamZqXlZWTkpGSkpCNjpCMioqLioiHhoeGhYSGg4GDhoKDg4GBg4GBgoGBgoOChISChISChIWDg4WEgoSEgYODgYGCgYGAgICAgX99f398fX18e3p6e3t7enp7fHx4e3x6e3x7fHx9fX59fn1+fX19fH19fnx9fn19fX18fHx7fHx6fH18fXx8fHx7fH1+fXx+f319fn19fn1+gH9+f4B/fn+AgICAgH+AgICAgIGAgICAgH9+f4B+f35+fn58e3t8e3p5eXh4d3Z1dHRzcXBvb21sbmxqaWhlZmVjYmFfX2BfXV1cXFxaWVlaWVlYV1hYV1hYWVhZWFlaWllbXFpbXV5fX15fYWJhYmNiYWJhYWJjZGVmZ2hqbG1ub3Fxc3V3dnd6e3t8e3x+f3+AgICAgoGBgoKDhISFh4aHiYqKi4uMjYyOj4+QkZKUlZWXmJmbm52enqCioqSlpqeoqaqrrK2ur7CxsrGys7O0tbW2tba3t7i3uLe4t7a3t7i3tre2tba1tLSzsrKysbCvrq2sq6qop6alo6OioJ+dnJqZmJeWlJKSkI+OjoyLioiIh4WEg4GBgH9+fXt6eXh3d3V0c3JxcG9ubWxsamppaWhnZmVlZGRjYmNiYWBhYGBfYF9fXl5fXl1dXVxdXF1dXF1cXF1cXF1dXV5dXV5fXl9eX19gYGFgYWJhYmFiY2NiY2RjZGNkZWRlZGVmZmVmZmVmZ2dmZ2hnaGhnaGloZ2hpaWhpamlqaWpqa2pra2xtbGxtbm1ubm5vcG9wcXBxcnFycnN0c3N0dXV2d3d4eHh5ent6e3x9fn5/f4CAgIGCg4SEhYaGh4iIiYqLi4uMjY2Oj5CQkZGSk5OUlJWWlpeYl5iZmZqbm5ybnJ2cnZ6en56fn6ChoKChoqGio6KjpKOko6SjpKWkpaSkpKSlpKWkpaSlpKSlpKOkpKOko6KioaKhoaCfoJ+enp2dnJybmpmZmJeXlpWUk5STkZGQj4+OjYyLioqJh4eGhYSEgoKBgIB/fn59fHt7enl5eHd3dnZ1dHRzc3JycXBxcG9vbm5tbWxrbGxraWppaWhpaGdnZ2dmZ2ZlZmVmZWRlZGVkY2RjZGNkZGRkZGRkZGRkZGRjZGRkY2RjZGNkZWRlZGVmZWZmZ2ZnZ2doaWhpaWpra2xsbW5tbm9ub29wcXFycnNzdHV1dXZ2d3d4eXl6enp7fHx9fX5+f4CAgIGAgYGCgoOEhISFhoWGhoeIh4iJiImKiYqLiouLjI2MjI2OjY6Pj46PkI+QkZCRkJGQkZGSkZKRkpGSkZGRkZKRkpKRkpGSkZKRkpGSkZKRkpGSkZCRkZCRkI+Qj5CPkI+Pjo+OjY6Njo2MjYyLjIuMi4qLioqJiomJiImIh4iHh4aHhoaFhoWFhIWEg4SDg4KDgoKBgoGAgYCBgICAgICAf4CAf39+f35/fn1+fX59fHx9fH18e3x7fHt6e3p7ent6e3p5enl6enl6eXp5eXl4eXh5eHl4eXh5eHl4eXh5eHh3eHh4d3h4d3h3d3h4d3l4eHd4d3h3eHd4d3h3eHh4eXh5eHl4eHl4eXh5enl6eXp5enl6eXp5ent6ent6e3x7fHx9fH18fX19fn1+fX5/fn9+f4B/gH+Af4CAgICAgIGAgYCBgoGCgYKCgoKDgoOEg4OEg4SFhIWEhYSFhoWGhYaHhoeHhoeGh4iHiIiHiImIiImKiYqJiYqJiouKi4qLiouKi4qLiouKi4qLiouKi4qLi4qLiouKi4qLiomJiomIiYiJiImIh4iIh4iHhoeGhYWGhYaFhIWEg4OEg4KDgoOCgYKBgIGAgICAgH+Af39+f359fn18fX19fHx8e3t6e3p7enl6eXp5enl6enl5eXh5eHh5eHl4eXh5eHl4eHd5eHd3eHl4d3h3eHd4d3h3eHh4d3h4d3h3d3h5eHl4eXh5eHl5eXp5enl6eXp7ent6e3p7e3t7fHt8e3x8fHx9fH1+fX59fn9+f35/gH+AgICAgICAgYGAgYKBgoGCgoKDgoOEg4SEhIWFhIWFhoWGhYaGhoaHhoeGh4aHhoeIh4iHiIeHiIeIh4iHiIeIiIiHiIeIh4iHiIiHiIeIh4iHiIeIh4eIh4eIh4aHh4aHhoeGh4aHhoWGhYaFhoWFhIWEhYSFhIWEhISDhIOEg4OCg4OCg4KDgYKCgYKCgYCBgIGAgYCBgICAgICAgICAf4B/f4B/gH+Af35/fn9+f35/fn1+fn19fn1+fX59fn19fX19fH18fXx9fH18fXx9fH18fXx8fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x8e3x7fHt8e3x7fHx8fXx9fH18fX5+fX59fn9+f35+f35/gH+Af4B/gICAgICAgICAgICAgYCBgIGAgIGAgYGBgoGCgYKBgoGCgYKBgoGCgoKDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KCgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGBgYCBgIGAgYCBgIGAgYCBgIGAgYCBgIGAgYCBgIGAgYCAgICBgIGAgYCBgIGAgYCBgIGAgYCBgExJU1RCAAAASU5GT0lDUkQMAAAAMjAwOC0wOS0yMQAASUVORwMAAAAgAAABSVNGVBYAAABTb255IFNvdW5kIEZvcmdlIDguMAAA",
-              "base64"
+              "base64",
             ),
           });
         },
@@ -402,7 +402,7 @@ test("handles UserError errors", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [{ text: "Something went wrong", type: "text" }],
         isError: true,
@@ -476,7 +476,7 @@ test("tracks tool progress", async () => {
         undefined,
         {
           onprogress: onProgress,
-        }
+        },
       );
 
       expect(onProgress).toHaveBeenCalledTimes(1);
@@ -541,7 +541,7 @@ test(
           undefined,
           {
             onprogress: onProgress,
-          }
+          },
         );
 
         expect(onProgress).toHaveBeenCalledTimes(4);
@@ -592,7 +592,7 @@ test(
         return server;
       },
     });
-  }
+  },
 );
 
 test("sets logging levels", async () => {
@@ -677,7 +677,7 @@ test("sends logging messages to the client", async () => {
               ...(message.params.data ?? {}),
             });
           }
-        }
+        },
       );
 
       await client.callTool({
@@ -780,7 +780,7 @@ test("clients reads a resource", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        })
+        }),
       ).toEqual({
         contents: [
           {
@@ -820,7 +820,7 @@ test("clients reads a resource that returns multiple resources", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        })
+        }),
       ).toEqual({
         contents: [
           {
@@ -874,7 +874,7 @@ test("embedded resources work in tools", async () => {
             userId: "123",
           },
           name: "get_user_profile",
-        })
+        }),
       ).toEqual({
         content: [
           {
@@ -919,7 +919,7 @@ test("embedded resources work in tools", async () => {
             content: [
               {
                 resource: await server.embedded(
-                  `user://profile/${args.userId}`
+                  `user://profile/${args.userId}`,
                 ),
                 type: "resource",
               },
@@ -944,7 +944,7 @@ test("embedded resources work with direct resources", async () => {
         await client.callTool({
           arguments: {},
           name: "get_logs",
-        })
+        }),
       ).toEqual({
         content: [
           {
@@ -1006,7 +1006,7 @@ test("adds prompts", async () => {
             changes: "foo",
           },
           name: "git-commit",
-        })
+        }),
       ).toEqual({
         description: "Generate a Git commit message",
         messages: [
@@ -1090,11 +1090,11 @@ test("uses events to notify server of client connect/disconnect", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client.connect(transport);
@@ -1138,11 +1138,11 @@ test("handles multiple clients", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport1 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client1.connect(transport1);
@@ -1154,11 +1154,11 @@ test("handles multiple clients", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport2 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client2.connect(transport2);
@@ -1187,7 +1187,7 @@ test("session knows about client capabilities", async () => {
               listChanged: true,
             },
           },
-        }
+        },
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1227,7 +1227,7 @@ test("session knows about roots", async () => {
               listChanged: true,
             },
           },
-        }
+        },
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1275,7 +1275,7 @@ test("session listens to roots changes", async () => {
               listChanged: true,
             },
           },
-        }
+        },
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1608,11 +1608,11 @@ test(
         },
         {
           capabilities: {},
-        }
+        },
       );
 
       const transport = new StreamableHTTPClientTransport(
-        new URL(`http://localhost:${port}/another-mcp`)
+        new URL(`http://localhost:${port}/another-mcp`),
       );
 
       // Connect client to server and wait for session to be ready
@@ -1646,7 +1646,7 @@ test(
     } finally {
       await server.stop();
     }
-  }
+  },
 );
 
 test("clients reads a resource accessed via a resource template", async () => {
@@ -1662,7 +1662,7 @@ test("clients reads a resource accessed via a resource template", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        })
+        }),
       ).toEqual({
         contents: [
           {
@@ -1727,7 +1727,7 @@ test("makes a sampling request", async () => {
           capabilities: {
             sampling: {},
           },
-        }
+        },
       );
       return client;
     },
@@ -1782,7 +1782,7 @@ test("throws ErrorCode.InvalidParams if tool parameters do not match zod schema"
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema."
+          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema.",
         );
       }
     },
@@ -1828,7 +1828,7 @@ test("server remains usable after InvalidParams error", async () => {
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema."
+          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema.",
         );
       }
 
@@ -1839,7 +1839,7 @@ test("server remains usable after InvalidParams error", async () => {
             b: 2,
           },
           name: "add",
-        })
+        }),
       ).toEqual({
         content: [{ text: "3", type: "text" }],
       });
@@ -1901,11 +1901,11 @@ test("allows new clients to connect after a client disconnects", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport1 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client1.connect(transport1);
@@ -1917,7 +1917,7 @@ test("allows new clients to connect after a client disconnects", async () => {
         b: 2,
       },
       name: "add",
-    })
+    }),
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -1931,11 +1931,11 @@ test("allows new clients to connect after a client disconnects", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport2 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   await client2.connect(transport2);
@@ -1947,7 +1947,7 @@ test("allows new clients to connect after a client disconnects", async () => {
         b: 2,
       },
       name: "add",
-    })
+    }),
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -2074,7 +2074,7 @@ test("provides auth to tools", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2091,14 +2091,14 @@ test("provides auth to tools", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
 
   expect(
     authenticate,
-    "authenticate should have been called"
+    "authenticate should have been called",
   ).toHaveBeenCalledTimes(1);
 
   expect(
@@ -2108,7 +2108,7 @@ test("provides auth to tools", async () => {
         b: 2,
       },
       name: "add",
-    })
+    }),
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -2130,7 +2130,7 @@ test("provides auth to tools", async () => {
       reportProgress: expect.any(Function),
       session: { id: 1 },
       streamContent: expect.any(Function),
-    }
+    },
   );
 });
 
@@ -2177,7 +2177,7 @@ test("provides auth to resources", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2194,7 +2194,7 @@ test("provides auth to resources", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2270,7 +2270,7 @@ test("provides auth to resource templates", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2287,7 +2287,7 @@ test("provides auth to resource templates", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2299,7 +2299,7 @@ test("provides auth to resource templates", async () => {
   expect(templateLoad).toHaveBeenCalledTimes(1);
   expect(templateLoad).toHaveBeenCalledWith(
     { resourceId: "resource-123" },
-    { permissions: ["read", "write"], userId: 99 }
+    { permissions: ["read", "write"], userId: 99 },
   );
 
   expect(result).toEqual({
@@ -2368,7 +2368,7 @@ test("provides auth to resource templates returning arrays", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2385,7 +2385,7 @@ test("provides auth to resource templates returning arrays", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2397,7 +2397,7 @@ test("provides auth to resource templates returning arrays", async () => {
   expect(templateLoad).toHaveBeenCalledTimes(1);
   expect(templateLoad).toHaveBeenCalledWith(
     { category: "reports" },
-    { accessLevel: 3, teamId: "team-alpha" }
+    { accessLevel: 3, teamId: "team-alpha" },
   );
 
   expect(result).toEqual({
@@ -2472,7 +2472,7 @@ test("provides auth to prompt argument completion", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2489,7 +2489,7 @@ test("provides auth to prompt argument completion", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2564,7 +2564,7 @@ test("provides auth to prompt load function", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2581,7 +2581,7 @@ test("provides auth to prompt load function", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2594,7 +2594,7 @@ test("provides auth to prompt load function", async () => {
   expect(promptLoad).toHaveBeenCalledTimes(1);
   expect(promptLoad).toHaveBeenCalledWith(
     { option: "dashboard" },
-    { level: "admin", username: "testuser" }
+    { level: "admin", username: "testuser" },
   );
 
   expect(result).toEqual({
@@ -2665,7 +2665,7 @@ test("provides auth to resource template argument completion", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
@@ -2682,7 +2682,7 @@ test("provides auth to resource template argument completion", async () => {
           });
         },
       },
-    }
+    },
   );
 
   await client.connect(transport);
@@ -2818,11 +2818,11 @@ test("blocks unauthorized requests", async () => {
     },
     {
       capabilities: {},
-    }
+    },
   );
 
   const transport = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`)
+    new URL(`http://localhost:${port}/sse`),
   );
 
   expect(async () => {
@@ -2861,7 +2861,7 @@ test("filters tools based on canAccess property", async () => {
     // Admin gets both tools
     const adminClient = new Client(
       { name: "admin", version: "1.0.0" },
-      { capabilities: {} }
+      { capabilities: {} },
     );
     const adminTransport = new SSEClientTransport(
       new URL(`http://localhost:${port}/sse`),
@@ -2873,7 +2873,7 @@ test("filters tools based on canAccess property", async () => {
               headers: { ...init?.headers, "x-role": "admin" },
             }),
         },
-      }
+      },
     );
     await adminClient.connect(adminTransport);
 
@@ -2886,7 +2886,7 @@ test("filters tools based on canAccess property", async () => {
     // User gets only public tool
     const userClient = new Client(
       { name: "user", version: "1.0.0" },
-      { capabilities: {} }
+      { capabilities: {} },
     );
     const userTransport = new SSEClientTransport(
       new URL(`http://localhost:${port}/sse`),
@@ -2898,7 +2898,7 @@ test("filters tools based on canAccess property", async () => {
               headers: { ...init?.headers, "x-role": "user" },
             }),
         },
-      }
+      },
     );
     await userClient.connect(userTransport);
 
@@ -2924,7 +2924,7 @@ test("tools without canAccess are accessible to all", async () => {
         name: "test-tool",
       });
       expect(
-        (result.content as Array<{ text: string; type: string }>)[0]
+        (result.content as Array<{ text: string; type: string }>)[0],
       ).toEqual({ text: "success", type: "text" });
     },
     server: async () => {
@@ -2963,10 +2963,10 @@ test("canAccess works without authentication", async () => {
   try {
     const client = new Client(
       { name: "test-client", version: "1.0.0" },
-      { capabilities: {} }
+      { capabilities: {} },
     );
     const transport = new SSEClientTransport(
-      new URL(`http://localhost:${port}/sse`)
+      new URL(`http://localhost:${port}/sse`),
     );
     await client.connect(transport);
 
@@ -3025,13 +3025,13 @@ test("HTTP Stream: calls a tool", { timeout: 20000 }, async () => {
       },
       {
         capabilities: {},
-      }
+      },
     );
 
     // IMPORTANT: Don't provide sessionId manually with HTTP streaming
     // The server will generate a session ID automatically
     const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`)
+      new URL(`http://localhost:${port}/mcp`),
     );
 
     // Connect client to server and wait for session to be ready
@@ -3087,7 +3087,7 @@ test("uses `formatInvalidParamsErrorMessage` callback to build ErrorCode.Invalid
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          `MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: My custom error message: Field b failed with error 'Expected number, received string'. Please check the parameter types and values according to the tool's schema.`
+          `MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: My custom error message: Field b failed with error 'Expected number, received string'. Please check the parameter types and values according to the tool's schema.`,
         );
       }
     },
@@ -3161,11 +3161,11 @@ test("stateless mode works correctly", async () => {
       },
       {
         capabilities: {},
-      }
+      },
     );
 
     const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`)
+      new URL(`http://localhost:${port}/mcp`),
     );
 
     await client.connect(transport);

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -70,11 +70,11 @@ const runWithTestServer = async ({
           },
           {
             capabilities: {},
-          },
+          }
         );
 
     const transport = new SSEClientTransport(
-      new URL(`http://localhost:${port}/sse`),
+      new URL(`http://localhost:${port}/sse`)
     );
 
     const session = await new Promise<FastMCPSession>((resolve) => {
@@ -220,7 +220,7 @@ test("calls a tool", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [{ text: "3", type: "text" }],
       });
@@ -258,7 +258,7 @@ test("returns a list", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [
           { text: "a", type: "text" },
@@ -304,7 +304,7 @@ test("returns an image", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [
           {
@@ -327,7 +327,7 @@ test("returns an image", async () => {
           return imageContent({
             buffer: Buffer.from(
               "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
-              "base64",
+              "base64"
             ),
           });
         },
@@ -353,7 +353,7 @@ test("returns an audio", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [
           {
@@ -376,7 +376,7 @@ test("returns an audio", async () => {
           return audioContent({
             buffer: Buffer.from(
               "UklGRhwMAABXQVZFZm10IBAAAAABAAEAgD4AAIA+AAABAAgAZGF0Ya4LAACAgICAgICAgICAgICAgICAgICAgICAgICAf3hxeH+AfXZ1eHx6dnR5fYGFgoOKi42aloubq6GOjI2Op7ythXJ0eYF5aV1AOFFib32HmZSHhpCalIiYi4SRkZaLfnhxaWptb21qaWBea2BRYmZTVmFgWFNXVVVhaGdbYGhZbXh1gXZ1goeIlot1k6yxtKaOkaWhq7KonKCZoaCjoKWuqqmurK6ztrO7tbTAvru/vb68vbW6vLGqsLOfm5yal5KKhoyBeHt2dXBnbmljVlJWUEBBPDw9Mi4zKRwhIBYaGRQcHBURGB0XFxwhGxocJSstMjg6PTc6PUxVV1lWV2JqaXN0coCHhIyPjpOenqWppK6xu72yxMu9us7Pw83Wy9nY29ve6OPr6uvs6ezu6ejk6erm3uPj3dbT1sjBzdDFuMHAt7m1r7W6qaCupJOTkpWPgHqAd3JrbGlnY1peX1hTUk9PTFRKR0RFQkRBRUVEQkdBPjs9Pzo6NT04Njs+PTxAPzo/Ojk6PEA5PUJAQD04PkRCREZLUk1KT1BRUVdXU1VRV1tZV1xgXltcXF9hXl9eY2VmZmlna3J0b3F3eHyBfX+JgIWJiouTlZCTmpybnqSgnqyrqrO3srK2uL2/u7jAwMLFxsfEv8XLzcrIy83JzcrP0s3M0dTP0drY1dPR1dzc19za19XX2dnU1NjU0dXPzdHQy8rMysfGxMLBvLu3ta+sraeioJ2YlI+MioeFfX55cnJsaWVjXVlbVE5RTktHRUVAPDw3NC8uLyknKSIiJiUdHiEeGx4eHRwZHB8cHiAfHh8eHSEhISMoJyMnKisrLCszNy8yOTg9QEJFRUVITVFOTlJVWltaXmNfX2ZqZ21xb3R3eHqAhoeJkZKTlZmhpJ6kqKeur6yxtLW1trW4t6+us7axrbK2tLa6ury7u7u9u7vCwb+/vr7Ev7y9v8G8vby6vru4uLq+tri8ubi5t7W4uLW5uLKxs7G0tLGwt7Wvs7avr7O0tLW4trS4uLO1trW1trm1tLm0r7Kyr66wramsqaKlp52bmpeWl5KQkImEhIB8fXh3eHJrbW5mYGNcWFhUUE1LRENDQUI9ODcxLy8vMCsqLCgoKCgpKScoKCYoKygpKyssLi0sLi0uMDIwMTIuLzQ0Njg4Njc8ODlBQ0A/RUdGSU5RUVFUV1pdXWFjZGdpbG1vcXJ2eXh6fICAgIWIio2OkJGSlJWanJqbnZ2cn6Kkp6enq62srbCysrO1uLy4uL+/vL7CwMHAvb/Cvbq9vLm5uba2t7Sysq+urqyqqaalpqShoJ+enZuamZqXlZWTkpGSkpCNjpCMioqLioiHhoeGhYSGg4GDhoKDg4GBg4GBgoGBgoOChISChISChIWDg4WEgoSEgYODgYGCgYGAgICAgX99f398fX18e3p6e3t7enp7fHx4e3x6e3x7fHx9fX59fn1+fX19fH19fnx9fn19fX18fHx7fHx6fH18fXx8fHx7fH1+fXx+f319fn19fn1+gH9+f4B/fn+AgICAgH+AgICAgIGAgICAgH9+f4B+f35+fn58e3t8e3p5eXh4d3Z1dHRzcXBvb21sbmxqaWhlZmVjYmFfX2BfXV1cXFxaWVlaWVlYV1hYV1hYWVhZWFlaWllbXFpbXV5fX15fYWJhYmNiYWJhYWJjZGVmZ2hqbG1ub3Fxc3V3dnd6e3t8e3x+f3+AgICAgoGBgoKDhISFh4aHiYqKi4uMjYyOj4+QkZKUlZWXmJmbm52enqCioqSlpqeoqaqrrK2ur7CxsrGys7O0tbW2tba3t7i3uLe4t7a3t7i3tre2tba1tLSzsrKysbCvrq2sq6qop6alo6OioJ+dnJqZmJeWlJKSkI+OjoyLioiIh4WEg4GBgH9+fXt6eXh3d3V0c3JxcG9ubWxsamppaWhnZmVlZGRjYmNiYWBhYGBfYF9fXl5fXl1dXVxdXF1dXF1cXF1cXF1dXV5dXV5fXl9eX19gYGFgYWJhYmFiY2NiY2RjZGNkZWRlZGVmZmVmZmVmZ2dmZ2hnaGhnaGloZ2hpaWhpamlqaWpqa2pra2xtbGxtbm1ubm5vcG9wcXBxcnFycnN0c3N0dXV2d3d4eHh5ent6e3x9fn5/f4CAgIGCg4SEhYaGh4iIiYqLi4uMjY2Oj5CQkZGSk5OUlJWWlpeYl5iZmZqbm5ybnJ2cnZ6en56fn6ChoKChoqGio6KjpKOko6SjpKWkpaSkpKSlpKWkpaSlpKSlpKOkpKOko6KioaKhoaCfoJ+enp2dnJybmpmZmJeXlpWUk5STkZGQj4+OjYyLioqJh4eGhYSEgoKBgIB/fn59fHt7enl5eHd3dnZ1dHRzc3JycXBxcG9vbm5tbWxrbGxraWppaWhpaGdnZ2dmZ2ZlZmVmZWRlZGVkY2RjZGNkZGRkZGRkZGRkZGRjZGRkY2RjZGNkZWRlZGVmZWZmZ2ZnZ2doaWhpaWpra2xsbW5tbm9ub29wcXFycnNzdHV1dXZ2d3d4eXl6enp7fHx9fX5+f4CAgIGAgYGCgoOEhISFhoWGhoeIh4iJiImKiYqLiouLjI2MjI2OjY6Pj46PkI+QkZCRkJGQkZGSkZKRkpGSkZGRkZKRkpKRkpGSkZKRkpGSkZKRkpGSkZCRkZCRkI+Qj5CPkI+Pjo+OjY6Njo2MjYyLjIuMi4qLioqJiomJiImIh4iHh4aHhoaFhoWFhIWEg4SDg4KDgoKBgoGAgYCBgICAgICAf4CAf39+f35/fn1+fX59fHx9fH18e3x7fHt6e3p7ent6e3p5enl6enl6eXp5eXl4eXh5eHl4eXh5eHl4eXh5eHh3eHh4d3h4d3h3d3h4d3l4eHd4d3h3eHd4d3h3eHh4eXh5eHl4eHl4eXh5enl6eXp5enl6eXp5ent6ent6e3x7fHx9fH18fX19fn1+fX5/fn9+f4B/gH+Af4CAgICAgIGAgYCBgoGCgYKCgoKDgoOEg4OEg4SFhIWEhYSFhoWGhYaHhoeHhoeGh4iHiIiHiImIiImKiYqJiYqJiouKi4qLiouKi4qLiouKi4qLiouKi4qLi4qLiouKi4qLiomJiomIiYiJiImIh4iIh4iHhoeGhYWGhYaFhIWEg4OEg4KDgoOCgYKBgIGAgICAgH+Af39+f359fn18fX19fHx8e3t6e3p7enl6eXp5enl6enl5eXh5eHh5eHl4eXh5eHl4eHd5eHd3eHl4d3h3eHd4d3h3eHh4d3h4d3h3d3h5eHl4eXh5eHl5eXp5enl6eXp7ent6e3p7e3t7fHt8e3x8fHx9fH1+fX59fn9+f35/gH+AgICAgICAgYGAgYKBgoGCgoKDgoOEg4SEhIWFhIWFhoWGhYaGhoaHhoeGh4aHhoeIh4iHiIeHiIeIh4iHiIeIiIiHiIeIh4iHiIiHiIeIh4iHiIeIh4eIh4eIh4aHh4aHhoeGh4aHhoWGhYaFhoWFhIWEhYSFhIWEhISDhIOEg4OCg4OCg4KDgYKCgYKCgYCBgIGAgYCBgICAgICAgICAf4B/f4B/gH+Af35/fn9+f35/fn1+fn19fn1+fX59fn19fX19fH18fXx9fH18fXx9fH18fXx8fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x7fHt8e3x8e3x7fHt8e3x7fHx8fXx9fH18fX5+fX59fn9+f35+f35/gH+Af4B/gICAgICAgICAgICAgYCBgIGAgIGAgYGBgoGCgYKBgoGCgYKBgoGCgoKDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KDgoOCg4KCgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGCgYKBgoGBgYCBgIGAgYCBgIGAgYCBgIGAgYCBgIGAgYCBgIGAgYCAgICBgIGAgYCBgIGAgYCBgIGAgYCBgExJU1RCAAAASU5GT0lDUkQMAAAAMjAwOC0wOS0yMQAASUVORwMAAAAgAAABSVNGVBYAAABTb255IFNvdW5kIEZvcmdlIDguMAAA",
-              "base64",
+              "base64"
             ),
           });
         },
@@ -402,7 +402,7 @@ test("handles UserError errors", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [{ text: "Something went wrong", type: "text" }],
         isError: true,
@@ -476,7 +476,7 @@ test("tracks tool progress", async () => {
         undefined,
         {
           onprogress: onProgress,
-        },
+        }
       );
 
       expect(onProgress).toHaveBeenCalledTimes(1);
@@ -541,7 +541,7 @@ test(
           undefined,
           {
             onprogress: onProgress,
-          },
+          }
         );
 
         expect(onProgress).toHaveBeenCalledTimes(4);
@@ -592,7 +592,7 @@ test(
         return server;
       },
     });
-  },
+  }
 );
 
 test("sets logging levels", async () => {
@@ -677,7 +677,7 @@ test("sends logging messages to the client", async () => {
               ...(message.params.data ?? {}),
             });
           }
-        },
+        }
       );
 
       await client.callTool({
@@ -780,7 +780,7 @@ test("clients reads a resource", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        }),
+        })
       ).toEqual({
         contents: [
           {
@@ -820,7 +820,7 @@ test("clients reads a resource that returns multiple resources", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        }),
+        })
       ).toEqual({
         contents: [
           {
@@ -874,7 +874,7 @@ test("embedded resources work in tools", async () => {
             userId: "123",
           },
           name: "get_user_profile",
-        }),
+        })
       ).toEqual({
         content: [
           {
@@ -919,7 +919,7 @@ test("embedded resources work in tools", async () => {
             content: [
               {
                 resource: await server.embedded(
-                  `user://profile/${args.userId}`,
+                  `user://profile/${args.userId}`
                 ),
                 type: "resource",
               },
@@ -944,7 +944,7 @@ test("embedded resources work with direct resources", async () => {
         await client.callTool({
           arguments: {},
           name: "get_logs",
-        }),
+        })
       ).toEqual({
         content: [
           {
@@ -1006,7 +1006,7 @@ test("adds prompts", async () => {
             changes: "foo",
           },
           name: "git-commit",
-        }),
+        })
       ).toEqual({
         description: "Generate a Git commit message",
         messages: [
@@ -1090,11 +1090,11 @@ test("uses events to notify server of client connect/disconnect", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client.connect(transport);
@@ -1138,11 +1138,11 @@ test("handles multiple clients", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport1 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client1.connect(transport1);
@@ -1154,11 +1154,11 @@ test("handles multiple clients", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport2 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client2.connect(transport2);
@@ -1187,7 +1187,7 @@ test("session knows about client capabilities", async () => {
               listChanged: true,
             },
           },
-        },
+        }
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1227,7 +1227,7 @@ test("session knows about roots", async () => {
               listChanged: true,
             },
           },
-        },
+        }
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1275,7 +1275,7 @@ test("session listens to roots changes", async () => {
               listChanged: true,
             },
           },
-        },
+        }
       );
 
       client.setRequestHandler(ListRootsRequestSchema, () => {
@@ -1608,11 +1608,11 @@ test(
         },
         {
           capabilities: {},
-        },
+        }
       );
 
       const transport = new StreamableHTTPClientTransport(
-        new URL(`http://localhost:${port}/another-mcp`),
+        new URL(`http://localhost:${port}/another-mcp`)
       );
 
       // Connect client to server and wait for session to be ready
@@ -1646,7 +1646,7 @@ test(
     } finally {
       await server.stop();
     }
-  },
+  }
 );
 
 test("clients reads a resource accessed via a resource template", async () => {
@@ -1662,7 +1662,7 @@ test("clients reads a resource accessed via a resource template", async () => {
       expect(
         await client.readResource({
           uri: "file:///logs/app.log",
-        }),
+        })
       ).toEqual({
         contents: [
           {
@@ -1727,7 +1727,7 @@ test("makes a sampling request", async () => {
           capabilities: {
             sampling: {},
           },
-        },
+        }
       );
       return client;
     },
@@ -1782,7 +1782,7 @@ test("throws ErrorCode.InvalidParams if tool parameters do not match zod schema"
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema.",
+          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema."
         );
       }
     },
@@ -1828,7 +1828,7 @@ test("server remains usable after InvalidParams error", async () => {
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema.",
+          "MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: b: Expected number, received string. Please check the parameter types and values according to the tool's schema."
         );
       }
 
@@ -1839,7 +1839,7 @@ test("server remains usable after InvalidParams error", async () => {
             b: 2,
           },
           name: "add",
-        }),
+        })
       ).toEqual({
         content: [{ text: "3", type: "text" }],
       });
@@ -1901,11 +1901,11 @@ test("allows new clients to connect after a client disconnects", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport1 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client1.connect(transport1);
@@ -1917,7 +1917,7 @@ test("allows new clients to connect after a client disconnects", async () => {
         b: 2,
       },
       name: "add",
-    }),
+    })
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -1931,11 +1931,11 @@ test("allows new clients to connect after a client disconnects", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport2 = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   await client2.connect(transport2);
@@ -1947,7 +1947,7 @@ test("allows new clients to connect after a client disconnects", async () => {
         b: 2,
       },
       name: "add",
-    }),
+    })
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -1999,6 +1999,7 @@ test("closing event source does not produce error", async () => {
 
   await server.start({
     httpStream: {
+      host: "127.0.0.1",
       port,
     },
     transportType: "httpStream",
@@ -2073,7 +2074,7 @@ test("provides auth to tools", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2090,14 +2091,14 @@ test("provides auth to tools", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
 
   expect(
     authenticate,
-    "authenticate should have been called",
+    "authenticate should have been called"
   ).toHaveBeenCalledTimes(1);
 
   expect(
@@ -2107,7 +2108,7 @@ test("provides auth to tools", async () => {
         b: 2,
       },
       name: "add",
-    }),
+    })
   ).toEqual({
     content: [{ text: "3", type: "text" }],
   });
@@ -2129,7 +2130,7 @@ test("provides auth to tools", async () => {
       reportProgress: expect.any(Function),
       session: { id: 1 },
       streamContent: expect.any(Function),
-    },
+    }
   );
 });
 
@@ -2176,7 +2177,7 @@ test("provides auth to resources", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2193,7 +2194,7 @@ test("provides auth to resources", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2269,7 +2270,7 @@ test("provides auth to resource templates", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2286,7 +2287,7 @@ test("provides auth to resource templates", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2298,7 +2299,7 @@ test("provides auth to resource templates", async () => {
   expect(templateLoad).toHaveBeenCalledTimes(1);
   expect(templateLoad).toHaveBeenCalledWith(
     { resourceId: "resource-123" },
-    { permissions: ["read", "write"], userId: 99 },
+    { permissions: ["read", "write"], userId: 99 }
   );
 
   expect(result).toEqual({
@@ -2367,7 +2368,7 @@ test("provides auth to resource templates returning arrays", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2384,7 +2385,7 @@ test("provides auth to resource templates returning arrays", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2396,7 +2397,7 @@ test("provides auth to resource templates returning arrays", async () => {
   expect(templateLoad).toHaveBeenCalledTimes(1);
   expect(templateLoad).toHaveBeenCalledWith(
     { category: "reports" },
-    { accessLevel: 3, teamId: "team-alpha" },
+    { accessLevel: 3, teamId: "team-alpha" }
   );
 
   expect(result).toEqual({
@@ -2471,7 +2472,7 @@ test("provides auth to prompt argument completion", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2488,7 +2489,7 @@ test("provides auth to prompt argument completion", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2563,7 +2564,7 @@ test("provides auth to prompt load function", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2580,7 +2581,7 @@ test("provides auth to prompt load function", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2593,7 +2594,7 @@ test("provides auth to prompt load function", async () => {
   expect(promptLoad).toHaveBeenCalledTimes(1);
   expect(promptLoad).toHaveBeenCalledWith(
     { option: "dashboard" },
-    { level: "admin", username: "testuser" },
+    { level: "admin", username: "testuser" }
   );
 
   expect(result).toEqual({
@@ -2664,7 +2665,7 @@ test("provides auth to resource template argument completion", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
@@ -2681,7 +2682,7 @@ test("provides auth to resource template argument completion", async () => {
           });
         },
       },
-    },
+    }
   );
 
   await client.connect(transport);
@@ -2817,11 +2818,11 @@ test("blocks unauthorized requests", async () => {
     },
     {
       capabilities: {},
-    },
+    }
   );
 
   const transport = new SSEClientTransport(
-    new URL(`http://localhost:${port}/sse`),
+    new URL(`http://localhost:${port}/sse`)
   );
 
   expect(async () => {
@@ -2860,7 +2861,7 @@ test("filters tools based on canAccess property", async () => {
     // Admin gets both tools
     const adminClient = new Client(
       { name: "admin", version: "1.0.0" },
-      { capabilities: {} },
+      { capabilities: {} }
     );
     const adminTransport = new SSEClientTransport(
       new URL(`http://localhost:${port}/sse`),
@@ -2872,7 +2873,7 @@ test("filters tools based on canAccess property", async () => {
               headers: { ...init?.headers, "x-role": "admin" },
             }),
         },
-      },
+      }
     );
     await adminClient.connect(adminTransport);
 
@@ -2885,7 +2886,7 @@ test("filters tools based on canAccess property", async () => {
     // User gets only public tool
     const userClient = new Client(
       { name: "user", version: "1.0.0" },
-      { capabilities: {} },
+      { capabilities: {} }
     );
     const userTransport = new SSEClientTransport(
       new URL(`http://localhost:${port}/sse`),
@@ -2897,7 +2898,7 @@ test("filters tools based on canAccess property", async () => {
               headers: { ...init?.headers, "x-role": "user" },
             }),
         },
-      },
+      }
     );
     await userClient.connect(userTransport);
 
@@ -2923,7 +2924,7 @@ test("tools without canAccess are accessible to all", async () => {
         name: "test-tool",
       });
       expect(
-        (result.content as Array<{ text: string; type: string }>)[0],
+        (result.content as Array<{ text: string; type: string }>)[0]
       ).toEqual({ text: "success", type: "text" });
     },
     server: async () => {
@@ -2962,10 +2963,10 @@ test("canAccess works without authentication", async () => {
   try {
     const client = new Client(
       { name: "test-client", version: "1.0.0" },
-      { capabilities: {} },
+      { capabilities: {} }
     );
     const transport = new SSEClientTransport(
-      new URL(`http://localhost:${port}/sse`),
+      new URL(`http://localhost:${port}/sse`)
     );
     await client.connect(transport);
 
@@ -3024,13 +3025,13 @@ test("HTTP Stream: calls a tool", { timeout: 20000 }, async () => {
       },
       {
         capabilities: {},
-      },
+      }
     );
 
     // IMPORTANT: Don't provide sessionId manually with HTTP streaming
     // The server will generate a session ID automatically
     const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`),
+      new URL(`http://localhost:${port}/mcp`)
     );
 
     // Connect client to server and wait for session to be ready
@@ -3086,7 +3087,7 @@ test("uses `formatInvalidParamsErrorMessage` callback to build ErrorCode.Invalid
 
         // @ts-expect-error - we know that error is an McpError
         expect(error.message).toBe(
-          `MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: My custom error message: Field b failed with error 'Expected number, received string'. Please check the parameter types and values according to the tool's schema.`,
+          `MCP error -32602: MCP error -32602: Tool 'add' parameter validation failed: My custom error message: Field b failed with error 'Expected number, received string'. Please check the parameter types and values according to the tool's schema.`
         );
       }
     },
@@ -3160,11 +3161,11 @@ test("stateless mode works correctly", async () => {
       },
       {
         capabilities: {},
-      },
+      }
     );
 
     const transport = new StreamableHTTPClientTransport(
-      new URL(`http://localhost:${port}/mcp`),
+      new URL(`http://localhost:${port}/mcp`)
     );
 
     await client.connect(transport);

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -62,7 +62,7 @@ type FastMCPSessionEvents = {
 };
 
 export const imageContent = async (
-  input: { buffer: Buffer } | { path: string } | { url: string }
+  input: { buffer: Buffer } | { path: string } | { url: string },
 ): Promise<ImageContent> => {
   let rawData: Buffer;
 
@@ -73,7 +73,7 @@ export const imageContent = async (
 
         if (!response.ok) {
           throw new Error(
-            `Server responded with status: ${response.status} - ${response.statusText}`
+            `Server responded with status: ${response.status} - ${response.statusText}`,
           );
         }
 
@@ -82,7 +82,7 @@ export const imageContent = async (
         throw new Error(
           `Failed to fetch image from URL (${input.url}): ${
             error instanceof Error ? error.message : String(error)
-          }`
+          }`,
         );
       }
     } else if ("path" in input) {
@@ -92,14 +92,14 @@ export const imageContent = async (
         throw new Error(
           `Failed to read image from path (${input.path}): ${
             error instanceof Error ? error.message : String(error)
-          }`
+          }`,
         );
       }
     } else if ("buffer" in input) {
       rawData = input.buffer;
     } else {
       throw new Error(
-        "Invalid input: Provide a valid 'url', 'path', or 'buffer'"
+        "Invalid input: Provide a valid 'url', 'path', or 'buffer'",
       );
     }
 
@@ -110,7 +110,7 @@ export const imageContent = async (
       console.warn(
         `Warning: Content may not be a valid image. Detected MIME: ${
           mimeType?.mime || "unknown"
-        }`
+        }`,
       );
     }
 
@@ -131,7 +131,7 @@ export const imageContent = async (
 };
 
 export const audioContent = async (
-  input: { buffer: Buffer } | { path: string } | { url: string }
+  input: { buffer: Buffer } | { path: string } | { url: string },
 ): Promise<AudioContent> => {
   let rawData: Buffer;
 
@@ -142,7 +142,7 @@ export const audioContent = async (
 
         if (!response.ok) {
           throw new Error(
-            `Server responded with status: ${response.status} - ${response.statusText}`
+            `Server responded with status: ${response.status} - ${response.statusText}`,
           );
         }
 
@@ -151,7 +151,7 @@ export const audioContent = async (
         throw new Error(
           `Failed to fetch audio from URL (${input.url}): ${
             error instanceof Error ? error.message : String(error)
-          }`
+          }`,
         );
       }
     } else if ("path" in input) {
@@ -161,14 +161,14 @@ export const audioContent = async (
         throw new Error(
           `Failed to read audio from path (${input.path}): ${
             error instanceof Error ? error.message : String(error)
-          }`
+          }`,
         );
       }
     } else if ("buffer" in input) {
       rawData = input.buffer;
     } else {
       throw new Error(
-        "Invalid input: Provide a valid 'url', 'path', or 'buffer'"
+        "Invalid input: Provide a valid 'url', 'path', or 'buffer'",
       );
     }
 
@@ -179,7 +179,7 @@ export const audioContent = async (
       console.warn(
         `Warning: Content may not be a valid audio file. Detected MIME: ${
           mimeType?.mime || "unknown"
-        }`
+        }`,
       );
     }
 
@@ -423,7 +423,7 @@ type InputResourceTemplate<
   description?: string;
   load: (
     args: ResourceTemplateArgumentsToObject<Arguments>,
-    auth?: T
+    auth?: T,
   ) => Promise<ResourceResult | ResourceResult[]>;
   mimeType?: string;
   name: string;
@@ -513,7 +513,7 @@ type ResourceTemplate<
   description?: string;
   load: (
     args: ResourceTemplateArgumentsToObject<Arguments>,
-    auth?: T
+    auth?: T,
   ) => Promise<ResourceResult | ResourceResult[]>;
   mimeType?: string;
   name: string;
@@ -830,7 +830,7 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
    */
   utils?: {
     formatInvalidParamsErrorMessage?: (
-      issues: readonly StandardSchemaV1.Issue[]
+      issues: readonly StandardSchemaV1.Issue[],
     ) => string;
   };
   version: `${number}.${number}.${number}`;
@@ -852,7 +852,7 @@ type Tool<
 
   execute: (
     args: StandardSchemaV1.InferOutput<Params>,
-    context: Context<T>
+    context: Context<T>,
   ) => Promise<
     | AudioContent
     | ContentResult
@@ -1015,7 +1015,7 @@ export class FastMCPSession<
 
     this.#server = new Server(
       { name: name, version: version },
-      { capabilities: this.#capabilities, instructions: instructions }
+      { capabilities: this.#capabilities, instructions: instructions },
     );
 
     this.#utils = utils;
@@ -1091,7 +1091,7 @@ export class FastMCPSession<
 
       if (!this.#clientCapabilities) {
         this.#logger.warn(
-          `[FastMCP warning] could not infer client capabilities after ${maxAttempts} attempts. Connection may be unstable.`
+          `[FastMCP warning] could not infer client capabilities after ${maxAttempts} attempts. Connection may be unstable.`,
         );
       }
 
@@ -1105,13 +1105,13 @@ export class FastMCPSession<
         } catch (e) {
           if (e instanceof McpError && e.code === ErrorCode.MethodNotFound) {
             this.#logger.debug(
-              "[FastMCP debug] listRoots method not supported by client"
+              "[FastMCP debug] listRoots method not supported by client",
             );
           } else {
             this.#logger.error(
               `[FastMCP error] received error listing roots.\n\n${
                 e instanceof Error ? e.stack : JSON.stringify(e)
-              }`
+              }`,
             );
           }
         }
@@ -1134,11 +1134,11 @@ export class FastMCPSession<
                 this.#logger.debug("[FastMCP debug] server ping failed");
               } else if (logLevel === "warning") {
                 this.#logger.warn(
-                  "[FastMCP warning] server is not responding to ping"
+                  "[FastMCP warning] server is not responding to ping",
                 );
               } else if (logLevel === "error") {
                 this.#logger.error(
-                  "[FastMCP error] server is not responding to ping"
+                  "[FastMCP error] server is not responding to ping",
                 );
               } else {
                 this.#logger.info("[FastMCP info] server ping failed");
@@ -1163,7 +1163,7 @@ export class FastMCPSession<
 
   public async requestSampling(
     message: z.infer<typeof CreateMessageRequestSchema>["params"],
-    options?: RequestOptions
+    options?: RequestOptions,
   ): Promise<SamplingResponse> {
     return this.#server.createMessage(message, options);
   }
@@ -1178,7 +1178,7 @@ export class FastMCPSession<
       this.#connectionState === "closed"
     ) {
       return Promise.reject(
-        new Error(`Connection is in ${this.#connectionState} state`)
+        new Error(`Connection is in ${this.#connectionState} state`),
       );
     }
 
@@ -1186,8 +1186,8 @@ export class FastMCPSession<
       const timeout = setTimeout(() => {
         reject(
           new Error(
-            "Connection timeout: Session failed to become ready within 5 seconds"
-          )
+            "Connection timeout: Session failed to become ready within 5 seconds",
+          ),
         );
       }, 5000);
 
@@ -1304,7 +1304,7 @@ export class FastMCPSession<
     this.#server.setRequestHandler(CompleteRequestSchema, async (request) => {
       if (request.params.ref.type === "ref/prompt") {
         const prompt = this.#prompts.find(
-          (prompt) => prompt.name === request.params.ref.name
+          (prompt) => prompt.name === request.params.ref.name,
         );
 
         if (!prompt) {
@@ -1323,8 +1323,8 @@ export class FastMCPSession<
           await prompt.complete(
             request.params.argument.name,
             request.params.argument.value,
-            this.#auth
-          )
+            this.#auth,
+          ),
         );
 
         return {
@@ -1334,7 +1334,7 @@ export class FastMCPSession<
 
       if (request.params.ref.type === "ref/resource") {
         const resource = this.#resourceTemplates.find(
-          (resource) => resource.uriTemplate === request.params.ref.uri
+          (resource) => resource.uriTemplate === request.params.ref.uri,
         );
 
         if (!resource) {
@@ -1352,7 +1352,7 @@ export class FastMCPSession<
             "Resource does not support completion",
             {
               request,
-            }
+            },
           );
         }
 
@@ -1360,8 +1360,8 @@ export class FastMCPSession<
           await resource.complete(
             request.params.argument.name,
             request.params.argument.value,
-            this.#auth
-          )
+            this.#auth,
+          ),
         );
 
         return {
@@ -1405,13 +1405,13 @@ export class FastMCPSession<
 
     this.#server.setRequestHandler(GetPromptRequestSchema, async (request) => {
       const prompt = prompts.find(
-        (prompt) => prompt.name === request.params.name
+        (prompt) => prompt.name === request.params.name,
       );
 
       if (!prompt) {
         throw new McpError(
           ErrorCode.MethodNotFound,
-          `Unknown prompt: ${request.params.name}`
+          `Unknown prompt: ${request.params.name}`,
         );
       }
 
@@ -1423,7 +1423,7 @@ export class FastMCPSession<
             ErrorCode.InvalidRequest,
             `Prompt '${request.params.name}' requires argument '${arg.name}': ${
               arg.description || "No description provided"
-            }`
+            }`,
           );
         }
       }
@@ -1433,14 +1433,14 @@ export class FastMCPSession<
       try {
         result = await prompt.load(
           args as Record<string, string | undefined>,
-          this.#auth
+          this.#auth,
         );
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         throw new McpError(
           ErrorCode.InternalError,
-          `Failed to load prompt '${request.params.name}': ${errorMessage}`
+          `Failed to load prompt '${request.params.name}': ${errorMessage}`,
         );
       }
 
@@ -1481,13 +1481,13 @@ export class FastMCPSession<
         if ("uri" in request.params) {
           const resource = resources.find(
             (resource) =>
-              "uri" in resource && resource.uri === request.params.uri
+              "uri" in resource && resource.uri === request.params.uri,
           );
 
           if (!resource) {
             for (const resourceTemplate of this.#resourceTemplates) {
               const uriTemplate = parseURITemplate(
-                resourceTemplate.uriTemplate
+                resourceTemplate.uriTemplate,
               );
 
               const match = uriTemplate.fromUri(request.params.uri);
@@ -1516,7 +1516,7 @@ export class FastMCPSession<
               ErrorCode.MethodNotFound,
               `Resource not found: '${request.params.uri}'. Available resources: ${
                 resources.map((r) => r.uri).join(", ") || "none"
-              }`
+              }`,
             );
           }
 
@@ -1536,7 +1536,7 @@ export class FastMCPSession<
               `Failed to load resource '${resource.name}' (${resource.uri}): ${errorMessage}`,
               {
                 uri: resource.uri,
-              }
+              },
             );
           }
 
@@ -1557,12 +1557,12 @@ export class FastMCPSession<
         throw new UnexpectedStateError("Unknown resource request", {
           request,
         });
-      }
+      },
     );
   }
 
   private setupResourceTemplateHandlers(
-    resourceTemplates: ResourceTemplate<T>[]
+    resourceTemplates: ResourceTemplate<T>[],
   ) {
     this.#server.setRequestHandler(
       ListResourceTemplatesRequestSchema,
@@ -1575,14 +1575,14 @@ export class FastMCPSession<
             uriTemplate: resourceTemplate.uriTemplate,
           })),
         } satisfies ListResourceTemplatesResult;
-      }
+      },
     );
   }
 
   private setupRootsHandlers() {
     if (this.#rootsConfig?.enabled === false) {
       this.#logger.debug(
-        "[FastMCP debug] roots capability explicitly disabled via config"
+        "[FastMCP debug] roots capability explicitly disabled via config",
       );
       return;
     }
@@ -1607,21 +1607,21 @@ export class FastMCPSession<
                 error.code === ErrorCode.MethodNotFound
               ) {
                 this.#logger.debug(
-                  "[FastMCP debug] listRoots method not supported by client"
+                  "[FastMCP debug] listRoots method not supported by client",
                 );
               } else {
                 this.#logger.error(
                   `[FastMCP error] received error listing roots.\n\n${
                     error instanceof Error ? error.stack : JSON.stringify(error)
-                  }`
+                  }`,
                 );
               }
             });
-        }
+        },
       );
     } else {
       this.#logger.debug(
-        "[FastMCP debug] roots capability not available, not setting up notification handler"
+        "[FastMCP debug] roots capability not available, not setting up notification handler",
       );
     }
   }
@@ -1643,7 +1643,7 @@ export class FastMCPSession<
                   }, // More complete schema for Cursor compatibility
               name: tool.name,
             };
-          })
+          }),
         ),
       };
     });
@@ -1654,7 +1654,7 @@ export class FastMCPSession<
       if (!tool) {
         throw new McpError(
           ErrorCode.MethodNotFound,
-          `Unknown tool: ${request.params.name}`
+          `Unknown tool: ${request.params.name}`,
         );
       }
 
@@ -1662,7 +1662,7 @@ export class FastMCPSession<
 
       if (tool.parameters) {
         const parsed = await tool.parameters["~standard"].validate(
-          request.params.arguments
+          request.params.arguments,
         );
 
         if (parsed.issues) {
@@ -1677,7 +1677,7 @@ export class FastMCPSession<
 
           throw new McpError(
             ErrorCode.InvalidParams,
-            `Tool '${request.params.name}' parameter validation failed: ${friendlyErrors}. Please check the parameter types and values according to the tool's schema.`
+            `Tool '${request.params.name}' parameter validation failed: ${friendlyErrors}. Please check the parameter types and values according to the tool's schema.`,
           );
         }
 
@@ -1707,7 +1707,7 @@ export class FastMCPSession<
               `[FastMCP warning] Failed to report progress for tool '${request.params.name}':`,
               progressError instanceof Error
                 ? progressError.message
-                : String(progressError)
+                : String(progressError),
             );
           }
         };
@@ -1774,7 +1774,7 @@ export class FastMCPSession<
               `[FastMCP warning] Failed to stream content for tool '${request.params.name}':`,
               streamError instanceof Error
                 ? streamError.message
-                : String(streamError)
+                : String(streamError),
             );
           }
         };
@@ -1794,8 +1794,8 @@ export class FastMCPSession<
                 const timeoutId = setTimeout(() => {
                   reject(
                     new UserError(
-                      `Tool '${request.params.name}' timed out after ${tool.timeoutMs}ms. Consider increasing timeoutMs or optimizing the tool implementation.`
-                    )
+                      `Tool '${request.params.name}' timed out after ${tool.timeoutMs}ms. Consider increasing timeoutMs or optimizing the tool implementation.`,
+                    ),
                   );
                 }, tool.timeoutMs);
 
@@ -1870,7 +1870,7 @@ function camelToSnakeCase(str: string): string {
  * Converts an object with camelCase keys to snake_case keys
  */
 function convertObjectToSnakeCase(
-  obj: Record<string, unknown>
+  obj: Record<string, unknown>,
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
@@ -1917,7 +1917,7 @@ export class FastMCP<
    * Adds a prompt to the server.
    */
   public addPrompt<const Args extends InputPromptArgument<T>[]>(
-    prompt: InputPrompt<T, Args>
+    prompt: InputPrompt<T, Args>,
   ) {
     this.#prompts.push(prompt);
   }
@@ -1954,7 +1954,7 @@ export class FastMCP<
   public async embedded(uri: string): Promise<ResourceContent["resource"]> {
     // First, try to find a direct resource match
     const directResource = this.#resources.find(
-      (resource) => resource.uri === uri
+      (resource) => resource.uri === uri,
     );
 
     if (directResource) {
@@ -2002,7 +2002,9 @@ export class FastMCP<
         }
 
         const result = await template.load(
-          params as ResourceTemplateArgumentsToObject<typeof template.arguments>
+          params as ResourceTemplateArgumentsToObject<
+            typeof template.arguments
+          >,
         );
 
         const resourceData: ResourceContent["resource"] = {
@@ -2039,7 +2041,7 @@ export class FastMCP<
         stateless?: boolean;
       };
       transportType: "httpStream" | "stdio";
-    }>
+    }>,
   ) {
     const config = this.#parseRuntimeConfig(options);
 
@@ -2093,7 +2095,7 @@ export class FastMCP<
       if (httpConfig.stateless) {
         // Stateless mode - create new server instance for each request
         this.#logger.info(
-          `[FastMCP info] Starting server in stateless mode on HTTP Stream at http://${httpConfig.host}:${httpConfig.port}${httpConfig.endpoint}`
+          `[FastMCP info] Starting server in stateless mode on HTTP Stream at http://${httpConfig.host}:${httpConfig.port}${httpConfig.endpoint}`,
         );
 
         this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
@@ -2118,7 +2120,7 @@ export class FastMCP<
           onConnect: async () => {
             // No persistent session tracking in stateless mode
             this.#logger.debug(
-              `[FastMCP debug] Stateless HTTP Stream request handled`
+              `[FastMCP debug] Stateless HTTP Stream request handled`,
             );
           },
           onUnhandledRequest: async (req, res) => {
@@ -2163,7 +2165,7 @@ export class FastMCP<
               req,
               res,
               false,
-              httpConfig.host
+              httpConfig.host,
             );
           },
           port: httpConfig.port,
@@ -2171,10 +2173,10 @@ export class FastMCP<
         });
 
         this.#logger.info(
-          `[FastMCP info] server is running on HTTP Stream at http://${httpConfig.host}:${httpConfig.port}${httpConfig.endpoint}`
+          `[FastMCP info] server is running on HTTP Stream at http://${httpConfig.host}:${httpConfig.port}${httpConfig.endpoint}`,
         );
         this.#logger.info(
-          `[FastMCP info] Transport type: httpStream (Streamable HTTP, not SSE)`
+          `[FastMCP info] Transport type: httpStream (Streamable HTTP, not SSE)`,
         );
       }
     } else {
@@ -2198,7 +2200,7 @@ export class FastMCP<
   #createSession(auth?: T): FastMCPSession<T> {
     const allowedTools = auth
       ? this.#tools.filter((tool) =>
-          tool.canAccess ? tool.canAccess(auth) : true
+          tool.canAccess ? tool.canAccess(auth) : true,
         )
       : this.#tools;
     return new FastMCPSession<T>({
@@ -2224,7 +2226,7 @@ export class FastMCP<
     req: http.IncomingMessage,
     res: http.ServerResponse,
     isStateless = false,
-    host: string
+    host: string,
   ) => {
     const healthConfig = this.#options.health ?? {};
 
@@ -2264,7 +2266,7 @@ export class FastMCP<
               .end(JSON.stringify(response));
           } else {
             const readySessions = this.#sessions.filter(
-              (s) => s.isReady
+              (s) => s.isReady,
             ).length;
             const totalSessions = this.#sessions.length;
             const allReady =
@@ -2304,7 +2306,7 @@ export class FastMCP<
         oauthConfig.authorizationServer
       ) {
         const metadata = convertObjectToSnakeCase(
-          oauthConfig.authorizationServer
+          oauthConfig.authorizationServer,
         );
         res
           .writeHead(200, {
@@ -2319,7 +2321,7 @@ export class FastMCP<
         oauthConfig.protectedResource
       ) {
         const metadata = convertObjectToSnakeCase(
-          oauthConfig.protectedResource
+          oauthConfig.protectedResource,
         );
         res
           .writeHead(200, {
@@ -2343,7 +2345,7 @@ export class FastMCP<
         stateless?: boolean;
       };
       transportType: "httpStream" | "stdio";
-    }>
+    }>,
   ):
     | {
         httpStream: {
@@ -2386,7 +2388,7 @@ export class FastMCP<
 
     if (transportType === "httpStream") {
       const port = parseInt(
-        overrides?.httpStream?.port?.toString() || portArg || envPort || "8080"
+        overrides?.httpStream?.port?.toString() || portArg || envPort || "8080",
       );
       const host =
         overrides?.httpStream?.host || hostArg || envHost || "localhost";

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -62,7 +62,7 @@ type FastMCPSessionEvents = {
 };
 
 export const imageContent = async (
-  input: { buffer: Buffer } | { path: string } | { url: string },
+  input: { buffer: Buffer } | { path: string } | { url: string }
 ): Promise<ImageContent> => {
   let rawData: Buffer;
 
@@ -73,7 +73,7 @@ export const imageContent = async (
 
         if (!response.ok) {
           throw new Error(
-            `Server responded with status: ${response.status} - ${response.statusText}`,
+            `Server responded with status: ${response.status} - ${response.statusText}`
           );
         }
 
@@ -82,7 +82,7 @@ export const imageContent = async (
         throw new Error(
           `Failed to fetch image from URL (${input.url}): ${
             error instanceof Error ? error.message : String(error)
-          }`,
+          }`
         );
       }
     } else if ("path" in input) {
@@ -92,14 +92,14 @@ export const imageContent = async (
         throw new Error(
           `Failed to read image from path (${input.path}): ${
             error instanceof Error ? error.message : String(error)
-          }`,
+          }`
         );
       }
     } else if ("buffer" in input) {
       rawData = input.buffer;
     } else {
       throw new Error(
-        "Invalid input: Provide a valid 'url', 'path', or 'buffer'",
+        "Invalid input: Provide a valid 'url', 'path', or 'buffer'"
       );
     }
 
@@ -110,7 +110,7 @@ export const imageContent = async (
       console.warn(
         `Warning: Content may not be a valid image. Detected MIME: ${
           mimeType?.mime || "unknown"
-        }`,
+        }`
       );
     }
 
@@ -131,7 +131,7 @@ export const imageContent = async (
 };
 
 export const audioContent = async (
-  input: { buffer: Buffer } | { path: string } | { url: string },
+  input: { buffer: Buffer } | { path: string } | { url: string }
 ): Promise<AudioContent> => {
   let rawData: Buffer;
 
@@ -142,7 +142,7 @@ export const audioContent = async (
 
         if (!response.ok) {
           throw new Error(
-            `Server responded with status: ${response.status} - ${response.statusText}`,
+            `Server responded with status: ${response.status} - ${response.statusText}`
           );
         }
 
@@ -151,7 +151,7 @@ export const audioContent = async (
         throw new Error(
           `Failed to fetch audio from URL (${input.url}): ${
             error instanceof Error ? error.message : String(error)
-          }`,
+          }`
         );
       }
     } else if ("path" in input) {
@@ -161,14 +161,14 @@ export const audioContent = async (
         throw new Error(
           `Failed to read audio from path (${input.path}): ${
             error instanceof Error ? error.message : String(error)
-          }`,
+          }`
         );
       }
     } else if ("buffer" in input) {
       rawData = input.buffer;
     } else {
       throw new Error(
-        "Invalid input: Provide a valid 'url', 'path', or 'buffer'",
+        "Invalid input: Provide a valid 'url', 'path', or 'buffer'"
       );
     }
 
@@ -179,7 +179,7 @@ export const audioContent = async (
       console.warn(
         `Warning: Content may not be a valid audio file. Detected MIME: ${
           mimeType?.mime || "unknown"
-        }`,
+        }`
       );
     }
 
@@ -423,7 +423,7 @@ type InputResourceTemplate<
   description?: string;
   load: (
     args: ResourceTemplateArgumentsToObject<Arguments>,
-    auth?: T,
+    auth?: T
   ) => Promise<ResourceResult | ResourceResult[]>;
   mimeType?: string;
   name: string;
@@ -513,7 +513,7 @@ type ResourceTemplate<
   description?: string;
   load: (
     args: ResourceTemplateArgumentsToObject<Arguments>,
-    auth?: T,
+    auth?: T
   ) => Promise<ResourceResult | ResourceResult[]>;
   mimeType?: string;
   name: string;
@@ -830,7 +830,7 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
    */
   utils?: {
     formatInvalidParamsErrorMessage?: (
-      issues: readonly StandardSchemaV1.Issue[],
+      issues: readonly StandardSchemaV1.Issue[]
     ) => string;
   };
   version: `${number}.${number}.${number}`;
@@ -852,7 +852,7 @@ type Tool<
 
   execute: (
     args: StandardSchemaV1.InferOutput<Params>,
-    context: Context<T>,
+    context: Context<T>
   ) => Promise<
     | AudioContent
     | ContentResult
@@ -1015,7 +1015,7 @@ export class FastMCPSession<
 
     this.#server = new Server(
       { name: name, version: version },
-      { capabilities: this.#capabilities, instructions: instructions },
+      { capabilities: this.#capabilities, instructions: instructions }
     );
 
     this.#utils = utils;
@@ -1091,7 +1091,7 @@ export class FastMCPSession<
 
       if (!this.#clientCapabilities) {
         this.#logger.warn(
-          `[FastMCP warning] could not infer client capabilities after ${maxAttempts} attempts. Connection may be unstable.`,
+          `[FastMCP warning] could not infer client capabilities after ${maxAttempts} attempts. Connection may be unstable.`
         );
       }
 
@@ -1105,13 +1105,13 @@ export class FastMCPSession<
         } catch (e) {
           if (e instanceof McpError && e.code === ErrorCode.MethodNotFound) {
             this.#logger.debug(
-              "[FastMCP debug] listRoots method not supported by client",
+              "[FastMCP debug] listRoots method not supported by client"
             );
           } else {
             this.#logger.error(
               `[FastMCP error] received error listing roots.\n\n${
                 e instanceof Error ? e.stack : JSON.stringify(e)
-              }`,
+              }`
             );
           }
         }
@@ -1134,11 +1134,11 @@ export class FastMCPSession<
                 this.#logger.debug("[FastMCP debug] server ping failed");
               } else if (logLevel === "warning") {
                 this.#logger.warn(
-                  "[FastMCP warning] server is not responding to ping",
+                  "[FastMCP warning] server is not responding to ping"
                 );
               } else if (logLevel === "error") {
                 this.#logger.error(
-                  "[FastMCP error] server is not responding to ping",
+                  "[FastMCP error] server is not responding to ping"
                 );
               } else {
                 this.#logger.info("[FastMCP info] server ping failed");
@@ -1163,7 +1163,7 @@ export class FastMCPSession<
 
   public async requestSampling(
     message: z.infer<typeof CreateMessageRequestSchema>["params"],
-    options?: RequestOptions,
+    options?: RequestOptions
   ): Promise<SamplingResponse> {
     return this.#server.createMessage(message, options);
   }
@@ -1178,7 +1178,7 @@ export class FastMCPSession<
       this.#connectionState === "closed"
     ) {
       return Promise.reject(
-        new Error(`Connection is in ${this.#connectionState} state`),
+        new Error(`Connection is in ${this.#connectionState} state`)
       );
     }
 
@@ -1186,8 +1186,8 @@ export class FastMCPSession<
       const timeout = setTimeout(() => {
         reject(
           new Error(
-            "Connection timeout: Session failed to become ready within 5 seconds",
-          ),
+            "Connection timeout: Session failed to become ready within 5 seconds"
+          )
         );
       }, 5000);
 
@@ -1304,7 +1304,7 @@ export class FastMCPSession<
     this.#server.setRequestHandler(CompleteRequestSchema, async (request) => {
       if (request.params.ref.type === "ref/prompt") {
         const prompt = this.#prompts.find(
-          (prompt) => prompt.name === request.params.ref.name,
+          (prompt) => prompt.name === request.params.ref.name
         );
 
         if (!prompt) {
@@ -1323,8 +1323,8 @@ export class FastMCPSession<
           await prompt.complete(
             request.params.argument.name,
             request.params.argument.value,
-            this.#auth,
-          ),
+            this.#auth
+          )
         );
 
         return {
@@ -1334,7 +1334,7 @@ export class FastMCPSession<
 
       if (request.params.ref.type === "ref/resource") {
         const resource = this.#resourceTemplates.find(
-          (resource) => resource.uriTemplate === request.params.ref.uri,
+          (resource) => resource.uriTemplate === request.params.ref.uri
         );
 
         if (!resource) {
@@ -1352,7 +1352,7 @@ export class FastMCPSession<
             "Resource does not support completion",
             {
               request,
-            },
+            }
           );
         }
 
@@ -1360,8 +1360,8 @@ export class FastMCPSession<
           await resource.complete(
             request.params.argument.name,
             request.params.argument.value,
-            this.#auth,
-          ),
+            this.#auth
+          )
         );
 
         return {
@@ -1405,13 +1405,13 @@ export class FastMCPSession<
 
     this.#server.setRequestHandler(GetPromptRequestSchema, async (request) => {
       const prompt = prompts.find(
-        (prompt) => prompt.name === request.params.name,
+        (prompt) => prompt.name === request.params.name
       );
 
       if (!prompt) {
         throw new McpError(
           ErrorCode.MethodNotFound,
-          `Unknown prompt: ${request.params.name}`,
+          `Unknown prompt: ${request.params.name}`
         );
       }
 
@@ -1423,7 +1423,7 @@ export class FastMCPSession<
             ErrorCode.InvalidRequest,
             `Prompt '${request.params.name}' requires argument '${arg.name}': ${
               arg.description || "No description provided"
-            }`,
+            }`
           );
         }
       }
@@ -1433,14 +1433,14 @@ export class FastMCPSession<
       try {
         result = await prompt.load(
           args as Record<string, string | undefined>,
-          this.#auth,
+          this.#auth
         );
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         throw new McpError(
           ErrorCode.InternalError,
-          `Failed to load prompt '${request.params.name}': ${errorMessage}`,
+          `Failed to load prompt '${request.params.name}': ${errorMessage}`
         );
       }
 
@@ -1481,13 +1481,13 @@ export class FastMCPSession<
         if ("uri" in request.params) {
           const resource = resources.find(
             (resource) =>
-              "uri" in resource && resource.uri === request.params.uri,
+              "uri" in resource && resource.uri === request.params.uri
           );
 
           if (!resource) {
             for (const resourceTemplate of this.#resourceTemplates) {
               const uriTemplate = parseURITemplate(
-                resourceTemplate.uriTemplate,
+                resourceTemplate.uriTemplate
               );
 
               const match = uriTemplate.fromUri(request.params.uri);
@@ -1516,7 +1516,7 @@ export class FastMCPSession<
               ErrorCode.MethodNotFound,
               `Resource not found: '${request.params.uri}'. Available resources: ${
                 resources.map((r) => r.uri).join(", ") || "none"
-              }`,
+              }`
             );
           }
 
@@ -1536,7 +1536,7 @@ export class FastMCPSession<
               `Failed to load resource '${resource.name}' (${resource.uri}): ${errorMessage}`,
               {
                 uri: resource.uri,
-              },
+              }
             );
           }
 
@@ -1557,12 +1557,12 @@ export class FastMCPSession<
         throw new UnexpectedStateError("Unknown resource request", {
           request,
         });
-      },
+      }
     );
   }
 
   private setupResourceTemplateHandlers(
-    resourceTemplates: ResourceTemplate<T>[],
+    resourceTemplates: ResourceTemplate<T>[]
   ) {
     this.#server.setRequestHandler(
       ListResourceTemplatesRequestSchema,
@@ -1575,14 +1575,14 @@ export class FastMCPSession<
             uriTemplate: resourceTemplate.uriTemplate,
           })),
         } satisfies ListResourceTemplatesResult;
-      },
+      }
     );
   }
 
   private setupRootsHandlers() {
     if (this.#rootsConfig?.enabled === false) {
       this.#logger.debug(
-        "[FastMCP debug] roots capability explicitly disabled via config",
+        "[FastMCP debug] roots capability explicitly disabled via config"
       );
       return;
     }
@@ -1607,21 +1607,21 @@ export class FastMCPSession<
                 error.code === ErrorCode.MethodNotFound
               ) {
                 this.#logger.debug(
-                  "[FastMCP debug] listRoots method not supported by client",
+                  "[FastMCP debug] listRoots method not supported by client"
                 );
               } else {
                 this.#logger.error(
                   `[FastMCP error] received error listing roots.\n\n${
                     error instanceof Error ? error.stack : JSON.stringify(error)
-                  }`,
+                  }`
                 );
               }
             });
-        },
+        }
       );
     } else {
       this.#logger.debug(
-        "[FastMCP debug] roots capability not available, not setting up notification handler",
+        "[FastMCP debug] roots capability not available, not setting up notification handler"
       );
     }
   }
@@ -1643,7 +1643,7 @@ export class FastMCPSession<
                   }, // More complete schema for Cursor compatibility
               name: tool.name,
             };
-          }),
+          })
         ),
       };
     });
@@ -1654,7 +1654,7 @@ export class FastMCPSession<
       if (!tool) {
         throw new McpError(
           ErrorCode.MethodNotFound,
-          `Unknown tool: ${request.params.name}`,
+          `Unknown tool: ${request.params.name}`
         );
       }
 
@@ -1662,7 +1662,7 @@ export class FastMCPSession<
 
       if (tool.parameters) {
         const parsed = await tool.parameters["~standard"].validate(
-          request.params.arguments,
+          request.params.arguments
         );
 
         if (parsed.issues) {
@@ -1677,7 +1677,7 @@ export class FastMCPSession<
 
           throw new McpError(
             ErrorCode.InvalidParams,
-            `Tool '${request.params.name}' parameter validation failed: ${friendlyErrors}. Please check the parameter types and values according to the tool's schema.`,
+            `Tool '${request.params.name}' parameter validation failed: ${friendlyErrors}. Please check the parameter types and values according to the tool's schema.`
           );
         }
 
@@ -1707,7 +1707,7 @@ export class FastMCPSession<
               `[FastMCP warning] Failed to report progress for tool '${request.params.name}':`,
               progressError instanceof Error
                 ? progressError.message
-                : String(progressError),
+                : String(progressError)
             );
           }
         };
@@ -1774,7 +1774,7 @@ export class FastMCPSession<
               `[FastMCP warning] Failed to stream content for tool '${request.params.name}':`,
               streamError instanceof Error
                 ? streamError.message
-                : String(streamError),
+                : String(streamError)
             );
           }
         };
@@ -1794,8 +1794,8 @@ export class FastMCPSession<
                 const timeoutId = setTimeout(() => {
                   reject(
                     new UserError(
-                      `Tool '${request.params.name}' timed out after ${tool.timeoutMs}ms. Consider increasing timeoutMs or optimizing the tool implementation.`,
-                    ),
+                      `Tool '${request.params.name}' timed out after ${tool.timeoutMs}ms. Consider increasing timeoutMs or optimizing the tool implementation.`
+                    )
                   );
                 }, tool.timeoutMs);
 
@@ -1870,7 +1870,7 @@ function camelToSnakeCase(str: string): string {
  * Converts an object with camelCase keys to snake_case keys
  */
 function convertObjectToSnakeCase(
-  obj: Record<string, unknown>,
+  obj: Record<string, unknown>
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
@@ -1917,7 +1917,7 @@ export class FastMCP<
    * Adds a prompt to the server.
    */
   public addPrompt<const Args extends InputPromptArgument<T>[]>(
-    prompt: InputPrompt<T, Args>,
+    prompt: InputPrompt<T, Args>
   ) {
     this.#prompts.push(prompt);
   }
@@ -1954,7 +1954,7 @@ export class FastMCP<
   public async embedded(uri: string): Promise<ResourceContent["resource"]> {
     // First, try to find a direct resource match
     const directResource = this.#resources.find(
-      (resource) => resource.uri === uri,
+      (resource) => resource.uri === uri
     );
 
     if (directResource) {
@@ -2002,9 +2002,7 @@ export class FastMCP<
         }
 
         const result = await template.load(
-          params as ResourceTemplateArgumentsToObject<
-            typeof template.arguments
-          >,
+          params as ResourceTemplateArgumentsToObject<typeof template.arguments>
         );
 
         const resourceData: ResourceContent["resource"] = {
@@ -2036,11 +2034,12 @@ export class FastMCP<
         enableJsonResponse?: boolean;
         endpoint?: `/${string}`;
         eventStore?: EventStore;
+        host?: string;
         port: number;
         stateless?: boolean;
       };
       transportType: "httpStream" | "stdio";
-    }>,
+    }>
   ) {
     const config = this.#parseRuntimeConfig(options);
 
@@ -2094,7 +2093,7 @@ export class FastMCP<
       if (httpConfig.stateless) {
         // Stateless mode - create new server instance for each request
         this.#logger.info(
-          `[FastMCP info] Starting server in stateless mode on HTTP Stream at http://localhost:${httpConfig.port}${httpConfig.endpoint}`,
+          `[FastMCP info] Starting server in stateless mode on HTTP Stream at http://${httpConfig.host}:${httpConfig.port}${httpConfig.endpoint}`
         );
 
         this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
@@ -2111,6 +2110,7 @@ export class FastMCP<
           },
           enableJsonResponse: httpConfig.enableJsonResponse,
           eventStore: httpConfig.eventStore,
+          host: httpConfig.host,
           // In stateless mode, we don't track sessions
           onClose: async () => {
             // No session tracking in stateless mode
@@ -2118,11 +2118,11 @@ export class FastMCP<
           onConnect: async () => {
             // No persistent session tracking in stateless mode
             this.#logger.debug(
-              `[FastMCP debug] Stateless HTTP Stream request handled`,
+              `[FastMCP debug] Stateless HTTP Stream request handled`
             );
           },
           onUnhandledRequest: async (req, res) => {
-            await this.#handleUnhandledRequest(req, res, true);
+            await this.#handleUnhandledRequest(req, res, true, httpConfig.host);
           },
           port: httpConfig.port,
           stateless: true,
@@ -2142,6 +2142,7 @@ export class FastMCP<
           },
           enableJsonResponse: httpConfig.enableJsonResponse,
           eventStore: httpConfig.eventStore,
+          host: httpConfig.host,
           onClose: async (session) => {
             this.emit("disconnect", {
               session: session as FastMCPSession<FastMCPSessionAuth>,
@@ -2158,17 +2159,22 @@ export class FastMCP<
           },
 
           onUnhandledRequest: async (req, res) => {
-            await this.#handleUnhandledRequest(req, res, false);
+            await this.#handleUnhandledRequest(
+              req,
+              res,
+              false,
+              httpConfig.host
+            );
           },
           port: httpConfig.port,
           streamEndpoint: httpConfig.endpoint,
         });
 
         this.#logger.info(
-          `[FastMCP info] server is running on HTTP Stream at http://localhost:${httpConfig.port}${httpConfig.endpoint}`,
+          `[FastMCP info] server is running on HTTP Stream at http://${httpConfig.host}:${httpConfig.port}${httpConfig.endpoint}`
         );
         this.#logger.info(
-          `[FastMCP info] Transport type: httpStream (Streamable HTTP, not SSE)`,
+          `[FastMCP info] Transport type: httpStream (Streamable HTTP, not SSE)`
         );
       }
     } else {
@@ -2192,7 +2198,7 @@ export class FastMCP<
   #createSession(auth?: T): FastMCPSession<T> {
     const allowedTools = auth
       ? this.#tools.filter((tool) =>
-          tool.canAccess ? tool.canAccess(auth) : true,
+          tool.canAccess ? tool.canAccess(auth) : true
         )
       : this.#tools;
     return new FastMCPSession<T>({
@@ -2218,6 +2224,7 @@ export class FastMCP<
     req: http.IncomingMessage,
     res: http.ServerResponse,
     isStateless = false,
+    host: string
   ) => {
     const healthConfig = this.#options.health ?? {};
 
@@ -2226,7 +2233,7 @@ export class FastMCP<
 
     if (enabled) {
       const path = healthConfig.path ?? "/health";
-      const url = new URL(req.url || "", "http://localhost");
+      const url = new URL(req.url || "", `http://${host}`);
 
       try {
         if (req.method === "GET" && url.pathname === path) {
@@ -2257,7 +2264,7 @@ export class FastMCP<
               .end(JSON.stringify(response));
           } else {
             const readySessions = this.#sessions.filter(
-              (s) => s.isReady,
+              (s) => s.isReady
             ).length;
             const totalSessions = this.#sessions.length;
             const allReady =
@@ -2290,14 +2297,14 @@ export class FastMCP<
     // Handle OAuth well-known endpoints
     const oauthConfig = this.#options.oauth;
     if (oauthConfig?.enabled && req.method === "GET") {
-      const url = new URL(req.url || "", "http://localhost");
+      const url = new URL(req.url || "", `http://${host}`);
 
       if (
         url.pathname === "/.well-known/oauth-authorization-server" &&
         oauthConfig.authorizationServer
       ) {
         const metadata = convertObjectToSnakeCase(
-          oauthConfig.authorizationServer,
+          oauthConfig.authorizationServer
         );
         res
           .writeHead(200, {
@@ -2312,7 +2319,7 @@ export class FastMCP<
         oauthConfig.protectedResource
       ) {
         const metadata = convertObjectToSnakeCase(
-          oauthConfig.protectedResource,
+          oauthConfig.protectedResource
         );
         res
           .writeHead(200, {
@@ -2331,17 +2338,19 @@ export class FastMCP<
       httpStream: {
         enableJsonResponse?: boolean;
         endpoint?: `/${string}`;
+        host?: string;
         port: number;
         stateless?: boolean;
       };
       transportType: "httpStream" | "stdio";
-    }>,
+    }>
   ):
     | {
         httpStream: {
           enableJsonResponse?: boolean;
           endpoint: `/${string}`;
           eventStore?: EventStore;
+          host: string;
           port: number;
           stateless?: boolean;
         };
@@ -2361,12 +2370,13 @@ export class FastMCP<
     const portArg = getArg("port");
     const endpointArg = getArg("endpoint");
     const statelessArg = getArg("stateless");
+    const hostArg = getArg("host");
 
     const envTransport = process.env.FASTMCP_TRANSPORT;
     const envPort = process.env.FASTMCP_PORT;
     const envEndpoint = process.env.FASTMCP_ENDPOINT;
     const envStateless = process.env.FASTMCP_STATELESS;
-
+    const envHost = process.env.FASTMCP_HOST;
     // Overrides > CLI > env > defaults
     const transportType =
       overrides?.transportType ||
@@ -2376,8 +2386,10 @@ export class FastMCP<
 
     if (transportType === "httpStream") {
       const port = parseInt(
-        overrides?.httpStream?.port?.toString() || portArg || envPort || "8080",
+        overrides?.httpStream?.port?.toString() || portArg || envPort || "8080"
       );
+      const host =
+        overrides?.httpStream?.host || hostArg || envHost || "localhost";
       const endpoint =
         overrides?.httpStream?.endpoint || endpointArg || envEndpoint || "/mcp";
       const enableJsonResponse =
@@ -2392,6 +2404,7 @@ export class FastMCP<
         httpStream: {
           enableJsonResponse,
           endpoint: endpoint as `/${string}`,
+          host,
           port,
           stateless,
         },


### PR DESCRIPTION
This PR allows users to host their applications on a custom path. This was a simple plumbing exercise, as `startHTTPServer` accepts a host parameter.

A unit test was added to test this, and I have used it in multiple projects.