### PR TITLE
fix: missing instructions for all transports

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2232,6 +2232,7 @@ export class FastMCP<
       auth,
       logger: this.#logger,
       name: this.#options.name,
+      instructions: this.#options.instructions,
       ping: this.#options.ping,
       prompts: this.#prompts,
       resources: this.#resources,

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2230,9 +2230,9 @@ export class FastMCP<
       : this.#tools;
     return new FastMCPSession<T>({
       auth,
+      instructions: this.#options.instructions,
       logger: this.#logger,
       name: this.#options.name,
-      instructions: this.#options.instructions,
       ping: this.#options.ping,
       prompts: this.#prompts,
       resources: this.#resources,


### PR DESCRIPTION
This PR is a follow-up to https://github.com/punkpeye/fastmcp/pull/39