### PR TITLE
feat: expose client details within tool execution (#171)

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -2121,6 +2121,7 @@ test("provides auth to tools", async () => {
       b: 2,
     },
     {
+      client: expect.any(Object),
       log: {
         debug: expect.any(Function),
         error: expect.any(Function),
@@ -2128,7 +2129,6 @@ test("provides auth to tools", async () => {
         warn: expect.any(Function),
       },
       reportProgress: expect.any(Function),
-      server: expect.any(Object),
       session: { id: 1 },
       streamContent: expect.any(Function),
     },
@@ -3289,7 +3289,7 @@ test("tools can access client info", async () => {
       server.addTool({
         description: "Get client information",
         execute: async (_args, context) => {
-          const clientInfo = context.server.getClientVersion();
+          const clientInfo = context.client.version;
           return `Client name: ${clientInfo?.name || "unknown"}\nClient version: ${clientInfo?.version || "unknown"}`;
         },
         name: "get-client-info",

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -200,6 +200,9 @@ export const audioContent = async (
 };
 
 type Context<T extends FastMCPSessionAuth> = {
+  client: {
+    version: ReturnType<Server["getClientVersion"]>;
+  };
   log: {
     debug: (message: string, data?: SerializableValue) => void;
     error: (message: string, data?: SerializableValue) => void;
@@ -207,7 +210,6 @@ type Context<T extends FastMCPSessionAuth> = {
     warn: (message: string, data?: SerializableValue) => void;
   };
   reportProgress: (progress: Progress) => Promise<void>;
-  server: Pick<Server, "getClientVersion">;
   session: T | undefined;
   streamContent: (content: Content | Content[]) => Promise<void>;
 };
@@ -1781,11 +1783,11 @@ export class FastMCPSession<
         };
 
         const executeToolPromise = tool.execute(args, {
+          client: {
+            version: this.#server.getClientVersion(),
+          },
           log,
           reportProgress,
-          server: {
-            getClientVersion: () => this.#server.getClientVersion(),
-          },
           session: this.#auth,
           streamContent,
         });


### PR DESCRIPTION
I felt exposing `clientVersion` is too narrow, and exposing the entire `server` is too wide. I opted to expose the server and pick just `getClientVersion` off it, you could expose other members later on if you'd like.