### PR TITLE
fix(oauth): coerce `expires_in` to number in token response parsing

### DIFF
--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -1142,9 +1142,9 @@ export class OAuthProxy {
     // Define Zod schema for token response validation
     const tokenResponseSchema = z.object({
       access_token: z.string().min(1, "access_token cannot be empty"),
-      expires_in: z.number().int().positive().optional(),
+      expires_in: z.coerce.number().int().positive().optional(),
       id_token: z.string().optional(),
-      refresh_expires_in: z.number().int().positive().optional(),
+      refresh_expires_in: z.coerce.number().int().positive().optional(),
       refresh_token: z.string().optional(),
       scope: z.string().optional(),
       token_type: z.string().optional(),


### PR DESCRIPTION
Some OAuth providers (e.g. SAP) return `expires_in` as a string `"3600"` instead of a number `3600`. While [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749#appendix-A.14) specifies `expires_in` as `1*DIGIT` (implying a number), SAP apparently interprets RFCs more as "suggestions" than "specifications" :)

Use `z.coerce.number()` instead of `z.number()` to handle both string and number values gracefully. This matches the existing behavior for URL-encoded form responses which already use `parseInt()`

Edit: Acknowledged as a bug in [SAP Note 3428084](https://me.sap.com/notes/3428084) (Feb 2024)