### PR TITLE
fix(edge): use LATEST_PROTOCOL_VERSION and fix Zod 4 schema conversion

### DIFF
--- a/src/edge/edge.test.ts
+++ b/src/edge/edge.test.ts
@@ -1,3 +1,4 @@
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
@@ -22,7 +23,7 @@ describe("EdgeFastMCP", () => {
           params: {
             capabilities: {},
             clientInfo: { name: "test-client", version: "1.0.0" },
-            protocolVersion: "2024-11-05",
+            protocolVersion: LATEST_PROTOCOL_VERSION,
           },
         }),
         headers: {

--- a/src/edge/index.ts
+++ b/src/edge/index.ts
@@ -23,7 +23,11 @@
  * ```
  */
 
-import { ErrorCode, JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ErrorCode,
+  JSONRPCMessage,
+  LATEST_PROTOCOL_VERSION,
+} from "@modelcontextprotocol/sdk/types.js";
 import { StandardSchemaV1 } from "@standard-schema/spec";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -209,7 +213,7 @@ export class EdgeFastMCP {
           resources: this.#resources.length > 0 ? {} : undefined,
           tools: this.#tools.length > 0 ? {} : undefined,
         },
-        protocolVersion: "2024-11-05",
+        protocolVersion: LATEST_PROTOCOL_VERSION,
         serverInfo: {
           name: this.#name,
           version: this.#version,
@@ -570,7 +574,13 @@ export class EdgeFastMCP {
     schema: StandardSchemaV1 | z.ZodType,
   ): Record<string, unknown> {
     try {
-      // Check if it's a Zod schema by looking for Zod-specific properties
+      // Zod 4+: use native toJSONSchema if available
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if (typeof (z as any).toJSONSchema === "function") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (z as any).toJSONSchema(schema) as Record<string, unknown>;
+      }
+      // Zod 3 fallback: use zod-to-json-schema
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       if ("_def" in (schema as any) || schema instanceof z.ZodType) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Problem

After deploying an EdgeFastMCP server to Cloudflare Workers, MCP clients (Claude Code, etc.) fail to connect with two issues:

1. **Stale protocol version**: `EdgeFastMCP` hardcodes `protocolVersion: "2024-11-05"` instead of using the SDK's `LATEST_PROTOCOL_VERSION` constant. The SDK has since bumped to `"2025-11-25"`, so clients reject the outdated version during initialization.

2. **Empty tool schemas**: `zod-to-json-schema` does not support Zod 4 and silently returns `{}` for `inputSchema`, making all tools unusable. Clients see tools with no parameters and can't invoke them.

Neither issue affects the non-edge `FastMCP` class, which delegates to the SDK's `Server` for protocol negotiation and schema handling.

## Fix

- Import and use `LATEST_PROTOCOL_VERSION` from `@modelcontextprotocol/sdk/types.js` instead of the hardcoded string
- Use Zod 4's native `z.toJSONSchema()` when available, falling back to `zod-to-json-schema` for Zod 3 compatibility

## Testing

- All 328 existing tests pass
- Updated the edge test to use `LATEST_PROTOCOL_VERSION`
- Verified on a live Cloudflare Workers deployment — clients now connect and tools return full `inputSchema`