### PR TITLE
fix: missing roots enabled check during connect

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1099,6 +1099,7 @@ export class FastMCPSession<
       }
 
       if (
+        this.#rootsConfig?.enabled === false &&
         this.#clientCapabilities?.roots?.listChanged &&
         typeof this.#server.listRoots === "function"
       ) {


### PR DESCRIPTION
# Disabling roots support only works partially

When disabling the roots support it only disables [one case](https://github.com/punkpeye/fastmcp/blob/2180eeda1d64edb6b5171f0ec14a5f66d98aed2c/src/FastMCP.ts#L1115).
There is a [second case](https://github.com/punkpeye/fastmcp/blob/2180eeda1d64edb6b5171f0ec14a5f66d98aed2c/src/FastMCP.ts#L1617), which is not guarded by the config setting.

This PR adds the check, if root support is enabled for the second case.