### PR TITLE
feat: add ext-apps _meta support for interactive UI components

### DIFF
--- a/src/FastMCP.ext-apps.test.ts
+++ b/src/FastMCP.ext-apps.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for MCP ext-apps _meta field support (issue #229)
+ *
+ * These tests verify that the _meta field is properly passed through
+ * in tool listings, enabling MCP ext-apps interactive UI components.
+ *
+ * @see https://github.com/punkpeye/fastmcp/issues/229
+ * @see https://modelcontextprotocol.github.io/ext-apps/
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { getRandomPort } from "get-port-please";
+import { expect, test } from "vitest";
+import { z } from "zod";
+
+import { FastMCP, FastMCPSession } from "./FastMCP.js";
+
+const runWithTestServer = async ({
+  client: createClient,
+  run,
+  server: createServer,
+}: {
+  client?: () => Promise<Client>;
+  run: ({
+    client,
+    server,
+  }: {
+    client: Client;
+    server: FastMCP;
+    session: FastMCPSession;
+  }) => Promise<void>;
+  server?: () => Promise<FastMCP>;
+}) => {
+  const port = await getRandomPort();
+
+  const server = createServer
+    ? await createServer()
+    : new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+  await server.start({
+    httpStream: {
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const client = createClient
+      ? await createClient()
+      : new Client(
+          {
+            name: "example-client",
+            version: "1.0.0",
+          },
+          {
+            capabilities: {},
+          },
+        );
+
+    const transport = new SSEClientTransport(
+      new URL(`http://localhost:${port}/sse`),
+    );
+
+    const session = await new Promise<FastMCPSession>((resolve) => {
+      server.on("connect", async (event) => {
+        await event.session.waitForReady();
+        resolve(event.session);
+      });
+
+      client.connect(transport);
+    });
+
+    await run({ client, server, session });
+  } finally {
+    await server.stop();
+  }
+
+  return port;
+};
+
+test("includes _meta.ui.resourceUri in tool listing", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const result = await client.listTools();
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools[0]).toMatchObject({
+        _meta: {
+          ui: {
+            resourceUri: "ui://greet-user/app.html",
+          },
+        },
+        description: "Greet a user with interactive UI",
+        name: "greet-user",
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        _meta: {
+          ui: {
+            resourceUri: "ui://greet-user/app.html",
+          },
+        },
+        description: "Greet a user with interactive UI",
+        execute: async (args) => {
+          return `Hello, ${args.name}!`;
+        },
+        name: "greet-user",
+        parameters: z.object({
+          name: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("tool without _meta works correctly", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const result = await client.listTools();
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools[0]).toMatchObject({
+        description: "Add two numbers",
+        name: "add",
+      });
+      // _meta should not be present
+      expect(result.tools[0]).not.toHaveProperty("_meta");
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Add two numbers",
+        execute: async (args) => {
+          return String(args.a + args.b);
+        },
+        name: "add",
+        parameters: z.object({
+          a: z.number(),
+          b: z.number(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("preserves arbitrary _meta fields", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const result = await client.listTools();
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools[0]._meta).toEqual({
+        customField: "custom-value",
+        nested: {
+          deep: true,
+        },
+        ui: {
+          resourceUri: "ui://custom-tool/app.html",
+        },
+        version: 2,
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        _meta: {
+          customField: "custom-value",
+          nested: {
+            deep: true,
+          },
+          ui: {
+            resourceUri: "ui://custom-tool/app.html",
+          },
+          version: 2,
+        },
+        description: "Tool with custom metadata",
+        execute: async () => {
+          return "result";
+        },
+        name: "custom-tool",
+      });
+
+      return server;
+    },
+  });
+});
+
+test("multiple tools with and without _meta", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const result = await client.listTools();
+      expect(result.tools).toHaveLength(3);
+
+      // Tool with _meta
+      const toolWithMeta = result.tools.find((t) => t.name === "tool-with-ui");
+      expect(toolWithMeta?._meta).toEqual({
+        ui: { resourceUri: "ui://tool-with-ui/app.html" },
+      });
+
+      // Tool without _meta
+      const toolWithoutMeta = result.tools.find(
+        (t) => t.name === "tool-without-ui",
+      );
+      expect(toolWithoutMeta).not.toHaveProperty("_meta");
+
+      // Another tool with different _meta
+      const anotherTool = result.tools.find(
+        (t) => t.name === "another-ui-tool",
+      );
+      expect(anotherTool?._meta).toEqual({
+        category: "dashboard",
+        ui: { resourceUri: "ui://another/dashboard.html" },
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        _meta: {
+          ui: { resourceUri: "ui://tool-with-ui/app.html" },
+        },
+        description: "Tool with UI",
+        execute: async () => "result",
+        name: "tool-with-ui",
+      });
+
+      server.addTool({
+        description: "Tool without UI",
+        execute: async () => "result",
+        name: "tool-without-ui",
+      });
+
+      server.addTool({
+        _meta: {
+          category: "dashboard",
+          ui: { resourceUri: "ui://another/dashboard.html" },
+        },
+        description: "Another tool with UI",
+        execute: async () => "result",
+        name: "another-ui-tool",
+      });
+
+      return server;
+    },
+  });
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -902,6 +902,20 @@ type Tool<
   T extends FastMCPSessionAuth,
   Params extends ToolParameters = ToolParameters,
 > = {
+  /**
+   * MCP ext-apps metadata for linking interactive UI components.
+   * This field is passed through to the tool listing response.
+   * @see https://modelcontextprotocol.github.io/ext-apps/
+   */
+  _meta?: {
+    /** Additional metadata fields */
+    [key: string]: unknown;
+    /** UI component configuration */
+    ui?: {
+      /** URI of the resource serving the UI (e.g., "ui://my-tool/app.html") */
+      resourceUri?: string;
+    };
+  };
   annotations?: {
     /**
      * When true, the tool leverages incremental content streaming
@@ -910,8 +924,8 @@ type Tool<
     streamingHint?: boolean;
   } & ToolAnnotations;
   canAccess?: (auth: T) => boolean;
-  description?: string;
 
+  description?: string;
   execute: (
     args: StandardSchemaV1.InferOutput<Params>,
     context: Context<T>,
@@ -1899,6 +1913,8 @@ export class FastMCPSession<
                   type: "object",
                 }) as SDKTool["inputSchema"],
             name: tool.name,
+            // Pass through _meta for MCP ext-apps UI support (issue #229)
+            ...(tool._meta && { _meta: tool._meta }),
           };
         }),
       );


### PR DESCRIPTION
Fixes #229

## Summary

Adds support for MCP ext-apps interactive UI components by preserving the `_meta` field in tool definitions.

## Changes

- Add `_meta` field to `Tool` interface type definition
- Pass through `_meta` in `setupToolHandlers` when present
- Add 4 comprehensive tests for `_meta` field preservation

## Testing

- [x] All 328 tests pass
- [x] Linting passes
- [x] Build succeeds