### PR TITLE
Add Edge Runtime Support and Custom HTTP Routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
       "import": "./dist/auth/index.js",
       "types": "./dist/auth/index.d.ts",
       "require": "./dist/auth/index.cjs"
+    },
+    "./edge": {
+      "import": "./dist/edge/index.js",
+      "types": "./dist/edge/index.d.ts",
+      "require": "./dist/edge/index.cjs"
     }
   },
   "dependencies": {
@@ -39,6 +44,7 @@
     "execa": "^9.6.1",
     "file-type": "^21.1.1",
     "fuse.js": "^7.1.0",
+    "hono": "^4.11.5",
     "mcp-proxy": "^6.4.0",
     "strict-event-emitter-types": "^2.0.0",
     "undici": "^7.16.0",
@@ -106,7 +112,9 @@
     "entry": [
       "src/FastMCP.ts",
       "src/bin/fastmcp.ts",
-      "src/auth/index.ts"
+      "src/auth/index.ts",
+      "src/edge/index.ts",
+      "src/examples/custom-routes.ts"
     ],
     "format": [
       "esm",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       fuse.js:
         specifier: ^7.1.0
         version: 7.1.0
+      hono:
+        specifier: ^4.11.5
+        version: 4.11.6
       jose:
         specifier: ^5.0.0
         version: 5.10.0
@@ -2411,6 +2414,10 @@ packages:
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
+  hono@4.11.6:
+    resolution: {integrity: sha512-ofIiiHyl34SV6AuhE3YT2mhO5HRWokce+eUYE82TsP6z0/H3JeJcjVWEMSIAiw2QkjDOEpES/lYsg8eEbsLtdw==}
+    engines: {node: '>=16.9.0'}
 
   hook-std@4.0.0:
     resolution: {integrity: sha512-IHI4bEVOt3vRUDJ+bFA9VUJlo7SzvFARPNLw75pqSmAOP2HmTWfFJtPvLBrDrlgjEYXY9zs7SFdHPQaJShkSCQ==}
@@ -6351,6 +6358,8 @@ snapshots:
       function-bind: 1.1.2
 
   highlight.js@10.7.3: {}
+
+  hono@4.11.6: {}
 
   hook-std@4.0.0: {}
 

--- a/src/FastMCP.routes.test.ts
+++ b/src/FastMCP.routes.test.ts
@@ -1,0 +1,982 @@
+import type { Context } from "hono";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { getRandomPort } from "get-port-please";
+import { fetch } from "undici";
+import { expect, test } from "vitest";
+import { z } from "zod";
+
+import { FastMCP, FastMCPSession } from "./FastMCP.js";
+
+const runWithTestServer = async ({
+  run,
+  server: createServer,
+}: {
+  run: ({
+    client,
+    port,
+    server,
+    session,
+  }: {
+    client: Client;
+    port: number;
+    server: FastMCP;
+    session: FastMCPSession;
+  }) => Promise<void>;
+  server?: () => Promise<FastMCP>;
+}) => {
+  const port = await getRandomPort();
+
+  const server = createServer
+    ? await createServer()
+    : new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+  await server.start({
+    httpStream: {
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const client = new Client(
+      {
+        name: "test-client",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    const transport = new SSEClientTransport(
+      new URL(`http://localhost:${port}/sse`),
+    );
+
+    const session = await new Promise<FastMCPSession>((resolve) => {
+      server.on("connect", async (event) => {
+        await event.session.waitForReady();
+        resolve(event.session);
+      });
+
+      client.connect(transport);
+    });
+
+    await run({ client, port, server, session });
+  } finally {
+    await server.stop();
+  }
+};
+
+test("custom routes handle GET requests", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response = await fetch(`http://localhost:${port}/custom`);
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as { message: string };
+      expect(data).toEqual({ message: "Hello from custom route" });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.get("/custom", async (c) => {
+        return c.json({ message: "Hello from custom route" });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes handle POST requests with JSON body", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const payload = { number: 42, test: "data" };
+      const response = await fetch(`http://localhost:${port}/echo`, {
+        body: JSON.stringify(payload),
+        headers: {
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as { received: unknown };
+      expect(data.received).toEqual(payload);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.post("/echo", async (c) => {
+        const body = await c.req.json();
+        return c.json({ received: body });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes handle path parameters", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      // Test single parameter
+      const response1 = await fetch(`http://localhost:${port}/users/123`);
+      expect(response1.status).toBe(200);
+      const data1 = (await response1.json()) as { userId: string };
+      expect(data1).toEqual({ userId: "123" });
+
+      // Test multiple parameters
+      const response2 = await fetch(
+        `http://localhost:${port}/users/456/posts/789`,
+      );
+      expect(response2.status).toBe(200);
+      const data2 = (await response2.json()) as {
+        postId: string;
+        userId: string;
+      };
+      expect(data2).toEqual({ postId: "789", userId: "456" });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.get("/users/:id", async (c) => {
+        const id = c.req.param("id");
+        return c.json({ userId: id });
+      });
+
+      app.get("/users/:userId/posts/:postId", async (c) => {
+        const userId = c.req.param("userId");
+        const postId = c.req.param("postId");
+        return c.json({ postId, userId });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes handle query parameters", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response = await fetch(
+        `http://localhost:${port}/search?q=test&limit=10&tags=a&tags=b`,
+      );
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as {
+        query: Record<string, string | string[]>;
+      };
+      expect(data.query.q).toBe("test");
+      expect(data.query.limit).toBe("10");
+      expect(data.query.tags).toEqual(["a", "b"]);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.get("/search", async (c) => {
+        const query = c.req.query();
+        // Convert single values to match old API behavior
+        const processedQuery: Record<string, string | string[]> = {};
+        for (const [key, value] of Object.entries(query)) {
+          if (key === "tags") {
+            // tags can be an array
+            const allTags = c.req.queries("tags");
+            processedQuery[key] = allTags || [];
+          } else {
+            processedQuery[key] = value;
+          }
+        }
+        return c.json({ query: processedQuery });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes handle different HTTP methods", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      // Note: OPTIONS is intercepted by mcp-proxy for CORS handling and returns 204
+      const methods = ["GET", "POST", "PUT", "DELETE", "PATCH"];
+
+      for (const method of methods) {
+        const response = await fetch(`http://localhost:${port}/resource`, {
+          method,
+        });
+        expect(response.status).toBe(200);
+
+        const data = (await response.json()) as { method: string };
+        expect(data.method).toBe(method);
+      }
+
+      // Test that OPTIONS returns 204 (handled by mcp-proxy for CORS)
+      const optionsResponse = await fetch(`http://localhost:${port}/resource`, {
+        method: "OPTIONS",
+      });
+      expect(optionsResponse.status).toBe(204);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+
+      app.get("/resource", async (c) => {
+        return c.json({ method: "GET" });
+      });
+
+      app.post("/resource", async (c) => {
+        return c.json({ method: "POST" });
+      });
+
+      app.put("/resource", async (c) => {
+        return c.json({ method: "PUT" });
+      });
+
+      app.delete("/resource", async (c) => {
+        return c.json({ method: "DELETE" });
+      });
+
+      app.patch("/resource", async (c) => {
+        return c.json({ method: "PATCH" });
+      });
+
+      // Note: OPTIONS handler won't be called due to mcp-proxy CORS handling
+      app.options("/resource", async (c) => {
+        return c.json({ method: "OPTIONS" });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes return proper status codes", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response1 = await fetch(`http://localhost:${port}/created`);
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(`http://localhost:${port}/not-found`);
+      expect(response2.status).toBe(404);
+
+      const response3 = await fetch(`http://localhost:${port}/deleted`, {
+        method: "DELETE",
+      });
+      expect(response3.status).toBe(204);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+
+      app.get("/created", async (c) => {
+        return c.json({ created: true }, 201);
+      });
+
+      app.get("/not-found", async (c) => {
+        return c.json({ error: "Not found" }, 404);
+      });
+
+      app.delete("/deleted", async (c) => {
+        return c.body(null, 204);
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes handle HTML responses", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response = await fetch(`http://localhost:${port}/page`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("text/html");
+
+      const html = await response.text();
+      expect(html).toContain("<h1>Hello</h1>");
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.get("/page", async (c) => {
+        return c.html("<html><body><h1>Hello</h1></body></html>");
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes handle errors gracefully", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response = await fetch(`http://localhost:${port}/error`);
+      expect(response.status).toBe(500);
+
+      const data = (await response.json()) as { error: string };
+      expect(data.error).toBe("Something went wrong");
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.get("/error", async () => {
+        throw new Error("Something went wrong");
+      });
+
+      // Add error handler to return JSON instead of HTML
+      app.onError((err, c) => {
+        return c.json({ error: err.message }, 500);
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes work alongside MCP endpoints", async () => {
+  await runWithTestServer({
+    run: async ({ client, port }) => {
+      // Test custom route
+      const response = await fetch(`http://localhost:${port}/api/status`);
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as { status: string };
+      expect(data.status).toBe("ok");
+
+      // Test MCP functionality still works
+      const tools = await client.listTools();
+      expect(tools.tools).toHaveLength(1);
+      expect(tools.tools[0].name).toBe("test_tool");
+
+      // Health endpoint still works
+      const healthResponse = await fetch(`http://localhost:${port}/health`);
+      expect(healthResponse.status).toBe(200);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      // Add a custom route using Hono
+      const app = server.getApp();
+      app.get("/api/status", async (c) => {
+        return c.json({ status: "ok" });
+      });
+
+      // Add an MCP tool
+      server.addTool({
+        description: "Test tool",
+        execute: async () => ({
+          content: [{ text: "Tool result", type: "text" }],
+        }),
+        name: "test_tool",
+        parameters: z.object({}),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes with wildcard patterns", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response = await fetch(
+        `http://localhost:${port}/static/css/style.css`,
+      );
+      expect(response.status).toBe(200);
+
+      const data = (await response.json()) as { path: string };
+      expect(data.path).toBe("/static/css/style.css");
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.get("/static/*", async (c) => {
+        return c.json({ path: c.req.path });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes respect route order", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      // Should match specific route
+      const response1 = await fetch(`http://localhost:${port}/api/special`);
+      const data1 = (await response1.json()) as { route: string };
+      expect(data1.route).toBe("special");
+
+      // Should match wildcard route
+      const response2 = await fetch(`http://localhost:${port}/api/other`);
+      const data2 = (await response2.json()) as { route: string };
+      expect(data2.route).toBe("wildcard");
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+
+      // More specific route first
+      app.get("/api/special", async (c) => {
+        return c.json({ route: "special" });
+      });
+
+      // Wildcard route second
+      app.get("/api/*", async (c) => {
+        return c.json({ route: "wildcard" });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes with authentication", { timeout: 10000 }, async () => {
+  interface TestAuth {
+    [key: string]: unknown;
+    userId: string;
+  }
+
+  const port = await getRandomPort();
+  const server = new FastMCP<TestAuth>({
+    authenticate: async (req) => {
+      const authHeader = req.headers.authorization;
+      if (authHeader === "Bearer valid-token") {
+        return { userId: "123" };
+      }
+      throw new Error("Unauthorized");
+    },
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  // Helper to get auth from context
+  const getAuth = async (c: Context): Promise<null | TestAuth> => {
+    const req = c.env.incoming;
+    const authHeader = req.headers.authorization;
+    if (authHeader === "Bearer valid-token") {
+      return { userId: "123" };
+    }
+    return null;
+  };
+
+  const app = server.getApp();
+  app.get("/protected", async (c) => {
+    const auth = await getAuth(c);
+    if (!auth) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    return c.json({
+      authenticated: true,
+      userId: auth.userId,
+    });
+  });
+
+  await server.start({
+    httpStream: { port },
+    transportType: "httpStream",
+  });
+
+  try {
+    // Test without auth
+    const response1 = await fetch(`http://localhost:${port}/protected`);
+    expect(response1.status).toBe(401);
+
+    // Test with valid auth
+    const response2 = await fetch(`http://localhost:${port}/protected`, {
+      headers: {
+        Authorization: "Bearer valid-token",
+      },
+    });
+    expect(response2.status).toBe(200);
+    const data = (await response2.json()) as {
+      authenticated: boolean;
+      userId: string;
+    };
+    expect(data).toEqual({ authenticated: true, userId: "123" });
+  } finally {
+    await server.stop();
+  }
+});
+
+test("routes return 404 for non-existent paths", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response = await fetch(`http://localhost:${port}/does-not-exist`);
+      expect(response.status).toBe(404);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.get("/exists", async (c) => {
+        return c.json({ exists: true });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes handle text body parsing", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response = await fetch(`http://localhost:${port}/text`, {
+        body: "Hello, World!",
+        headers: {
+          "Content-Type": "text/plain",
+        },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      const data = (await response.json()) as {
+        length: number;
+        received: string;
+      };
+      expect(data).toEqual({ length: 13, received: "Hello, World!" });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      const app = server.getApp();
+      app.post("/text", async (c) => {
+        const text = await c.req.text();
+        return c.json({ length: text.length, received: text });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("custom routes handle concurrent requests", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      // Send multiple concurrent requests
+      const promises = Array.from({ length: 5 }, () =>
+        fetch(`http://localhost:${port}/counter`),
+      );
+
+      const responses = await Promise.all(promises);
+      const results = await Promise.all(
+        responses.map((r) => r.json() as Promise<{ count: number }>),
+      );
+
+      // Results should contain counts from 1 to 5 (not necessarily in order)
+      const counts = results.map((r) => r.count).sort((a, b) => a - b);
+      expect(counts).toEqual([1, 2, 3, 4, 5]);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      // Use a closure to capture the counter
+      const state = { requestCount: 0 };
+
+      const app = server.getApp();
+      app.get("/counter", async (c) => {
+        state.requestCount++;
+        const currentCount = state.requestCount;
+        // Simulate some async work
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return c.json({ count: currentCount });
+      });
+
+      return server;
+    },
+  });
+});
+
+test("public routes bypass authentication", async () => {
+  interface TestAuth {
+    [key: string]: unknown;
+    userId: string;
+  }
+
+  const port = await getRandomPort();
+  const server = new FastMCP<TestAuth>({
+    authenticate: async (req) => {
+      const authHeader = req.headers.authorization;
+      if (authHeader === "Bearer valid-token") {
+        return { userId: "123" };
+      }
+      throw new Error("Unauthorized");
+    },
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  // Helper to get auth from context (returns null if not authenticated)
+  const getAuth = async (c: Context): Promise<null | TestAuth> => {
+    const req = c.env.incoming;
+    const authHeader = req.headers.authorization;
+    if (authHeader === "Bearer valid-token") {
+      return { userId: "123" };
+    }
+    return null;
+  };
+
+  const app = server.getApp();
+
+  // Add a public route - no auth check
+  app.get("/public", async (c) => {
+    const auth = await getAuth(c);
+    return c.json({
+      auth: auth || undefined,
+      message: "This is public",
+      public: true,
+    });
+  });
+
+  // Add a private route for comparison
+  app.get("/private", async (c) => {
+    const auth = await getAuth(c);
+    if (!auth) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    return c.json({
+      auth,
+      message: "This is private",
+      public: false,
+    });
+  });
+
+  await server.start({
+    httpStream: { port },
+    transportType: "httpStream",
+  });
+
+  try {
+    // Test public route without auth - should work
+    const publicResponse = await fetch(`http://localhost:${port}/public`);
+    expect(publicResponse.status).toBe(200);
+    const publicData = (await publicResponse.json()) as {
+      auth: unknown;
+      message: string;
+      public: boolean;
+    };
+    expect(publicData).toEqual({
+      auth: undefined, // No auth for public routes
+      message: "This is public",
+      public: true,
+    });
+
+    // Test private route without auth - should fail
+    const privateResponse = await fetch(`http://localhost:${port}/private`);
+    expect(privateResponse.status).toBe(401);
+
+    // Test private route with valid auth - should work
+    const privateAuthResponse = await fetch(
+      `http://localhost:${port}/private`,
+      {
+        headers: {
+          Authorization: "Bearer valid-token",
+        },
+      },
+    );
+    expect(privateAuthResponse.status).toBe(200);
+    const privateAuthData = (await privateAuthResponse.json()) as {
+      auth: { userId: string };
+      message: string;
+      public: boolean;
+    };
+    expect(privateAuthData).toEqual({
+      auth: { userId: "123" },
+      message: "This is private",
+      public: false,
+    });
+  } finally {
+    await server.stop();
+  }
+});
+
+test("public routes work with OAuth discovery endpoints", async () => {
+  const port = await getRandomPort();
+  const server = new FastMCP({
+    authenticate: async () => {
+      // Always reject auth to verify public routes bypass this
+      throw new Error("Auth should be bypassed for public routes");
+    },
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  const app = server.getApp();
+
+  // Add OAuth discovery endpoint as public route (no auth check)
+  app.get("/.well-known/openid-configuration", async (c) => {
+    return c.json({
+      authorization_endpoint: "https://example.com/auth",
+      issuer: "https://example.com",
+      token_endpoint: "https://example.com/token",
+    });
+  });
+
+  // Add protected resource metadata as public route (no auth check)
+  app.get("/.well-known/oauth-protected-resource", async (c) => {
+    return c.json({
+      authorizationServers: ["https://example.com"],
+      resource: "https://example.com/api",
+    });
+  });
+
+  await server.start({
+    httpStream: { port },
+    transportType: "httpStream",
+  });
+
+  try {
+    // Test OpenID configuration endpoint
+    const oidcResponse = await fetch(
+      `http://localhost:${port}/.well-known/openid-configuration`,
+    );
+    expect(oidcResponse.status).toBe(200);
+    const oidcData = (await oidcResponse.json()) as {
+      authorization_endpoint: string;
+      issuer: string;
+      token_endpoint: string;
+    };
+    expect(oidcData.issuer).toBe("https://example.com");
+
+    // Test protected resource metadata endpoint
+    const resourceResponse = await fetch(
+      `http://localhost:${port}/.well-known/oauth-protected-resource`,
+    );
+    expect(resourceResponse.status).toBe(200);
+    const resourceData = (await resourceResponse.json()) as {
+      authorizationServers: string[];
+      resource: string;
+    };
+    expect(resourceData.resource).toBe("https://example.com/api");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("public routes work with wildcards", async () => {
+  const port = await getRandomPort();
+  const server = new FastMCP({
+    authenticate: async () => {
+      throw new Error("Auth should be bypassed");
+    },
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  const app = server.getApp();
+
+  // Add public wildcard route for static files (no auth check)
+  app.get("/public/*", async (c) => {
+    return c.json({
+      file: c.req.path,
+      message: "Public static file",
+    });
+  });
+
+  await server.start({
+    httpStream: { port },
+    transportType: "httpStream",
+  });
+
+  try {
+    const response = await fetch(
+      `http://localhost:${port}/public/css/style.css`,
+    );
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      file: string;
+      message: string;
+    };
+    expect(data.file).toBe("/public/css/style.css");
+    expect(data.message).toBe("Public static file");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("mixed public and private routes with same path pattern", async () => {
+  interface TestAuth {
+    [key: string]: unknown;
+    role: string;
+  }
+
+  const port = await getRandomPort();
+  const server = new FastMCP<TestAuth>({
+    authenticate: async (req) => {
+      const authHeader = req.headers.authorization;
+      if (authHeader === "Bearer admin-token") {
+        return { role: "admin" };
+      }
+      throw new Error("Unauthorized");
+    },
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  // Helper to get auth from context
+  const getAuth = async (c: Context): Promise<null | TestAuth> => {
+    const req = c.env.incoming;
+    const authHeader = req.headers.authorization;
+    if (authHeader === "Bearer admin-token") {
+      return { role: "admin" };
+    }
+    return null;
+  };
+
+  const app = server.getApp();
+
+  // Public GET endpoint (no auth check)
+  app.get("/api/status", async (c) => {
+    return c.json({ public: true, status: "ok" });
+  });
+
+  // Private POST endpoint with same path
+  app.post("/api/status", async (c) => {
+    const auth = await getAuth(c);
+    if (!auth) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    return c.json({
+      message: "Status updated",
+      public: false,
+      user: auth.role,
+    });
+  });
+
+  await server.start({
+    httpStream: { port },
+    transportType: "httpStream",
+  });
+
+  try {
+    // Test public GET - should work without auth
+    const getResponse = await fetch(`http://localhost:${port}/api/status`);
+    expect(getResponse.status).toBe(200);
+    const getData = (await getResponse.json()) as {
+      public: boolean;
+      status: string;
+    };
+    expect(getData).toEqual({ public: true, status: "ok" });
+
+    // Test private POST without auth - should fail
+    const postResponse = await fetch(`http://localhost:${port}/api/status`, {
+      method: "POST",
+    });
+    expect(postResponse.status).toBe(401);
+
+    // Test private POST with auth - should work
+    const postAuthResponse = await fetch(
+      `http://localhost:${port}/api/status`,
+      {
+        headers: {
+          Authorization: "Bearer admin-token",
+        },
+        method: "POST",
+      },
+    );
+    expect(postAuthResponse.status).toBe(200);
+    const postAuthData = (await postAuthResponse.json()) as {
+      message: string;
+      public: boolean;
+      user: string;
+    };
+    expect(postAuthData).toEqual({
+      message: "Status updated",
+      public: false,
+      user: "admin",
+    });
+  } finally {
+    await server.stop();
+  }
+});
+
+test("route options validation", async () => {
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  const app = server.getApp();
+
+  // Test that routes can be added without throwing
+  expect(() => {
+    app.get("/test1", async (c) => {
+      return c.json({ test: 1 });
+    });
+  }).not.toThrow();
+
+  expect(() => {
+    app.get("/test2", async (c) => {
+      return c.json({ test: 2 });
+    });
+  }).not.toThrow();
+
+  expect(() => {
+    app.get("/test3", async (c) => {
+      return c.json({ test: 3 });
+    });
+  }).not.toThrow();
+
+  expect(() => {
+    app.get("/test4", async (c) => {
+      return c.json({ test: 4 });
+    });
+  }).not.toThrow();
+});

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -1,0 +1,563 @@
+/**
+ * Web-standard Streamable HTTP Server Transport for MCP
+ *
+ * This transport implements the MCP Streamable HTTP specification using
+ * web standard APIs (Request, Response, TransformStream) for compatibility
+ * with edge runtimes like Cloudflare Workers, Deno, and Bun.
+ */
+
+import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  isInitializeRequest,
+  isJSONRPCNotification,
+  isJSONRPCResponse,
+  JSONRPCMessage,
+  JSONRPCMessageSchema,
+  MessageExtraInfo,
+  RequestId,
+} from "@modelcontextprotocol/sdk/types.js";
+
+export type EventId = string;
+/**
+ * Interface for resumability support via event storage
+ */
+export interface EventStore {
+  getStreamIdForEventId?(eventId: EventId): Promise<StreamId | undefined>;
+  replayEventsAfter(
+    lastEventId: EventId,
+    options: {
+      send: (eventId: EventId, message: JSONRPCMessage) => Promise<void>;
+    },
+  ): Promise<StreamId>;
+  storeEvent(streamId: StreamId, message: JSONRPCMessage): Promise<EventId>;
+}
+
+export type StreamId = string;
+
+/**
+ * Configuration options for WebStreamableHTTPServerTransport
+ */
+export interface WebStreamableHTTPServerTransportOptions {
+  /**
+   * If true, return JSON responses instead of SSE streams
+   */
+  enableJsonResponse?: boolean;
+
+  /**
+   * Event store for resumability support
+   */
+  eventStore?: EventStore;
+
+  /**
+   * Callback for session close events
+   */
+  onsessionclosed?: (sessionId: string) => Promise<void> | void;
+
+  /**
+   * Callback for session initialization events
+   */
+  onsessioninitialized?: (sessionId: string) => Promise<void> | void;
+
+  /**
+   * Function that generates a session ID for the transport.
+   * Return undefined to disable session management (stateless mode).
+   */
+  sessionIdGenerator: (() => string) | undefined;
+}
+
+const MAXIMUM_MESSAGE_SIZE = 4 * 1024 * 1024; // 4MB
+
+/**
+ * Web-standard Server transport for Streamable HTTP.
+ * Uses web APIs (Request, Response, TransformStream) for edge runtime compatibility.
+ */
+export class WebStreamableHTTPServerTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+  sessionId?: string;
+  private _enableJsonResponse = false;
+  private _encoder = new TextEncoder();
+  private _eventStore?: EventStore;
+  private _onsessionclosed?: (sessionId: string) => Promise<void> | void;
+  private _onsessioninitialized?: (sessionId: string) => Promise<void> | void;
+  private _pendingResponses: JSONRPCMessage[] = [];
+  private _requestToStreamMapping = new Map<RequestId, StreamId>();
+
+  private _standaloneSseStreamId = "_GET_stream";
+  private _started = false;
+  private _streamMapping = new Map<
+    StreamId,
+    WritableStreamDefaultWriter<Uint8Array>
+  >();
+  private sessionIdGenerator: (() => string) | undefined;
+
+  constructor(options: WebStreamableHTTPServerTransportOptions) {
+    this.sessionIdGenerator = options.sessionIdGenerator;
+    this._enableJsonResponse = options.enableJsonResponse ?? false;
+    this._eventStore = options.eventStore;
+    this._onsessioninitialized = options.onsessioninitialized;
+    this._onsessionclosed = options.onsessionclosed;
+  }
+
+  /**
+   * Close the transport
+   */
+  async close(): Promise<void> {
+    for (const writer of this._streamMapping.values()) {
+      try {
+        await writer.close();
+      } catch {
+        // Ignore close errors
+      }
+    }
+    this._streamMapping.clear();
+    this._started = false;
+    this.onclose?.();
+  }
+
+  /**
+   * Handles an incoming web Request and returns a Response
+   */
+  async handleRequest(
+    request: Request,
+    parsedBody?: unknown,
+  ): Promise<Response> {
+    const method = request.method;
+
+    if (method === "POST") {
+      return this.handlePostRequest(request, parsedBody);
+    } else if (method === "GET") {
+      return this.handleGetRequest(request);
+    } else if (method === "DELETE") {
+      return this.handleDeleteRequest(request);
+    } else {
+      return this.handleUnsupportedRequest();
+    }
+  }
+
+  /**
+   * Send a message to connected clients
+   */
+  async send(
+    message: JSONRPCMessage,
+    options?: { relatedRequestId?: RequestId },
+  ): Promise<void> {
+    // Store for pending responses (used in JSON response mode)
+    this._pendingResponses.push(message);
+
+    // Send to SSE streams
+    const streamId = options?.relatedRequestId
+      ? this._requestToStreamMapping.get(options.relatedRequestId)
+      : this._standaloneSseStreamId;
+
+    if (streamId) {
+      const writer = this._streamMapping.get(streamId);
+      if (writer) {
+        try {
+          if (this._eventStore) {
+            const eventId = await this._eventStore.storeEvent(
+              streamId,
+              message,
+            );
+            await this.writeSSEEventWithId(writer, eventId, message);
+          } else {
+            await this.writeSSEEvent(writer, message);
+          }
+        } catch (error) {
+          this.onerror?.(
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        }
+      }
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this._started) {
+      throw new Error("Transport already started");
+    }
+    this._started = true;
+  }
+
+  /**
+   * Create an error response
+   */
+  private createErrorResponse(
+    status: number,
+    code: number,
+    message: string,
+  ): Response {
+    return new Response(
+      JSON.stringify({
+        error: { code, message },
+        id: null,
+        jsonrpc: "2.0",
+      }),
+      {
+        headers: {
+          ...this.getResponseHeaders(),
+          "Content-Type": "application/json",
+        },
+        status,
+      },
+    );
+  }
+
+  /**
+   * Get common response headers
+   */
+  private getResponseHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {};
+    if (this.sessionId) {
+      headers["mcp-session-id"] = this.sessionId;
+    }
+    return headers;
+  }
+
+  /**
+   * Handles DELETE requests to terminate sessions
+   */
+  private async handleDeleteRequest(request: Request): Promise<Response> {
+    const sessionId = request.headers.get("mcp-session-id");
+
+    if (this.sessionIdGenerator) {
+      if (!sessionId) {
+        return this.createErrorResponse(
+          400,
+          -32000,
+          "Bad Request: Mcp-Session-Id header is required",
+        );
+      }
+
+      if (this.sessionId !== sessionId) {
+        return this.createErrorResponse(404, -32001, "Session not found");
+      }
+    }
+
+    // Close all streams
+    for (const writer of this._streamMapping.values()) {
+      try {
+        await writer.close();
+      } catch {
+        // Ignore close errors
+      }
+    }
+    this._streamMapping.clear();
+
+    await this._onsessionclosed?.(this.sessionId ?? "");
+    this.sessionId = undefined;
+
+    return new Response(null, {
+      headers: this.getResponseHeaders(),
+      status: 204,
+    });
+  }
+
+  /**
+   * Handles GET requests for SSE stream
+   */
+  private async handleGetRequest(request: Request): Promise<Response> {
+    const acceptHeader = request.headers.get("accept");
+    if (!acceptHeader?.includes("text/event-stream")) {
+      return this.createErrorResponse(
+        406,
+        -32000,
+        "Not Acceptable: Client must accept text/event-stream",
+      );
+    }
+
+    // Validate session
+    const sessionId = request.headers.get("mcp-session-id");
+    if (this.sessionIdGenerator && !sessionId) {
+      return this.createErrorResponse(
+        400,
+        -32000,
+        "Bad Request: Mcp-Session-Id header is required",
+      );
+    }
+
+    if (this.sessionIdGenerator && this.sessionId !== sessionId) {
+      return this.createErrorResponse(404, -32001, "Session not found");
+    }
+
+    // Check for existing standalone stream
+    if (this._streamMapping.has(this._standaloneSseStreamId)) {
+      return this.createErrorResponse(
+        409,
+        -32000,
+        "Conflict: SSE stream already exists for this session",
+      );
+    }
+
+    // Handle resumability
+    if (this._eventStore) {
+      const lastEventId = request.headers.get("last-event-id");
+      if (lastEventId) {
+        return this.handleReplayEvents(lastEventId);
+      }
+    }
+
+    // Create SSE stream
+    const { readable, writable } = new TransformStream<Uint8Array>();
+    const writer = writable.getWriter();
+    this._streamMapping.set(this._standaloneSseStreamId, writer);
+
+    return new Response(readable, {
+      headers: {
+        ...this.getResponseHeaders(),
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream",
+      },
+      status: 200,
+    });
+  }
+
+  /**
+   * Handles POST requests containing JSON-RPC messages
+   */
+  private async handlePostRequest(
+    request: Request,
+    parsedBody?: unknown,
+  ): Promise<Response> {
+    // Validate Accept header
+    const acceptHeader = request.headers.get("accept");
+    if (
+      !acceptHeader?.includes("application/json") &&
+      !acceptHeader?.includes("text/event-stream")
+    ) {
+      return this.createErrorResponse(
+        406,
+        -32000,
+        "Not Acceptable: Client must accept application/json or text/event-stream",
+      );
+    }
+
+    // Validate Content-Type
+    const contentType = request.headers.get("content-type");
+    if (!contentType?.includes("application/json")) {
+      return this.createErrorResponse(
+        415,
+        -32000,
+        "Unsupported Media Type: Content-Type must be application/json",
+      );
+    }
+
+    // Validate Content-Length
+    const contentLength = parseInt(
+      request.headers.get("content-length") ?? "0",
+      10,
+    );
+    if (contentLength > MAXIMUM_MESSAGE_SIZE) {
+      return this.createErrorResponse(
+        413,
+        -32000,
+        `Request body too large. Maximum size is ${MAXIMUM_MESSAGE_SIZE} bytes`,
+      );
+    }
+
+    // Parse body
+    let rawMessage: unknown;
+    try {
+      rawMessage = parsedBody ?? (await request.json());
+    } catch {
+      return this.createErrorResponse(400, -32700, "Parse error: Invalid JSON");
+    }
+
+    // Handle batch or single message
+    const arrayMessage: unknown[] = Array.isArray(rawMessage)
+      ? rawMessage
+      : [rawMessage];
+
+    // Validate messages
+    const messages: JSONRPCMessage[] = [];
+    for (const msg of arrayMessage) {
+      const result = JSONRPCMessageSchema.safeParse(msg);
+      if (!result.success) {
+        return this.createErrorResponse(
+          400,
+          -32700,
+          "Parse error: Invalid JSON-RPC message",
+        );
+      }
+      messages.push(result.data);
+    }
+
+    // Handle session ID
+    const requestSessionId = request.headers.get("mcp-session-id");
+    const hasInitRequest = messages.some((msg) => isInitializeRequest(msg));
+
+    // Validate session requirements
+    if (hasInitRequest && requestSessionId) {
+      return this.createErrorResponse(
+        400,
+        -32600,
+        "Invalid Request: Initialization requests must not include a sessionId",
+      );
+    }
+
+    if (hasInitRequest && messages.length > 1) {
+      return this.createErrorResponse(
+        400,
+        -32600,
+        "Invalid Request: Only one initialization request is allowed",
+      );
+    }
+
+    if (!hasInitRequest && !requestSessionId && this.sessionIdGenerator) {
+      return this.createErrorResponse(
+        400,
+        -32000,
+        "Bad Request: Mcp-Session-Id header is required",
+      );
+    }
+
+    // Generate or validate session ID
+    if (hasInitRequest && this.sessionIdGenerator) {
+      this.sessionId = this.sessionIdGenerator();
+      await this._onsessioninitialized?.(this.sessionId);
+    } else if (requestSessionId) {
+      if (this.sessionIdGenerator && this.sessionId !== requestSessionId) {
+        return this.createErrorResponse(404, -32001, "Session not found");
+      }
+    }
+
+    // Process messages through the transport
+    this._pendingResponses = [];
+    for (const message of messages) {
+      this.onmessage?.(message, { authInfo: undefined });
+    }
+
+    // If all messages are notifications/responses, return 202
+    if (
+      messages.every(
+        (msg) => isJSONRPCNotification(msg) || isJSONRPCResponse(msg),
+      )
+    ) {
+      return new Response(null, {
+        headers: this.getResponseHeaders(),
+        status: 202,
+      });
+    }
+
+    // Return JSON response if enabled and client accepts it
+    if (
+      this._enableJsonResponse &&
+      acceptHeader?.includes("application/json")
+    ) {
+      // Wait a tick for responses to be collected
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const responseBody =
+        this._pendingResponses.length === 1
+          ? JSON.stringify(this._pendingResponses[0])
+          : JSON.stringify(this._pendingResponses);
+
+      return new Response(responseBody, {
+        headers: {
+          ...this.getResponseHeaders(),
+          "Content-Type": "application/json",
+        },
+        status: 200,
+      });
+    }
+
+    // Return SSE stream
+    const { readable, writable } = new TransformStream<Uint8Array>();
+    const writer = writable.getWriter();
+    const streamId = `post_${Date.now()}`;
+    this._streamMapping.set(streamId, writer);
+
+    // Send any pending responses as SSE events
+    (async () => {
+      try {
+        for (const response of this._pendingResponses) {
+          await this.writeSSEEvent(writer, response);
+        }
+      } catch (error) {
+        this.onerror?.(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    })();
+
+    return new Response(readable, {
+      headers: {
+        ...this.getResponseHeaders(),
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream",
+      },
+      status: 200,
+    });
+  }
+
+  /**
+   * Replay events for resumability
+   */
+  private async handleReplayEvents(lastEventId: string): Promise<Response> {
+    if (!this._eventStore) {
+      return this.createErrorResponse(
+        400,
+        -32000,
+        "Resumability not supported",
+      );
+    }
+
+    const { readable, writable } = new TransformStream<Uint8Array>();
+    const writer = writable.getWriter();
+
+    try {
+      const streamId = await this._eventStore.replayEventsAfter(lastEventId, {
+        send: async (eventId, message) => {
+          await this.writeSSEEventWithId(writer, eventId, message);
+        },
+      });
+      this._streamMapping.set(streamId, writer);
+    } catch (error) {
+      await writer.close();
+      return this.createErrorResponse(500, -32000, `Replay failed: ${error}`);
+    }
+
+    return new Response(readable, {
+      headers: {
+        ...this.getResponseHeaders(),
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "Content-Type": "text/event-stream",
+      },
+      status: 200,
+    });
+  }
+
+  /**
+   * Handles unsupported HTTP methods
+   */
+  private handleUnsupportedRequest(): Response {
+    return this.createErrorResponse(405, -32000, "Method not allowed");
+  }
+
+  /**
+   * Write an SSE event to the stream
+   */
+  private async writeSSEEvent(
+    writer: WritableStreamDefaultWriter<Uint8Array>,
+    message: JSONRPCMessage,
+  ): Promise<void> {
+    const data = `data: ${JSON.stringify(message)}\n\n`;
+    await writer.write(this._encoder.encode(data));
+  }
+
+  /**
+   * Write an SSE event with ID to the stream
+   */
+  private async writeSSEEventWithId(
+    writer: WritableStreamDefaultWriter<Uint8Array>,
+    eventId: string,
+    message: JSONRPCMessage,
+  ): Promise<void> {
+    const data = `id: ${eventId}\ndata: ${JSON.stringify(message)}\n\n`;
+    await writer.write(this._encoder.encode(data));
+  }
+}

--- a/src/edge/edge.test.ts
+++ b/src/edge/edge.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { EdgeFastMCP } from "./index.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type JsonResponse = any;
+
+describe("EdgeFastMCP", () => {
+  it("should handle initialize request", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "initialize",
+          params: {
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "1.0.0" },
+            protocolVersion: "2024-11-05",
+          },
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBe(1);
+    expect(body.result.serverInfo.name).toBe("TestServer");
+    expect(body.result.serverInfo.version).toBe("1.0.0");
+  });
+
+  it("should list tools", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    server.addTool({
+      description: "Greet someone",
+      execute: async ({ name }) => `Hello, ${name}!`,
+      name: "greet",
+      parameters: z.object({ name: z.string() }),
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 2,
+          jsonrpc: "2.0",
+          method: "tools/list",
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.result.tools).toHaveLength(1);
+    expect(body.result.tools[0].name).toBe("greet");
+    expect(body.result.tools[0].description).toBe("Greet someone");
+  });
+
+  it("should call a tool", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    server.addTool({
+      description: "Greet someone",
+      execute: async ({ name }) => `Hello, ${name}!`,
+      name: "greet",
+      parameters: z.object({ name: z.string() }),
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 3,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: {
+            arguments: { name: "World" },
+            name: "greet",
+          },
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.result.content).toEqual([
+      { text: "Hello, World!", type: "text" },
+    ]);
+  });
+
+  it("should list resources", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    server.addResource({
+      description: "A test resource",
+      load: async () => "Test content",
+      mimeType: "text/plain",
+      name: "Test Resource",
+      uri: "test://resource",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 4,
+          jsonrpc: "2.0",
+          method: "resources/list",
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.result.resources).toHaveLength(1);
+    expect(body.result.resources[0].uri).toBe("test://resource");
+  });
+
+  it("should read a resource", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    server.addResource({
+      load: async () => "Test content",
+      name: "Test Resource",
+      uri: "test://resource",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 5,
+          jsonrpc: "2.0",
+          method: "resources/read",
+          params: { uri: "test://resource" },
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.result.contents[0].text).toBe("Test content");
+  });
+
+  it("should list prompts", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    server.addPrompt({
+      arguments: [
+        { description: "First argument", name: "arg1", required: true },
+      ],
+      description: "A test prompt",
+      load: async (args) => `Prompt with ${args.arg1}`,
+      name: "test_prompt",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 6,
+          jsonrpc: "2.0",
+          method: "prompts/list",
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.result.prompts).toHaveLength(1);
+    expect(body.result.prompts[0].name).toBe("test_prompt");
+  });
+
+  it("should get a prompt", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    server.addPrompt({
+      description: "A test prompt",
+      load: async (args) => `Prompt with ${args.value ?? "default"}`,
+      name: "test_prompt",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 7,
+          jsonrpc: "2.0",
+          method: "prompts/get",
+          params: { arguments: { value: "test" }, name: "test_prompt" },
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.result.messages[0].content.text).toBe("Prompt with test");
+  });
+
+  it("should handle health check", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    const response = await server.fetch(new Request("http://localhost/health"));
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain("Ok");
+  });
+
+  it("should handle ping", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 8,
+          jsonrpc: "2.0",
+          method: "ping",
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.result).toEqual({});
+  });
+
+  it("should return error for invalid JSON", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: "not json",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const body: JsonResponse = await response.json();
+    expect(body.error.code).toBe(-32700);
+  });
+
+  it("should return 406 for wrong Accept header", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({}),
+        headers: {
+          Accept: "text/html",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(406);
+  });
+
+  it("should allow custom MCP path", async () => {
+    const server = new EdgeFastMCP({
+      mcpPath: "/api/mcp",
+      name: "TestServer",
+      version: "1.0.0",
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/api/mcp", {
+        body: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "ping",
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/edge/index.ts
+++ b/src/edge/index.ts
@@ -1,0 +1,611 @@
+/**
+ * FastMCP Edge Runtime Support
+ *
+ * This module provides edge runtime compatibility for FastMCP, enabling
+ * deployment to Cloudflare Workers, Deno Deploy, and other edge platforms.
+ *
+ * @example
+ * ```typescript
+ * // Cloudflare Workers
+ * import { EdgeFastMCP } from "fastmcp/edge";
+ * import { z } from "zod";
+ *
+ * const server = new EdgeFastMCP({ name: "MyMCP", version: "1.0.0" });
+ *
+ * server.addTool({
+ *   name: "hello",
+ *   description: "Say hello",
+ *   parameters: z.object({ name: z.string() }),
+ *   execute: async ({ name }) => `Hello, ${name}!`,
+ * });
+ *
+ * export default server;
+ * ```
+ */
+
+import { ErrorCode, JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { StandardSchemaV1 } from "@standard-schema/spec";
+import { Hono } from "hono";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+export { WebStreamableHTTPServerTransport } from "./WebStreamableHTTPServerTransport.js";
+export type {
+  EventStore,
+  WebStreamableHTTPServerTransportOptions,
+} from "./WebStreamableHTTPServerTransport.js";
+
+/**
+ * Options for EdgeFastMCP
+ */
+export interface EdgeFastMCPOptions {
+  description?: string;
+  logger?: EdgeLogger;
+  /**
+   * Base path for MCP endpoints (default: "/mcp")
+   */
+  mcpPath?: string;
+  name: string;
+  version: string;
+}
+
+/**
+ * Type for edge runtime fetch handler
+ */
+export type EdgeFetchHandler = (request: Request) => Promise<Response>;
+
+/**
+ * Logger interface for edge environments
+ */
+export interface EdgeLogger {
+  debug(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  log(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+}
+
+/**
+ * Prompt definition for EdgeFastMCP
+ */
+export interface EdgePrompt {
+  arguments?: Array<{ description?: string; name: string; required?: boolean }>;
+  description?: string;
+  load: (args: Record<string, string>) => Promise<
+    | {
+        messages: Array<{
+          content: { text: string; type: string };
+          role: string;
+        }>;
+      }
+    | string
+  >;
+  name: string;
+}
+
+/**
+ * Resource definition for EdgeFastMCP
+ */
+export interface EdgeResource {
+  description?: string;
+  load: () => Promise<
+    { blob?: string; mimeType?: string; text?: string } | string
+  >;
+  mimeType?: string;
+  name: string;
+  uri: string;
+}
+
+/**
+ * Tool definition for EdgeFastMCP
+ */
+export interface EdgeTool<TParams = unknown> {
+  description: string;
+  execute: (params: TParams) => Promise<
+    | {
+        content: Array<{
+          data?: string;
+          mimeType?: string;
+          text?: string;
+          type: string;
+        }>;
+      }
+    | string
+  >;
+  name: string;
+  parameters?: StandardSchemaV1<TParams> | z.ZodType<TParams>;
+}
+
+/**
+ * Edge-compatible FastMCP server for Cloudflare Workers, Deno, and Bun
+ *
+ * This is a simplified implementation optimized for stateless edge environments.
+ * It uses web-standard APIs only (no Node.js dependencies).
+ */
+export class EdgeFastMCP {
+  #honoApp = new Hono();
+  #logger: EdgeLogger;
+  #mcpPath: string;
+  #name: string;
+  #prompts: EdgePrompt[] = [];
+  #resources: EdgeResource[] = [];
+  #tools: EdgeTool[] = [];
+  #version: string;
+
+  constructor(options: EdgeFastMCPOptions) {
+    this.#name = options.name;
+    this.#version = options.version;
+    this.#logger = options.logger ?? console;
+    this.#mcpPath = options.mcpPath ?? "/mcp";
+
+    this.#setupRoutes();
+  }
+
+  /**
+   * Add a prompt to the server
+   */
+  addPrompt(prompt: EdgePrompt): this {
+    this.#prompts.push(prompt);
+    return this;
+  }
+
+  /**
+   * Add a resource to the server
+   */
+  addResource(resource: EdgeResource): this {
+    this.#resources.push(resource);
+    return this;
+  }
+
+  /**
+   * Add a tool to the server
+   */
+  addTool<TParams>(tool: EdgeTool<TParams>): this {
+    this.#tools.push(tool as EdgeTool);
+    return this;
+  }
+
+  /**
+   * Handle an incoming request (main entry point for edge runtimes)
+   */
+  async fetch(request: Request): Promise<Response> {
+    return this.#honoApp.fetch(request);
+  }
+
+  /**
+   * Get the Hono app for adding custom routes
+   */
+  getApp(): Hono {
+    return this.#honoApp;
+  }
+
+  /**
+   * Create an error HTTP response
+   */
+  #errorResponse(status: number, code: number, message: string): Response {
+    return new Response(
+      JSON.stringify({
+        error: { code, message },
+        id: null,
+        jsonrpc: "2.0",
+      }),
+      {
+        headers: { "Content-Type": "application/json" },
+        status,
+      },
+    );
+  }
+
+  /**
+   * Handle initialize request
+   */
+  #handleInitialize(id: number | string): JSONRPCMessage {
+    return {
+      id,
+      jsonrpc: "2.0",
+      result: {
+        capabilities: {
+          prompts: this.#prompts.length > 0 ? {} : undefined,
+          resources: this.#resources.length > 0 ? {} : undefined,
+          tools: this.#tools.length > 0 ? {} : undefined,
+        },
+        protocolVersion: "2024-11-05",
+        serverInfo: {
+          name: this.#name,
+          version: this.#version,
+        },
+      },
+    } as JSONRPCMessage;
+  }
+
+  /**
+   * Handle MCP POST requests
+   */
+  async #handleMcpRequest(request: Request): Promise<Response> {
+    // Validate headers
+    const acceptHeader = request.headers.get("accept");
+    if (
+      !acceptHeader?.includes("application/json") &&
+      !acceptHeader?.includes("text/event-stream")
+    ) {
+      return this.#errorResponse(
+        406,
+        -32000,
+        "Not Acceptable: Client must accept application/json or text/event-stream",
+      );
+    }
+
+    const contentType = request.headers.get("content-type");
+    if (!contentType?.includes("application/json")) {
+      return this.#errorResponse(
+        415,
+        -32000,
+        "Unsupported Media Type: Content-Type must be application/json",
+      );
+    }
+
+    // Parse request body
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return this.#errorResponse(400, -32700, "Parse error: Invalid JSON");
+    }
+
+    // Handle single or batch requests
+    const messages = Array.isArray(body) ? body : [body];
+    const responses: JSONRPCMessage[] = [];
+
+    for (const message of messages) {
+      const response = await this.#handleMessage(message);
+      if (response) {
+        responses.push(response);
+      }
+    }
+
+    // Return appropriate response format
+    if (responses.length === 0) {
+      return new Response(null, { status: 202 });
+    }
+
+    const responseBody =
+      responses.length === 1
+        ? JSON.stringify(responses[0])
+        : JSON.stringify(responses);
+
+    return new Response(responseBody, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      status: 200,
+    });
+  }
+
+  /**
+   * Handle SSE GET requests
+   */
+  async #handleMcpSseRequest(request: Request): Promise<Response> {
+    const acceptHeader = request.headers.get("accept");
+    if (!acceptHeader?.includes("text/event-stream")) {
+      return this.#errorResponse(
+        406,
+        -32000,
+        "Not Acceptable: Client must accept text/event-stream",
+      );
+    }
+
+    // In stateless mode, GET requests are not supported (no server-initiated messages)
+    return this.#errorResponse(
+      405,
+      -32000,
+      "Method Not Allowed: SSE streams not supported in stateless mode",
+    );
+  }
+
+  /**
+   * Handle individual MCP messages
+   */
+  async #handleMessage(message: unknown): Promise<JSONRPCMessage | null> {
+    if (!message || typeof message !== "object") {
+      return this.#rpcError(null, -32700, "Parse error: Invalid message");
+    }
+
+    const msg = message as {
+      id?: number | string;
+      jsonrpc?: string;
+      method?: string;
+      params?: unknown;
+    };
+
+    if (msg.jsonrpc !== "2.0") {
+      return this.#rpcError(
+        msg.id ?? null,
+        -32600,
+        "Invalid Request: jsonrpc must be 2.0",
+      );
+    }
+
+    // Handle notifications (no response expected)
+    if (!("id" in msg) || msg.id === undefined) {
+      return null;
+    }
+
+    const method = msg.method;
+    const id = msg.id;
+    const params = msg.params as Record<string, unknown> | undefined;
+
+    try {
+      switch (method) {
+        case "initialize":
+          return this.#handleInitialize(id);
+
+        case "ping":
+          return { id, jsonrpc: "2.0", result: {} } as JSONRPCMessage;
+
+        case "prompts/get":
+          return this.#handlePromptsGet(id, params);
+
+        case "prompts/list":
+          return this.#handlePromptsList(id);
+
+        case "resources/list":
+          return this.#handleResourcesList(id);
+
+        case "resources/read":
+          return this.#handleResourcesRead(id, params);
+
+        case "tools/call":
+          return this.#handleToolsCall(id, params);
+
+        case "tools/list":
+          return this.#handleToolsList(id);
+
+        default:
+          return this.#rpcError(id, -32601, `Method not found: ${method}`);
+      }
+    } catch (error) {
+      this.#logger.error(`Error handling ${method}:`, error);
+      return this.#rpcError(
+        id,
+        -32603,
+        `Internal error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Handle prompts/get request
+   */
+  async #handlePromptsGet(
+    id: number | string,
+    params?: Record<string, unknown>,
+  ): Promise<JSONRPCMessage> {
+    const promptName = params?.name as string;
+    const promptArgs = params?.arguments as Record<string, string> | undefined;
+
+    const prompt = this.#prompts.find((p) => p.name === promptName);
+    if (!prompt) {
+      return this.#rpcError(
+        id,
+        ErrorCode.InvalidParams,
+        `Prompt not found: ${promptName}`,
+      );
+    }
+
+    try {
+      const result = await prompt.load(promptArgs ?? {});
+      const messages =
+        typeof result === "string"
+          ? [{ content: { text: result, type: "text" }, role: "user" }]
+          : result.messages;
+
+      return {
+        id,
+        jsonrpc: "2.0",
+        result: { messages },
+      } as JSONRPCMessage;
+    } catch (error) {
+      return this.#rpcError(
+        id,
+        ErrorCode.InternalError,
+        `Prompt load failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Handle prompts/list request
+   */
+  #handlePromptsList(id: number | string): JSONRPCMessage {
+    return {
+      id,
+      jsonrpc: "2.0",
+      result: {
+        prompts: this.#prompts.map((p) => ({
+          arguments: p.arguments,
+          description: p.description,
+          name: p.name,
+        })),
+      },
+    } as JSONRPCMessage;
+  }
+
+  /**
+   * Handle resources/list request
+   */
+  #handleResourcesList(id: number | string): JSONRPCMessage {
+    return {
+      id,
+      jsonrpc: "2.0",
+      result: {
+        resources: this.#resources.map((r) => ({
+          description: r.description,
+          mimeType: r.mimeType,
+          name: r.name,
+          uri: r.uri,
+        })),
+      },
+    } as JSONRPCMessage;
+  }
+
+  /**
+   * Handle resources/read request
+   */
+  async #handleResourcesRead(
+    id: number | string,
+    params?: Record<string, unknown>,
+  ): Promise<JSONRPCMessage> {
+    const uri = params?.uri as string;
+    const resource = this.#resources.find((r) => r.uri === uri);
+
+    if (!resource) {
+      return this.#rpcError(
+        id,
+        ErrorCode.InvalidParams,
+        `Resource not found: ${uri}`,
+      );
+    }
+
+    try {
+      const result = await resource.load();
+      const content =
+        typeof result === "string"
+          ? { mimeType: resource.mimeType ?? "text/plain", text: result, uri }
+          : { uri, ...result };
+
+      return {
+        id,
+        jsonrpc: "2.0",
+        result: { contents: [content] },
+      } as JSONRPCMessage;
+    } catch (error) {
+      return this.#rpcError(
+        id,
+        ErrorCode.InternalError,
+        `Resource load failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Handle tools/call request
+   */
+  async #handleToolsCall(
+    id: number | string,
+    params?: Record<string, unknown>,
+  ): Promise<JSONRPCMessage> {
+    const toolName = params?.name as string;
+    const toolArgs = params?.arguments as Record<string, unknown> | undefined;
+
+    const tool = this.#tools.find((t) => t.name === toolName);
+    if (!tool) {
+      return this.#rpcError(
+        id,
+        ErrorCode.InvalidParams,
+        `Tool not found: ${toolName}`,
+      );
+    }
+
+    try {
+      const result = await tool.execute(toolArgs ?? {});
+
+      // Normalize result to content array
+      const content =
+        typeof result === "string"
+          ? [{ text: result, type: "text" }]
+          : result.content;
+
+      return {
+        id,
+        jsonrpc: "2.0",
+        result: { content },
+      } as JSONRPCMessage;
+    } catch (error) {
+      return this.#rpcError(
+        id,
+        ErrorCode.InternalError,
+        `Tool execution failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  /**
+   * Handle tools/list request
+   */
+  #handleToolsList(id: number | string): JSONRPCMessage {
+    return {
+      id,
+      jsonrpc: "2.0",
+      result: {
+        tools: this.#tools.map((tool) => ({
+          description: tool.description,
+          inputSchema: tool.parameters
+            ? this.#schemaToJsonSchema(tool.parameters)
+            : { type: "object" },
+          name: tool.name,
+        })),
+      },
+    } as JSONRPCMessage;
+  }
+
+  /**
+   * Create an RPC error message
+   */
+  #rpcError(
+    id: null | number | string,
+    code: number,
+    message: string,
+  ): JSONRPCMessage {
+    return {
+      error: { code, message },
+      id,
+      jsonrpc: "2.0",
+    } as JSONRPCMessage;
+  }
+
+  /**
+   * Convert schema to JSON Schema
+   */
+  #schemaToJsonSchema(
+    schema: StandardSchemaV1 | z.ZodType,
+  ): Record<string, unknown> {
+    try {
+      // Check if it's a Zod schema by looking for Zod-specific properties
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ("_def" in (schema as any) || schema instanceof z.ZodType) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return zodToJsonSchema(schema as any, { target: "openApi3" }) as Record<
+          string,
+          unknown
+        >;
+      }
+      // For StandardSchema, fall back to a generic object schema
+      return { type: "object" };
+    } catch {
+      return { type: "object" };
+    }
+  }
+
+  /**
+   * Set up MCP and health routes
+   */
+  #setupRoutes(): void {
+    // Health endpoint
+    this.#honoApp.get("/health", (c) => c.text("✓ Ok"));
+
+    // MCP endpoint - handles all MCP protocol messages
+    this.#honoApp.post(this.#mcpPath, async (c) => {
+      return this.#handleMcpRequest(c.req.raw);
+    });
+
+    // MCP GET endpoint for SSE streams (server-initiated messages)
+    this.#honoApp.get(this.#mcpPath, async (c) => {
+      return this.#handleMcpSseRequest(c.req.raw);
+    });
+
+    // MCP DELETE endpoint for session termination
+    this.#honoApp.delete(this.#mcpPath, async () => {
+      return new Response(null, { status: 204 });
+    });
+  }
+}

--- a/src/examples/custom-routes.ts
+++ b/src/examples/custom-routes.ts
@@ -1,0 +1,509 @@
+#!/usr/bin/env node
+
+/**
+ * Example FastMCP server demonstrating custom HTTP routes using Hono's native API.
+ *
+ * This example shows how to:
+ * - Use getApp() to access Hono's native API
+ * - Add REST API endpoints with Hono's standard methods (app.get(), app.post(), etc.)
+ * - Implement authentication with a custom helper function
+ * - Handle file uploads
+ * - Serve admin interfaces
+ * - Create webhooks
+ * - OAuth discovery endpoints
+ * - Integrate custom routes with MCP tools
+ *
+ * Run with:
+ *   npx fastmcp dev src/examples/custom-routes.ts
+ *   npx fastmcp inspect src/examples/custom-routes.ts
+ *
+ * Or directly:
+ *   node dist/examples/custom-routes.js --transport=http-stream --port=8080
+ */
+
+import type { Context } from "hono";
+
+import { z } from "zod";
+
+import { FastMCP } from "../FastMCP.js";
+
+// Example in-memory data store
+interface User {
+  email: string;
+  id: string;
+  name: string;
+}
+
+const users = new Map<string, User>([
+  ["1", { email: "alice@example.com", id: "1", name: "Alice" }],
+  ["2", { email: "bob@example.com", id: "2", name: "Bob" }],
+]);
+
+let requestCount = 0;
+
+// Simple authentication for demonstration
+interface UserAuth {
+  [key: string]: unknown;
+  role: string;
+  userId: string;
+}
+
+// Create the FastMCP server with authentication
+const server = new FastMCP<UserAuth>({
+  // Simple authentication - in production, use proper tokens/JWTs
+  authenticate: async (req) => {
+    const authHeader = req.headers.authorization;
+    if (authHeader === "Bearer admin-token") {
+      return { role: "admin", userId: "admin" };
+    } else if (authHeader === "Bearer user-token") {
+      return { role: "user", userId: "user1" };
+    }
+    throw new Error("Invalid or missing authentication");
+  },
+  name: "custom-routes-example",
+  version: "1.0.0",
+});
+
+// Get the Hono app instance for direct access to Hono's native API
+const app = server.getApp();
+
+// Helper to get authentication from Node.js request
+const getAuth = async (c: Context): Promise<null | UserAuth> => {
+  const req = c.env.incoming;
+  const authHeader = req.headers.authorization;
+  if (authHeader === "Bearer admin-token") {
+    return { role: "admin", userId: "admin" };
+  } else if (authHeader === "Bearer user-token") {
+    return { role: "user", userId: "user1" };
+  }
+  return null;
+};
+
+// ===== PUBLIC ROUTES (No Authentication Required) =====
+
+// OAuth discovery endpoint - public by design
+app.get("/.well-known/openid-configuration", async (c) => {
+  return c.json({
+    authorization_endpoint: "https://example.com/oauth/authorize",
+    issuer: "https://example.com",
+    jwks_uri: "https://example.com/.well-known/jwks.json",
+    response_types_supported: ["code"],
+    scopes_supported: ["openid", "profile", "email"],
+    subject_types_supported: ["public"],
+    token_endpoint: "https://example.com/oauth/token",
+  });
+});
+
+// OAuth protected resource metadata - also public
+app.get("/.well-known/oauth-protected-resource", async (c) => {
+  return c.json({
+    authorizationServers: ["https://example.com"],
+    resource: "https://example.com/api",
+    scopesSupported: ["read", "write"],
+  });
+});
+
+// Public status endpoint - no auth needed
+app.get("/status", async (c) => {
+  return c.json({
+    message: "Server is running",
+    status: "healthy",
+    timestamp: new Date().toISOString(),
+    version: "1.0.0",
+  });
+});
+
+// Public documentation endpoint
+app.get("/docs", async (c) => {
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>API Documentation</title>
+      <style>
+        body { font-family: sans-serif; margin: 40px; line-height: 1.6; }
+        h1, h2 { color: #333; }
+        .endpoint { background: #f8f9fa; padding: 15px; margin: 10px 0; border-left: 4px solid #007bff; }
+        .method { font-weight: bold; color: #28a745; }
+        .auth-required { color: #dc3545; font-size: 0.9em; }
+        .public { color: #6c757d; font-size: 0.9em; }
+      </style>
+    </head>
+    <body>
+      <h1>Custom Routes API Documentation</h1>
+
+      <h2>Public Endpoints (No Authentication)</h2>
+      <div class="endpoint">
+        <span class="method">GET</span> <code>/status</code>
+        <div class="public">✓ Public - Server health status</div>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span> <code>/.well-known/openid-configuration</code>
+        <div class="public">✓ Public - OAuth discovery</div>
+      </div>
+
+      <h2>Private Endpoints (Authentication Required)</h2>
+      <div class="endpoint">
+        <span class="method">GET</span> <code>/api/users</code>
+        <div class="auth-required">🔒 Requires: Bearer token</div>
+      </div>
+      <div class="endpoint">
+        <span class="method">GET</span> <code>/admin</code>
+        <div class="auth-required">🔒 Requires: admin token</div>
+      </div>
+
+      <h2>Authentication</h2>
+      <p>Use one of these tokens in the Authorization header:</p>
+      <ul>
+        <li><code>Bearer admin-token</code> - Admin access</li>
+        <li><code>Bearer user-token</code> - User access</li>
+      </ul>
+
+      <h2>Examples</h2>
+      <pre>
+# Public endpoint (no auth needed)
+curl http://localhost:8080/status
+
+# Private endpoint (auth required)
+curl -H "Authorization: Bearer user-token" http://localhost:8080/api/users
+      </pre>
+    </body>
+    </html>
+  `;
+  return c.html(html);
+});
+
+// Public static assets
+app.get("/public/*", async (c) => {
+  // In a real app, you'd serve actual files here
+  return c.json({
+    file: c.req.url,
+    message: "This would serve static files",
+    public: true,
+  });
+});
+
+// ===== PRIVATE ROUTES (Authentication Required) =====
+
+// Add custom routes for a REST API
+app.get("/api/users", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  const userList = Array.from(users.values());
+  return c.json({
+    authenticated_as: auth.userId,
+    count: userList.length,
+    role: auth.role,
+    users: userList,
+  });
+});
+
+app.get("/api/users/:id", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  const id = c.req.param("id");
+  const user = users.get(id);
+  if (!user) {
+    return c.json({ error: "User not found" }, 404);
+  }
+  return c.json(user);
+});
+
+app.post("/api/users", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  const body = (await c.req.json()) as { email: string; name: string };
+
+  if (!body.name || !body.email) {
+    return c.json({ error: "Name and email are required" }, 400);
+  }
+
+  const id = String(users.size + 1);
+  const newUser: User = {
+    email: body.email,
+    id,
+    name: body.name,
+  };
+
+  users.set(id, newUser);
+  return c.json(newUser, 201);
+});
+
+app.put("/api/users/:id", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  const id = c.req.param("id");
+  const user = users.get(id);
+  if (!user) {
+    return c.json({ error: "User not found" }, 404);
+  }
+
+  const body = (await c.req.json()) as Partial<User>;
+  const updatedUser = { ...user, ...body, id: user.id };
+  users.set(user.id, updatedUser);
+  return c.json(updatedUser);
+});
+
+app.delete("/api/users/:id", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  const id = c.req.param("id");
+  if (!users.has(id)) {
+    return c.json({ error: "User not found" }, 404);
+  }
+
+  users.delete(id);
+  return c.body(null, 204);
+});
+
+// Add a simple admin dashboard - requires admin role
+app.get("/admin", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  // Check for admin role
+  if (auth.role !== "admin") {
+    return c.json({ error: "Admin access required" }, 403);
+  }
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Admin Dashboard</title>
+      <style>
+        body { font-family: sans-serif; margin: 40px; }
+        h1 { color: #333; }
+        .stats { background: #f0f0f0; padding: 20px; border-radius: 8px; }
+        .stat { margin: 10px 0; }
+      </style>
+    </head>
+    <body>
+      <h1>Admin Dashboard</h1>
+      <div class="stats">
+        <div class="stat">Total Users: ${users.size}</div>
+        <div class="stat">Request Count: ${requestCount}</div>
+        <div class="stat">Server Time: ${new Date().toISOString()}</div>
+      </div>
+      <h2>Users</h2>
+      <ul>
+        ${Array.from(users.values())
+          .map((u) => `<li>${u.name} (${u.email})</li>`)
+          .join("")}
+      </ul>
+    </body>
+    </html>
+  `;
+  return c.html(html);
+});
+
+// Add a webhook endpoint
+app.post("/webhook/github", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  const payload = await c.req.json();
+  const event = c.req.header("x-github-event");
+
+  console.log(`GitHub webhook received: ${event}`, payload);
+
+  // Process webhook (e.g., trigger MCP tools)
+  return c.json({ event, received: true });
+});
+
+// Add a file upload endpoint
+app.post("/upload", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  try {
+    const body = await c.req.text();
+    const size = Buffer.byteLength(body);
+
+    return c.json({
+      message: "File received",
+      size: `${size} bytes`,
+    });
+  } catch (error) {
+    return c.json(
+      {
+        error: error instanceof Error ? error.message : "Upload failed",
+      },
+      500,
+    );
+  }
+});
+
+// Add middleware-like request counting
+app.get("/stats", async (c) => {
+  const auth = await getAuth(c);
+  if (!auth) {
+    return c.json({ error: "Authentication required" }, 401);
+  }
+
+  requestCount++;
+  return c.json({
+    requests: requestCount,
+    timestamp: Date.now(),
+    uptime: process.uptime(),
+  });
+});
+
+// Add MCP tools that can interact with the custom routes
+server.addTool({
+  description: "List all users from the REST API",
+  execute: async () => {
+    const userList = Array.from(users.values());
+    return {
+      content: [
+        {
+          text: `Found ${userList.length} users:\n${userList
+            .map((u) => `- ${u.name} (${u.email})`)
+            .join("\n")}`,
+          type: "text",
+        },
+      ],
+    };
+  },
+  name: "list_users",
+  parameters: z.object({}),
+});
+
+server.addTool({
+  description: "Create a new user via the REST API",
+  execute: async ({ email, name }) => {
+    const id = String(users.size + 1);
+    const newUser: User = { email, id, name };
+    users.set(id, newUser);
+
+    return {
+      content: [
+        {
+          text: `User created successfully:\nID: ${id}\nName: ${name}\nEmail: ${email}`,
+          type: "text",
+        },
+      ],
+    };
+  },
+  name: "create_user",
+  parameters: z.object({
+    email: z.string().email(),
+    name: z.string(),
+  }),
+});
+
+server.addTool({
+  description: "Get server statistics",
+  execute: async () => {
+    return {
+      content: [
+        {
+          text: `Server Statistics:
+- Total Users: ${users.size}
+- Request Count: ${requestCount}
+- Uptime: ${Math.floor(process.uptime())} seconds
+- Memory Usage: ${Math.round(process.memoryUsage().heapUsed / 1024 / 1024)} MB`,
+          type: "text",
+        },
+      ],
+    };
+  },
+  name: "get_stats",
+  parameters: z.object({}),
+});
+
+// Add a resource that exposes the user list
+server.addResource({
+  description: "Current user database",
+  load: async () => ({
+    text: JSON.stringify(Array.from(users.values()), null, 2),
+  }),
+  mimeType: "application/json",
+  name: "user-database",
+  uri: "resource://users",
+});
+
+// Start the server
+const PORT = process.env.FASTMCP_PORT
+  ? parseInt(process.env.FASTMCP_PORT)
+  : 8080;
+
+server
+  .start({
+    httpStream: { port: PORT },
+    transportType: "httpStream",
+  })
+  .then(() => {
+    console.log(`
+🚀 Custom Routes Example Server Started!
+
+MCP Endpoint: http://localhost:${PORT}/mcp
+Health Check: http://localhost:${PORT}/health
+
+PUBLIC ROUTES (No Authentication):
+- Status:       http://localhost:${PORT}/status
+- Docs:         http://localhost:${PORT}/docs
+- OAuth Config: http://localhost:${PORT}/.well-known/openid-configuration
+- Static Files: http://localhost:${PORT}/public/*
+
+PRIVATE ROUTES (Authentication Required):
+- REST API:     http://localhost:${PORT}/api/users
+- Admin Panel:  http://localhost:${PORT}/admin (admin only)
+- Statistics:   http://localhost:${PORT}/stats
+- File Upload:  http://localhost:${PORT}/upload
+- GitHub Hook:  http://localhost:${PORT}/webhook/github
+
+Authentication:
+Use "Authorization: Bearer admin-token" or "Bearer user-token"
+
+Try these commands:
+
+# Public routes (no auth needed)
+curl http://localhost:${PORT}/status
+curl http://localhost:${PORT}/docs
+curl http://localhost:${PORT}/.well-known/openid-configuration
+
+# Private routes (auth required)
+curl -H "Authorization: Bearer user-token" http://localhost:${PORT}/api/users
+curl -H "Authorization: Bearer admin-token" http://localhost:${PORT}/admin
+curl -X POST -H "Authorization: Bearer user-token" -H "Content-Type: application/json" \\
+     -d '{"name":"Charlie","email":"charlie@example.com"}' \\
+     http://localhost:${PORT}/api/users
+
+# Test authentication failure
+curl http://localhost:${PORT}/api/users  # Should return 401
+
+MCP Tools available:
+- list_users
+- create_user  
+- get_stats
+
+Test with MCP Inspector:
+npx fastmcp inspect src/examples/custom-routes.ts
+  `);
+  })
+  .catch((error) => {
+    console.error("Failed to start server:", error);
+    process.exit(1);
+  });

--- a/src/examples/edge-cloudflare-worker.ts
+++ b/src/examples/edge-cloudflare-worker.ts
@@ -1,0 +1,107 @@
+/**
+ * EdgeFastMCP - Cloudflare Workers Example
+ *
+ * This example demonstrates how to use FastMCP on Cloudflare Workers
+ * using the edge-compatible module.
+ *
+ * To deploy:
+ * 1. Copy this file to your Cloudflare Workers project
+ * 2. Install fastmcp: npm install fastmcp
+ * 3. Change the import to: import { EdgeFastMCP } from "fastmcp/edge";
+ * 4. Create a wrangler.toml with:
+ *    name = "my-mcp-server"
+ *    main = "src/index.ts"
+ *    compatibility_date = "2024-11-01"
+ * 5. Deploy with: npx wrangler deploy
+ */
+
+import { z } from "zod";
+
+// NOTE: In your deployed project, use: import { EdgeFastMCP } from "fastmcp/edge";
+import { EdgeFastMCP } from "../edge/index.js";
+
+// Create the edge-compatible MCP server
+const server = new EdgeFastMCP({
+  description: "An MCP server running on Cloudflare Workers",
+  name: "CloudflareWorkerMCP",
+  version: "1.0.0",
+});
+
+// Add a simple tool
+server.addTool({
+  description: "Greet someone by name",
+  execute: async ({ name }) => {
+    return `Hello, ${name}! This response is from a Cloudflare Worker.`;
+  },
+  name: "greet",
+  parameters: z.object({
+    name: z.string().describe("The name to greet"),
+  }),
+});
+
+// Add a tool that returns structured content
+server.addTool({
+  description: "Get weather information for a location",
+  execute: async ({ location }) => {
+    // In a real app, you would call a weather API here
+    return {
+      content: [
+        {
+          text: `Weather for ${location}:\n- Temperature: 72°F\n- Conditions: Sunny\n- Humidity: 45%`,
+          type: "text",
+        },
+      ],
+    };
+  },
+  name: "get_weather",
+  parameters: z.object({
+    location: z.string().describe("The city or location"),
+  }),
+});
+
+// Add a static resource
+server.addResource({
+  description: "Information about this MCP server",
+  load: async () => {
+    return "This is a FastMCP server running on Cloudflare Workers edge runtime.";
+  },
+  mimeType: "text/plain",
+  name: "Server Info",
+  uri: "info://server",
+});
+
+// Add a prompt template
+server.addPrompt({
+  arguments: [
+    { description: "Programming language", name: "language", required: true },
+    {
+      description: "What to focus on (optional)",
+      name: "focus",
+      required: false,
+    },
+  ],
+  description: "Generate a prompt to analyze code",
+  load: async (args) => {
+    const focus = args.focus ? ` focusing on ${args.focus}` : "";
+    return {
+      messages: [
+        {
+          content: {
+            text: `Please analyze the following ${args.language} code${focus}:`,
+            type: "text",
+          },
+          role: "user",
+        },
+      ],
+    };
+  },
+  name: "analyze_code",
+});
+
+// Export the server as the default (Cloudflare Workers format)
+export default server;
+
+// Alternative: You can also access the underlying Hono app for custom routes
+// const app = server.getApp();
+// app.get("/custom", (c) => c.text("Custom route!"));
+// export default { fetch: (req) => server.fetch(req) };


### PR DESCRIPTION
  This adds edge runtime support via EdgeFastMCP and custom HTTP routes for both FastMCP and EdgeFastMCP.                                                                                                                                
                                                                                                                                                                                                                                         
  What's included:                                                                                                                                                                                                                       
                                                                                                                                                                                                                                         
  1. EdgeFastMCP (fastmcp/edge) - Deploy MCP servers to Cloudflare Workers, Deno Deploy, and other V8 isolate environments                                                                                                               
  2. Custom HTTP routes - server.getApp() returns the Hono instance for adding REST endpoints, webhooks, and admin interfaces alongside MCP                                                                                              
  3. Public routes - Routes can bypass authentication for OAuth discovery, health checks, and static assets                                                                                                                              
                                                                                                                                                                                                                                         
  Both classes use Hono internally, so EdgeFastMCP gets the same ergonomic API. EdgeFastMCP is stateless-only and doesn't include built-in auth yet (i.e., it was written before OAuth was added to FastMCP). That's documented as a     
  planned enhancement—PRs welcome.                                                                                                                                                                                                       
                                                                                                                                                                                                                                         
  Demo: https://fastmcp.jordanhburke.com/                                                                                                                                                                                                
                                                                                                                                                                                                                                         
  Addresses #136, #160                                                                                                                                                                                                                   
                                                                                                                                                                                                                                         
  Test plan                                                                                                                                                                                                                              
                                                                                                                                                                                                                                         
  - pnpm test passes (326 tests across 20 files)                                                                                                                                                                                         
  - Edge tests pass (src/edge/edge.test.ts)                                                                                                                                                                                              
  - Routes tests pass (src/FastMCP.routes.test.ts)  