### PR TITLE
feat: Add MCP 2025-11-25 compliant PRM sub-path discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1454,7 +1454,18 @@ const server = new FastMCP({
 This configuration automatically exposes OAuth discovery endpoints:
 
 - `/.well-known/oauth-authorization-server` - Authorization server metadata (RFC 8414)
-- `/.well-known/oauth-protected-resource` - Protected resource metadata (RFC 9470)
+- `/.well-known/oauth-protected-resource` - Protected resource metadata (RFC 9728)
+- `/.well-known/oauth-protected-resource<endpoint>` - Protected resource metadata at sub-path (MCP 2025-11-25)
+
+**Discovery Mechanism (MCP Specification 2025-11-25):**
+
+Clients discover protected resource metadata using the following search order:
+
+1. **WWW-Authenticate header** - Primary method (handled automatically by mcp-proxy)
+2. **Sub-path well-known** - `/.well-known/oauth-protected-resource<endpoint>` (e.g., `/.well-known/oauth-protected-resource/mcp`)
+3. **Root well-known** - `/.well-known/oauth-protected-resource` (fallback)
+
+Both the sub-path and root endpoints return identical metadata, ensuring compatibility with all MCP client implementations.
 
 For JWT token validation, you can use libraries like [`get-jwks`](https://github.com/nearform/get-jwks) and [`@fastify/jwt`](https://github.com/fastify/fastify-jwt) for OAuth JWT tokens.
 

--- a/src/examples/oauth-server.ts
+++ b/src/examples/oauth-server.ts
@@ -78,12 +78,14 @@ server.addTool({
         {
           text: `This is an OAuth-enabled FastMCP server!
 
-OAuth Discovery Endpoints:
+OAuth Discovery Endpoints (MCP 2025-11-25):
 - Authorization Server: /.well-known/oauth-authorization-server
-- Protected Resource: /.well-known/oauth-protected-resource
+- Protected Resource (root): /.well-known/oauth-protected-resource
+- Protected Resource (sub-path): /.well-known/oauth-protected-resource/mcp
 
 The server demonstrates how to configure OAuth metadata for MCP servers
-that need to integrate with OAuth 2.0 authorization flows.`,
+that need to integrate with OAuth 2.0 authorization flows. Clients can
+discover metadata using either the root or sub-path endpoints.`,
           type: "text",
         },
       ],
@@ -105,9 +107,13 @@ Try these endpoints:
 - MCP (HTTP Stream): http://localhost:4111/mcp
 - MCP (SSE): http://localhost:4111/sse
 - Health: http://localhost:4111/health
-- OAuth Authorization Server: http://localhost:4111/.well-known/oauth-authorization-server
-- OAuth Protected Resource: http://localhost:4111/.well-known/oauth-protected-resource
+
+OAuth Discovery Endpoints (MCP Specification 2025-11-25):
+- Authorization Server: http://localhost:4111/.well-known/oauth-authorization-server
+- Protected Resource (root): http://localhost:4111/.well-known/oauth-protected-resource
+- Protected Resource (sub-path): http://localhost:4111/.well-known/oauth-protected-resource/mcp
 
 The OAuth endpoints work with both SSE and HTTP Stream transports and return
-JSON metadata following RFC 8414 standards.
+JSON metadata following RFC 8414 (Authorization Server) and RFC 9728 (Protected Resource).
+Both PRM endpoints return identical metadata for client compatibility.
 `);


### PR DESCRIPTION
Implements Protected Resource Metadata (PRM) endpoint discovery with sub-path support as specified in MCP Specification 2025-11-25.

Changes:
- Add sub-path PRM endpoint: /.well-known/oauth-protected-resource<endpoint>
- Maintain backward compatibility with root endpoint
- Update discovery mechanism to follow MCP spec search order:
  1. WWW-Authenticate header (handled by mcp-proxy)
  2. Sub-path well-known (e.g., /.well-known/oauth-protected-resource/mcp)
  3. Root well-known (/.well-known/oauth-protected-resource)

Implementation Details:
- Modified #handleUnhandledRequest to accept streamEndpoint parameter
- Both sub-path and root endpoints return identical RFC 9728 metadata
- Added comprehensive test coverage (3 new test cases)
- Updated documentation and examples

Test Results:
✅ All 7 OAuth discovery tests pass
✅ All 3 OAuth proxy tests pass
✅ Sub-path discovery with default endpoint (/mcp)
✅ Custom endpoint paths (/api/v1/mcp)
✅ 404 responses for non-matching paths

Fixes compliance with MCP Specification 2025-11-25 section on Protected Resource Metadata discovery fallback mechanism.

