### PR TITLE
fix: pass eventStore through parseRuntimeConfig

### DIFF
--- a/src/FastMCP.event-store.test.ts
+++ b/src/FastMCP.event-store.test.ts
@@ -1,0 +1,43 @@
+import type { EventStore } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+import { expect, test, vi } from "vitest";
+
+test("passes eventStore through to mcp-proxy", async () => {
+  vi.resetModules();
+
+  const startHTTPServerMock = vi.fn(async () => ({
+    close: async () => {},
+  }));
+
+  vi.doMock("mcp-proxy", () => ({
+    startHTTPServer: startHTTPServerMock,
+  }));
+
+  const { FastMCP } = await import("./FastMCP.js");
+
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  const eventStore = { id: "test-store" } as unknown as EventStore;
+
+  try {
+    await server.start({
+      httpStream: {
+        eventStore,
+        port: 0,
+      },
+      transportType: "httpStream",
+    });
+
+    expect(startHTTPServerMock).toHaveBeenCalledTimes(1);
+    expect(startHTTPServerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ eventStore }),
+    );
+  } finally {
+    await server.stop();
+    vi.unmock("mcp-proxy");
+    vi.resetModules();
+  }
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3054,6 +3054,7 @@ export class FastMCP<
       httpStream: {
         enableJsonResponse?: boolean;
         endpoint?: `/${string}`;
+        eventStore?: EventStore;
         host?: string;
         port: number;
         stateless?: boolean;
@@ -3115,11 +3116,13 @@ export class FastMCP<
         statelessArg === "true" ||
         envStateless === "true" ||
         false;
+      const eventStore = overrides?.httpStream?.eventStore;
 
       return {
         httpStream: {
           enableJsonResponse,
           endpoint: endpoint as `/${string}`,
+          eventStore,
           host,
           port,
           stateless,


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `eventStore` option passed to `FastMCP.start()` was silently ignored, making it impossible for users to inject a custom/bounded `EventStore` implementation.

---

## The Problem

### Production OOM Issue

When running FastMCP in production with HTTP streaming transport, the default `EventStore` from the MCP SDK is **unbounded**. This means:

1. Every streamed event is stored in memory indefinitely
2. Long-running servers accumulate events without limit
3. Eventually, the process crashes with an Out of Memory error

### The Root Cause

The `start()` method correctly accepts an `eventStore` option in its type signature:

```typescript
public async start(options?: Partial<{
  httpStream: {
    eventStore?: EventStore;  // <-- This exists
    // ...
  };
}>) {
  const config = this.#parseRuntimeConfig(options);
  // ...
}
```

**However**, the private `#parseRuntimeConfig()` method was **not extracting or returning** the `eventStore` from the overrides. It only returned:

```typescript
httpStream: { enableJsonResponse, endpoint, host, port, stateless }
// eventStore is MISSING!
```

This meant any `eventStore` passed by the user was silently dropped, and the downstream HTTP transport always received `undefined`, causing it to fall back to the unbounded in-memory store.

---

## The Fix

### Changes Made (3 lines)

1. **Added `eventStore` to the overrides type** (line ~3057):
   ```typescript
   eventStore?: EventStore;
   ```

2. **Extract `eventStore` from overrides** (line ~3119):
   ```typescript
   const eventStore = overrides?.httpStream?.eventStore;
   ```

3. **Include `eventStore` in the returned config** (line ~3125):
   ```typescript
   httpStream: {
     enableJsonResponse,
     endpoint: endpoint as `/${string}`,
     eventStore,  // <-- Now included
     host,
     port,
     stateless,
   }
   ```

---

## Why This Matters

### Before This Fix

```typescript
import { FastMCP } from "fastmcp";
import { InMemoryEventStore } from "@modelcontextprotocol/sdk/server/streamableHttp.js";

// Create a bounded event store (example: max 1000 events)
const boundedStore = new InMemoryEventStore({ maxEvents: 1000 });

const mcp = new FastMCP({ name: "my-server", version: "1.0.0" });

await mcp.start({
  httpStream: {
    port: 3000,
    eventStore: boundedStore,  // SILENTLY IGNORED!
  }
});

// Result: Uses unbounded store -> OOM in production
```

### After This Fix

```typescript
import { FastMCP } from "fastmcp";
import { InMemoryEventStore } from "@modelcontextprotocol/sdk/server/streamableHttp.js";

const boundedStore = new InMemoryEventStore({ maxEvents: 1000 });

const mcp = new FastMCP({ name: "my-server", version: "1.0.0" });

await mcp.start({
  httpStream: {
    port: 3000,
    eventStore: boundedStore,  // NOW WORKS!
  }
});

// Result: Uses bounded store -> stable memory usage
```

---

## Backward Compatibility

This change is **100% backward compatible**:

- **Default behavior unchanged**: If no `eventStore` is provided, the value is `undefined` and the downstream transport uses its default (same as before)
- **No breaking changes**: Existing code continues to work identically
- **Opt-in only**: Only users who explicitly pass an `eventStore` will see different behavior

---

## Testing

The existing infrastructure already passes `eventStore` to the underlying HTTP transport (see lines 2552 and 2606 in `FastMCP.ts`). The only missing piece was extracting it from the user's options in `#parseRuntimeConfig()`.

With this fix:
1. User passes `eventStore` to `start()`
2. `#parseRuntimeConfig()` now extracts and returns it
3. The HTTP transport receives and uses the custom store

---

## Related Files

| File | Change |
|------|--------|
| `src/FastMCP.ts` | Added `eventStore` passthrough in `#parseRuntimeConfig()` |

---

## Checklist

- [x] Minimal change (3 lines)
- [x] Follows existing code patterns
- [x] No new dependencies
- [x] Backward compatible
- [x] Fixes production OOM issue for users who need bounded event storage

---

## Thank You

Thanks for reviewing this fix, @punkpeye! This small change enables FastMCP users to control memory usage in production by injecting their own bounded `EventStore` implementations.
