### PR TITLE
feat: add OpenAPI-to-MCP converter (fromOpenAPI) — closes #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,6 +1394,54 @@ server.addTool({
 });
 ```
 
+
+### OpenAPI Integration
+
+Automatically convert any [OpenAPI 3.x](https://swagger.io/specification/) specification into MCP tools, resources, and resource templates:
+
+```typescript
+import { FastMCP } from "fastmcp";
+import { fromOpenAPI } from "fastmcp/openapi";
+
+const spec = JSON.parse(fs.readFileSync("openapi.json", "utf-8"));
+
+const { tools, resources, resourceTemplates } = fromOpenAPI({
+  spec,
+  client: {
+    request: async (config) => {
+      const res = await fetch(config.url, {
+        method: config.method,
+        headers: config.headers,
+        body: config.body ? JSON.stringify(config.body) : undefined,
+      });
+      return { status: res.status, data: await res.json() };
+    },
+  },
+});
+
+const server = new FastMCP({ name: "My API", version: "1.0.0" });
+
+for (const tool of tools) server.addTool(tool);
+for (const resource of resources) server.addResource(resource);
+for (const template of resourceTemplates) server.addResourceTemplate(template);
+
+server.start({ transportType: "stdio" });
+```
+
+Routes are classified automatically:
+- `GET` without path params → **Resource**
+- `GET` with path params → **Resource Template**
+- `POST`/`PUT`/`PATCH`/`DELETE` → **Tool**
+
+Features:
+- Zero external dependencies (inline OpenAPI types)
+- Full `$ref` resolution
+- Request body flattening with `body_` prefix
+- Pluggable HTTP client (bring your own `fetch`/`axios`)
+- Custom base URL and default headers (e.g., for auth)
+
+For detailed documentation, see [OpenAPI Integration Guide](./docs/openapi.md).
+
 ### Prompts
 
 [Prompts](https://modelcontextprotocol.io/docs/concepts/prompts) enable servers to define reusable prompt templates and workflows that clients can easily surface to users and LLMs. They provide a powerful way to standardize and share common LLM interactions.

--- a/README.md
+++ b/README.md
@@ -1394,7 +1394,6 @@ server.addTool({
 });
 ```
 
-
 ### OpenAPI Integration
 
 Automatically convert any [OpenAPI 3.x](https://swagger.io/specification/) specification into MCP tools, resources, and resource templates:
@@ -1429,11 +1428,13 @@ server.start({ transportType: "stdio" });
 ```
 
 Routes are classified automatically:
+
 - `GET` without path params → **Resource**
 - `GET` with path params → **Resource Template**
 - `POST`/`PUT`/`PATCH`/`DELETE` → **Tool**
 
 Features:
+
 - Zero external dependencies (inline OpenAPI types)
 - Full `$ref` resolution
 - Request body flattening with `body_` prefix

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,0 +1,345 @@
+# OpenAPI Integration
+
+FastMCP can automatically convert any [OpenAPI 3.x](https://swagger.io/specification/) specification into MCP tools, resources, and resource templates — allowing you to expose any REST API to LLMs without writing individual tool definitions.
+
+## Quick Start
+
+```typescript
+import { FastMCP } from "fastmcp";
+import { fromOpenAPI } from "fastmcp/openapi";
+import fs from "node:fs";
+
+// Load your OpenAPI spec
+const spec = JSON.parse(fs.readFileSync("openapi.json", "utf-8"));
+
+// Convert to MCP definitions
+const { tools, resources, resourceTemplates } = fromOpenAPI({
+  spec,
+  client: {
+    request: async (config) => {
+      const res = await fetch(config.url, {
+        method: config.method,
+        headers: config.headers,
+        body: config.body ? JSON.stringify(config.body) : undefined,
+      });
+      return { status: res.status, data: await res.json() };
+    },
+  },
+});
+
+// Register with FastMCP
+const server = new FastMCP({ name: "My API", version: "1.0.0" });
+
+for (const tool of tools) {
+  server.addTool(tool);
+}
+
+for (const resource of resources) {
+  server.addResource(resource);
+}
+
+for (const template of resourceTemplates) {
+  server.addResourceTemplate(template);
+}
+
+server.start({ transportType: "stdio" });
+```
+
+## How Routes Are Classified
+
+`fromOpenAPI` automatically classifies each OpenAPI operation:
+
+| HTTP Method | Path Parameters | MCP Type |
+|---|---|---|
+| `GET` | None | **Resource** — static data the LLM can read |
+| `GET` | Has `{params}` | **Resource Template** — parameterized data |
+| `POST`, `PUT`, `PATCH`, `DELETE` | Any | **Tool** — an action the LLM can invoke |
+
+For example, given this OpenAPI spec:
+
+```yaml
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+  /pets/{petId}:
+    get:
+      operationId: getPet
+      summary: Get a pet by ID
+      parameters:
+        - name: petId
+          in: path
+    delete:
+      operationId: deletePet
+      summary: Delete a pet
+      parameters:
+        - name: petId
+          in: path
+```
+
+`fromOpenAPI` produces:
+- **Resource**: `listPets` (URI: `api:///pets`)
+- **Resource Template**: `getPet` (URI template: `api:///pets/{petId}`)
+- **Tool**: `deletePet`
+
+## Options
+
+### `spec` (required)
+
+The parsed OpenAPI 3.x specification object.
+
+```typescript
+const spec = JSON.parse(fs.readFileSync("openapi.json", "utf-8"));
+```
+
+### `client` (required)
+
+An HTTP client implementing the `HttpClient` interface. This is how `fromOpenAPI` makes requests to the underlying API.
+
+```typescript
+type HttpClient = {
+  request: (config: {
+    url: string;
+    method: string;
+    headers?: Record<string, string>;
+    body?: unknown;
+  }) => Promise<{ status: number; data: unknown }>;
+};
+```
+
+You can use `fetch`, `axios`, or any HTTP library:
+
+**Using fetch:**
+```typescript
+const client = {
+  request: async (config) => {
+    const res = await fetch(config.url, {
+      method: config.method,
+      headers: config.headers,
+      body: config.body ? JSON.stringify(config.body) : undefined,
+    });
+    return { status: res.status, data: await res.json() };
+  },
+};
+```
+
+**Using axios:**
+```typescript
+import axios from "axios";
+
+const client = {
+  request: async (config) => {
+    const res = await axios({
+      url: config.url,
+      method: config.method,
+      headers: config.headers,
+      data: config.body,
+    });
+    return { status: res.status, data: res.data };
+  },
+};
+```
+
+### `baseUrl` (optional)
+
+Override the base URL for API requests. If not provided, uses the first `servers[].url` from the spec, or falls back to `http://localhost`.
+
+```typescript
+const { tools } = fromOpenAPI({
+  spec,
+  client,
+  baseUrl: "https://api.example.com/v2",
+});
+```
+
+### `headers` (optional)
+
+Default headers to include with every request. Useful for authentication:
+
+```typescript
+const { tools } = fromOpenAPI({
+  spec,
+  client,
+  headers: {
+    Authorization: "Bearer sk-...",
+    "X-API-Key": "my-key",
+  },
+});
+```
+
+## Parameter Handling
+
+### Path Parameters
+
+Path parameters are automatically substituted into the URL:
+
+```
+GET /pets/{petId} + { petId: "123" } → GET /pets/123
+```
+
+### Query Parameters
+
+Query parameters are appended to the URL:
+
+```
+GET /pets?limit=10&status=available
+```
+
+### Header Parameters
+
+Header parameters defined in the OpenAPI spec are extracted from tool arguments and sent as HTTP headers.
+
+### Request Body
+
+For operations with a request body, the body properties are flattened into the tool parameters with a `body_` prefix to avoid name collisions with path/query parameters:
+
+```yaml
+# OpenAPI spec
+paths:
+  /pets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                tag:
+                  type: string
+```
+
+The tool will accept `body_name` and `body_tag` parameters, which are reassembled into the request body:
+
+```typescript
+// LLM calls tool with: { body_name: "Fido", body_tag: "dog" }
+// Request body sent:   { name: "Fido", tag: "dog" }
+```
+
+## `$ref` Resolution
+
+`fromOpenAPI` fully resolves `$ref` references within the spec, including:
+
+- Schema references (`$ref: "#/components/schemas/Pet"`)
+- Parameter references (`$ref: "#/components/parameters/PetId"`)
+- Request body references (`$ref: "#/components/requestBodies/PetBody"`)
+
+Circular references are handled gracefully.
+
+## Full Example: Petstore API
+
+```typescript
+import { FastMCP } from "fastmcp";
+import { fromOpenAPI } from "fastmcp/openapi";
+
+const petstoreSpec = {
+  openapi: "3.0.0",
+  info: { title: "Petstore", version: "1.0.0" },
+  servers: [{ url: "https://petstore.example.com" }],
+  paths: {
+    "/pets": {
+      get: {
+        operationId: "listPets",
+        summary: "List all pets",
+        parameters: [
+          { name: "limit", in: "query", schema: { type: "integer" } },
+        ],
+      },
+      post: {
+        operationId: "createPet",
+        summary: "Create a pet",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  tag: { type: "string" },
+                },
+                required: ["name"],
+              },
+            },
+          },
+        },
+      },
+    },
+    "/pets/{petId}": {
+      get: {
+        operationId: "getPet",
+        summary: "Get a pet by ID",
+        parameters: [
+          { name: "petId", in: "path", required: true, schema: { type: "string" } },
+        ],
+      },
+    },
+  },
+};
+
+const { tools, resources, resourceTemplates } = fromOpenAPI({
+  spec: petstoreSpec,
+  client: {
+    request: async (config) => {
+      const res = await fetch(config.url, {
+        method: config.method,
+        headers: config.headers,
+        body: config.body ? JSON.stringify(config.body) : undefined,
+      });
+      return { status: res.status, data: await res.json() };
+    },
+  },
+});
+
+const server = new FastMCP({ name: "Petstore MCP", version: "1.0.0" });
+
+// Registers: listPets (resource), getPet (resource template), createPet (tool)
+for (const tool of tools) server.addTool(tool);
+for (const resource of resources) server.addResource(resource);
+for (const template of resourceTemplates) server.addResourceTemplate(template);
+
+server.start({ transportType: "stdio" });
+```
+
+## API Reference
+
+### `fromOpenAPI(options)`
+
+Converts an OpenAPI spec into FastMCP-compatible definitions.
+
+**Parameters:**
+- `options.spec` — `OpenAPIDocument` — Parsed OpenAPI 3.x spec
+- `options.client` — `HttpClient` — HTTP client for making requests
+- `options.baseUrl` — `string` (optional) — Override the API base URL
+- `options.headers` — `Record<string, string>` (optional) — Default request headers
+
+**Returns:**
+```typescript
+{
+  tools: Array<{
+    name: string;
+    description: string;
+    parameters: JsonSchema;
+    execute: (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
+  }>;
+  resources: Array<{
+    name: string;
+    description: string;
+    uri: string;
+    read: () => Promise<{ text: string }>;
+  }>;
+  resourceTemplates: Array<{
+    name: string;
+    description: string;
+    uriTemplate: string;
+    read: (args: Record<string, unknown>) => Promise<{ text: string }>;
+  }>;
+}
+```
+
+### Exported Types
+
+```typescript
+import type { FromOpenAPIOptions, HttpClient } from "fastmcp/openapi";
+import type { OpenAPIDocument, OpenAPIRoute } from "fastmcp/openapi";
+```

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -49,11 +49,11 @@ server.start({ transportType: "stdio" });
 
 `fromOpenAPI` automatically classifies each OpenAPI operation:
 
-| HTTP Method | Path Parameters | MCP Type |
-|---|---|---|
-| `GET` | None | **Resource** — static data the LLM can read |
-| `GET` | Has `{params}` | **Resource Template** — parameterized data |
-| `POST`, `PUT`, `PATCH`, `DELETE` | Any | **Tool** — an action the LLM can invoke |
+| HTTP Method                      | Path Parameters | MCP Type                                    |
+| -------------------------------- | --------------- | ------------------------------------------- |
+| `GET`                            | None            | **Resource** — static data the LLM can read |
+| `GET`                            | Has `{params}`  | **Resource Template** — parameterized data  |
+| `POST`, `PUT`, `PATCH`, `DELETE` | Any             | **Tool** — an action the LLM can invoke     |
 
 For example, given this OpenAPI spec:
 
@@ -79,6 +79,7 @@ paths:
 ```
 
 `fromOpenAPI` produces:
+
 - **Resource**: `listPets` (URI: `api:///pets`)
 - **Resource Template**: `getPet` (URI template: `api:///pets/{petId}`)
 - **Tool**: `deletePet`
@@ -111,6 +112,7 @@ type HttpClient = {
 You can use `fetch`, `axios`, or any HTTP library:
 
 **Using fetch:**
+
 ```typescript
 const client = {
   request: async (config) => {
@@ -125,6 +127,7 @@ const client = {
 ```
 
 **Using axios:**
+
 ```typescript
 import axios from "axios";
 
@@ -270,7 +273,12 @@ const petstoreSpec = {
         operationId: "getPet",
         summary: "Get a pet by ID",
         parameters: [
-          { name: "petId", in: "path", required: true, schema: { type: "string" } },
+          {
+            name: "petId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
         ],
       },
     },
@@ -308,19 +316,23 @@ server.start({ transportType: "stdio" });
 Converts an OpenAPI spec into FastMCP-compatible definitions.
 
 **Parameters:**
+
 - `options.spec` — `OpenAPIDocument` — Parsed OpenAPI 3.x spec
 - `options.client` — `HttpClient` — HTTP client for making requests
 - `options.baseUrl` — `string` (optional) — Override the API base URL
 - `options.headers` — `Record<string, string>` (optional) — Default request headers
 
 **Returns:**
+
 ```typescript
 {
   tools: Array<{
     name: string;
     description: string;
     parameters: JsonSchema;
-    execute: (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
+    execute: (
+      args: Record<string, unknown>,
+    ) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
   }>;
   resources: Array<{
     name: string;

--- a/src/fromOpenAPI.ts
+++ b/src/fromOpenAPI.ts
@@ -1,0 +1,279 @@
+import { buildToolParameters, classifyRoute, extractRoutes } from "./openapi.js";
+import type { OpenAPIDocument, OpenAPIRoute } from "./openapi.js";
+
+type HttpClient = {
+  request: (config: {
+    body?: unknown;
+    headers?: Record<string, string>;
+    method: string;
+    url: string;
+  }) => Promise<{ data: unknown; status: number }>;
+};
+
+type FromOpenAPIOptions = {
+  /**
+   * HTTP client to use for making API requests.
+   * Must implement a request() method.
+   */
+  client: HttpClient;
+
+  /**
+   * Headers to include with every request (e.g., auth).
+   */
+  headers?: Record<string, string>;
+
+  /**
+   * Base URL for the API.
+   * If not provided, uses the first server URL from the spec.
+   */
+  baseUrl?: string;
+
+  /**
+   * OpenAPI specification object (parsed JSON).
+   */
+  spec: OpenAPIDocument;
+};
+
+/**
+ * Substitute path parameters into a URL template.
+ * e.g., "/pets/{petId}" + {petId: "123"} -> "/pets/123"
+ */
+function substitutePathParams(
+  pathTemplate: string,
+  params: Record<string, unknown>,
+): string {
+  return pathTemplate.replace(/\{(\w+)\}/g, (_, key) => {
+    const value = params[key];
+    return value !== undefined ? encodeURIComponent(String(value)) : `{${key}}`;
+  });
+}
+
+/**
+ * Build the full URL for a route, including query parameters.
+ */
+function buildUrl(
+  baseUrl: string,
+  route: OpenAPIRoute,
+  args: Record<string, unknown>,
+): string {
+  const path = substitutePathParams(route.path, args);
+  const url = new URL(path, baseUrl);
+
+  for (const param of route.parameters) {
+    if (param.in === "query" && args[param.name] !== undefined) {
+      url.searchParams.set(param.name, String(args[param.name]));
+    }
+  }
+
+  return url.toString();
+}
+
+/**
+ * Extract headers from route parameters and arguments.
+ */
+function extractHeaders(
+  route: OpenAPIRoute,
+  args: Record<string, unknown>,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const param of route.parameters) {
+    if (param.in === "header" && args[param.name] !== undefined) {
+      headers[param.name] = String(args[param.name]);
+    }
+  }
+  return headers;
+}
+
+/**
+ * Extract body fields from arguments.
+ * Body fields are prefixed with "body_" when flattened.
+ */
+function extractBody(
+  args: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const bodyFields: Record<string, unknown> = {};
+  let hasBody = false;
+
+  for (const [key, value] of Object.entries(args)) {
+    if (key === "body") {
+      return value as Record<string, unknown>;
+    }
+    if (key.startsWith("body_")) {
+      bodyFields[key.slice(5)] = value;
+      hasBody = true;
+    }
+  }
+
+  return hasBody ? bodyFields : undefined;
+}
+
+/**
+ * Create an MCP tool handler for an OpenAPI route.
+ */
+function createToolHandler(
+  route: OpenAPIRoute,
+  baseUrl: string,
+  client: HttpClient,
+  defaultHeaders: Record<string, string>,
+) {
+  return async (args: Record<string, unknown>) => {
+    const url = buildUrl(baseUrl, route, args);
+    const routeHeaders = extractHeaders(route, args);
+    const body = extractBody(args);
+
+    const response = await client.request({
+      body: body,
+      headers: {
+        "Content-Type": "application/json",
+        ...defaultHeaders,
+        ...routeHeaders,
+      },
+      method: route.method.toUpperCase(),
+      url,
+    });
+
+    return {
+      content: [
+        {
+          text: typeof response.data === "string"
+            ? response.data
+            : JSON.stringify(response.data, null, 2),
+          type: "text" as const,
+        },
+      ],
+    };
+  };
+}
+
+/**
+ * Create an MCP resource handler for an OpenAPI GET route.
+ */
+function createResourceHandler(
+  route: OpenAPIRoute,
+  baseUrl: string,
+  client: HttpClient,
+  defaultHeaders: Record<string, string>,
+) {
+  return async () => {
+    const url = buildUrl(baseUrl, route, {});
+
+    const response = await client.request({
+      headers: {
+        "Content-Type": "application/json",
+        ...defaultHeaders,
+      },
+      method: "GET",
+      url,
+    });
+
+    return {
+      text: typeof response.data === "string"
+        ? response.data
+        : JSON.stringify(response.data, null, 2),
+    };
+  };
+}
+
+/**
+ * Convert an OpenAPI spec into FastMCP-compatible tool, resource,
+ * and resource template definitions.
+ *
+ * @example
+ * ```ts
+ * import { FastMCP } from "fastmcp";
+ * import { fromOpenAPI } from "fastmcp/openapi";
+ *
+ * const spec = JSON.parse(fs.readFileSync("openapi.json", "utf-8"));
+ * const { tools, resources, resourceTemplates } = fromOpenAPI({
+ *   spec,
+ *   client: { request: (config) => fetch(config.url, config).then(async r => ({ status: r.status, data: await r.json() })) },
+ * });
+ *
+ * const mcp = new FastMCP({ name: "My API", version: "1.0.0" });
+ * tools.forEach(t => mcp.addTool(t));
+ * resources.forEach(r => mcp.addResource(r));
+ * ```
+ */
+export function fromOpenAPI(options: FromOpenAPIOptions) {
+  const { client, headers = {}, spec } = options;
+  const baseUrl = options.baseUrl ??
+    (spec as Record<string, unknown> & { servers?: Array<{ url: string }> }).servers?.[0]?.url ??
+    "http://localhost";
+
+  const routes = extractRoutes(spec);
+  const tools: Array<{
+    description: string;
+    execute: (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
+    name: string;
+    parameters: ReturnType<typeof buildToolParameters>["jsonSchema"];
+  }> = [];
+
+  const resources: Array<{
+    description: string;
+    name: string;
+    read: () => Promise<{ text: string }>;
+    uri: string;
+  }> = [];
+
+  const resourceTemplates: Array<{
+    description: string;
+    name: string;
+    read: (args: Record<string, unknown>) => Promise<{ text: string }>;
+    uriTemplate: string;
+  }> = [];
+
+  for (const route of routes) {
+    const classification = classifyRoute(route);
+    const params = buildToolParameters(spec, route);
+
+    switch (classification) {
+      case "tool": {
+        tools.push({
+          description: route.description,
+          execute: createToolHandler(route, baseUrl, client, headers),
+          name: route.operationId,
+          parameters: params.jsonSchema,
+        });
+        break;
+      }
+      case "resource": {
+        resources.push({
+          description: route.description,
+          name: route.operationId,
+          read: createResourceHandler(route, baseUrl, client, headers),
+          uri: `api://${route.path}`,
+        });
+        break;
+      }
+      case "resourceTemplate": {
+        const templateUri = route.path.replace(/\{(\w+)\}/g, "{$1}");
+        resourceTemplates.push({
+          description: route.description,
+          name: route.operationId,
+          read: async (args: Record<string, unknown>) => {
+            const url = buildUrl(baseUrl, route, args);
+            const response = await client.request({
+              headers: {
+                "Content-Type": "application/json",
+                ...headers,
+              },
+              method: "GET",
+              url,
+            });
+            return {
+              text: typeof response.data === "string"
+                ? response.data
+                : JSON.stringify(response.data, null, 2),
+            };
+          },
+          uriTemplate: `api://${templateUri}`,
+        });
+        break;
+      }
+    }
+  }
+
+  return { resources, resourceTemplates, tools };
+}
+
+export type { FromOpenAPIOptions, HttpClient };

--- a/src/fromOpenAPI.ts
+++ b/src/fromOpenAPI.ts
@@ -1,20 +1,18 @@
+import type { OpenAPIDocument, OpenAPIRoute } from "./openapi.js";
+
 import {
   buildToolParameters,
   classifyRoute,
   extractRoutes,
 } from "./openapi.js";
-import type { OpenAPIDocument, OpenAPIRoute } from "./openapi.js";
-
-type HttpClient = {
-  request: (config: {
-    body?: unknown;
-    headers?: Record<string, string>;
-    method: string;
-    url: string;
-  }) => Promise<{ data: unknown; status: number }>;
-};
 
 type FromOpenAPIOptions = {
+  /**
+   * Base URL for the API.
+   * If not provided, uses the first server URL from the spec.
+   */
+  baseUrl?: string;
+
   /**
    * HTTP client to use for making API requests.
    * Must implement a request() method.
@@ -27,29 +25,125 @@ type FromOpenAPIOptions = {
   headers?: Record<string, string>;
 
   /**
-   * Base URL for the API.
-   * If not provided, uses the first server URL from the spec.
-   */
-  baseUrl?: string;
-
-  /**
    * OpenAPI specification object (parsed JSON).
    */
   spec: OpenAPIDocument;
 };
 
+type HttpClient = {
+  request: (config: {
+    body?: unknown;
+    headers?: Record<string, string>;
+    method: string;
+    url: string;
+  }) => Promise<{ data: unknown; status: number }>;
+};
+
 /**
- * Substitute path parameters into a URL template.
- * e.g., "/pets/{petId}" + {petId: "123"} -> "/pets/123"
+ * Convert an OpenAPI spec into FastMCP-compatible tool, resource,
+ * and resource template definitions.
+ *
+ * @example
+ * ```ts
+ * import { FastMCP } from "fastmcp";
+ * import { fromOpenAPI } from "fastmcp/openapi";
+ *
+ * const spec = JSON.parse(fs.readFileSync("openapi.json", "utf-8"));
+ * const { tools, resources, resourceTemplates } = fromOpenAPI({
+ *   spec,
+ *   client: { request: (config) => fetch(config.url, config).then(async r => ({ status: r.status, data: await r.json() })) },
+ * });
+ *
+ * const mcp = new FastMCP({ name: "My API", version: "1.0.0" });
+ * tools.forEach(t => mcp.addTool(t));
+ * resources.forEach(r => mcp.addResource(r));
+ * ```
  */
-function substitutePathParams(
-  pathTemplate: string,
-  params: Record<string, unknown>,
-): string {
-  return pathTemplate.replace(/\{(\w+)\}/g, (_, key) => {
-    const value = params[key];
-    return value !== undefined ? encodeURIComponent(String(value)) : `{${key}}`;
-  });
+export function fromOpenAPI(options: FromOpenAPIOptions) {
+  const { client, headers = {}, spec } = options;
+  const baseUrl =
+    options.baseUrl ??
+    (spec as { servers?: Array<{ url: string }> } & Record<string, unknown>)
+      .servers?.[0]?.url ??
+    "http://localhost";
+
+  const routes = extractRoutes(spec);
+  const tools: Array<{
+    description: string;
+    execute: (
+      args: Record<string, unknown>,
+    ) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
+    name: string;
+    parameters: ReturnType<typeof buildToolParameters>["jsonSchema"];
+  }> = [];
+
+  const resources: Array<{
+    description: string;
+    name: string;
+    read: () => Promise<{ text: string }>;
+    uri: string;
+  }> = [];
+
+  const resourceTemplates: Array<{
+    description: string;
+    name: string;
+    read: (args: Record<string, unknown>) => Promise<{ text: string }>;
+    uriTemplate: string;
+  }> = [];
+
+  for (const route of routes) {
+    const classification = classifyRoute(route);
+    const params = buildToolParameters(spec, route);
+
+    switch (classification) {
+      case "resource": {
+        resources.push({
+          description: route.description,
+          name: route.operationId,
+          read: createResourceHandler(route, baseUrl, client, headers),
+          uri: `api://${route.path}`,
+        });
+        break;
+      }
+      case "resourceTemplate": {
+        const templateUri = route.path.replace(/\{(\w+)\}/g, "{$1}");
+        resourceTemplates.push({
+          description: route.description,
+          name: route.operationId,
+          read: async (args: Record<string, unknown>) => {
+            const url = buildUrl(baseUrl, route, args);
+            const response = await client.request({
+              headers: {
+                "Content-Type": "application/json",
+                ...headers,
+              },
+              method: "GET",
+              url,
+            });
+            return {
+              text:
+                typeof response.data === "string"
+                  ? response.data
+                  : JSON.stringify(response.data, null, 2),
+            };
+          },
+          uriTemplate: `api://${templateUri}`,
+        });
+        break;
+      }
+      case "tool": {
+        tools.push({
+          description: route.description,
+          execute: createToolHandler(route, baseUrl, client, headers),
+          name: route.operationId,
+          parameters: params.jsonSchema,
+        });
+        break;
+      }
+    }
+  }
+
+  return { resources, resourceTemplates, tools };
 }
 
 /**
@@ -73,42 +167,33 @@ function buildUrl(
 }
 
 /**
- * Extract headers from route parameters and arguments.
+ * Create an MCP resource handler for an OpenAPI GET route.
  */
-function extractHeaders(
+function createResourceHandler(
   route: OpenAPIRoute,
-  args: Record<string, unknown>,
-): Record<string, string> {
-  const headers: Record<string, string> = {};
-  for (const param of route.parameters) {
-    if (param.in === "header" && args[param.name] !== undefined) {
-      headers[param.name] = String(args[param.name]);
-    }
-  }
-  return headers;
-}
+  baseUrl: string,
+  client: HttpClient,
+  defaultHeaders: Record<string, string>,
+) {
+  return async () => {
+    const url = buildUrl(baseUrl, route, {});
 
-/**
- * Extract body fields from arguments.
- * Body fields are prefixed with "body_" when flattened.
- */
-function extractBody(
-  args: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  const bodyFields: Record<string, unknown> = {};
-  let hasBody = false;
+    const response = await client.request({
+      headers: {
+        "Content-Type": "application/json",
+        ...defaultHeaders,
+      },
+      method: "GET",
+      url,
+    });
 
-  for (const [key, value] of Object.entries(args)) {
-    if (key === "body") {
-      return value as Record<string, unknown>;
-    }
-    if (key.startsWith("body_")) {
-      bodyFields[key.slice(5)] = value;
-      hasBody = true;
-    }
-  }
-
-  return hasBody ? bodyFields : undefined;
+    return {
+      text:
+        typeof response.data === "string"
+          ? response.data
+          : JSON.stringify(response.data, null, 2),
+    };
+  };
 }
 
 /**
@@ -151,140 +236,56 @@ function createToolHandler(
 }
 
 /**
- * Create an MCP resource handler for an OpenAPI GET route.
+ * Extract body fields from arguments.
+ * Body fields are prefixed with "body_" when flattened.
  */
-function createResourceHandler(
-  route: OpenAPIRoute,
-  baseUrl: string,
-  client: HttpClient,
-  defaultHeaders: Record<string, string>,
-) {
-  return async () => {
-    const url = buildUrl(baseUrl, route, {});
+function extractBody(
+  args: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const bodyFields: Record<string, unknown> = {};
+  let hasBody = false;
 
-    const response = await client.request({
-      headers: {
-        "Content-Type": "application/json",
-        ...defaultHeaders,
-      },
-      method: "GET",
-      url,
-    });
-
-    return {
-      text:
-        typeof response.data === "string"
-          ? response.data
-          : JSON.stringify(response.data, null, 2),
-    };
-  };
-}
-
-/**
- * Convert an OpenAPI spec into FastMCP-compatible tool, resource,
- * and resource template definitions.
- *
- * @example
- * ```ts
- * import { FastMCP } from "fastmcp";
- * import { fromOpenAPI } from "fastmcp/openapi";
- *
- * const spec = JSON.parse(fs.readFileSync("openapi.json", "utf-8"));
- * const { tools, resources, resourceTemplates } = fromOpenAPI({
- *   spec,
- *   client: { request: (config) => fetch(config.url, config).then(async r => ({ status: r.status, data: await r.json() })) },
- * });
- *
- * const mcp = new FastMCP({ name: "My API", version: "1.0.0" });
- * tools.forEach(t => mcp.addTool(t));
- * resources.forEach(r => mcp.addResource(r));
- * ```
- */
-export function fromOpenAPI(options: FromOpenAPIOptions) {
-  const { client, headers = {}, spec } = options;
-  const baseUrl =
-    options.baseUrl ??
-    (spec as Record<string, unknown> & { servers?: Array<{ url: string }> })
-      .servers?.[0]?.url ??
-    "http://localhost";
-
-  const routes = extractRoutes(spec);
-  const tools: Array<{
-    description: string;
-    execute: (
-      args: Record<string, unknown>,
-    ) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
-    name: string;
-    parameters: ReturnType<typeof buildToolParameters>["jsonSchema"];
-  }> = [];
-
-  const resources: Array<{
-    description: string;
-    name: string;
-    read: () => Promise<{ text: string }>;
-    uri: string;
-  }> = [];
-
-  const resourceTemplates: Array<{
-    description: string;
-    name: string;
-    read: (args: Record<string, unknown>) => Promise<{ text: string }>;
-    uriTemplate: string;
-  }> = [];
-
-  for (const route of routes) {
-    const classification = classifyRoute(route);
-    const params = buildToolParameters(spec, route);
-
-    switch (classification) {
-      case "tool": {
-        tools.push({
-          description: route.description,
-          execute: createToolHandler(route, baseUrl, client, headers),
-          name: route.operationId,
-          parameters: params.jsonSchema,
-        });
-        break;
-      }
-      case "resource": {
-        resources.push({
-          description: route.description,
-          name: route.operationId,
-          read: createResourceHandler(route, baseUrl, client, headers),
-          uri: `api://${route.path}`,
-        });
-        break;
-      }
-      case "resourceTemplate": {
-        const templateUri = route.path.replace(/\{(\w+)\}/g, "{$1}");
-        resourceTemplates.push({
-          description: route.description,
-          name: route.operationId,
-          read: async (args: Record<string, unknown>) => {
-            const url = buildUrl(baseUrl, route, args);
-            const response = await client.request({
-              headers: {
-                "Content-Type": "application/json",
-                ...headers,
-              },
-              method: "GET",
-              url,
-            });
-            return {
-              text:
-                typeof response.data === "string"
-                  ? response.data
-                  : JSON.stringify(response.data, null, 2),
-            };
-          },
-          uriTemplate: `api://${templateUri}`,
-        });
-        break;
-      }
+  for (const [key, value] of Object.entries(args)) {
+    if (key === "body") {
+      return value as Record<string, unknown>;
+    }
+    if (key.startsWith("body_")) {
+      bodyFields[key.slice(5)] = value;
+      hasBody = true;
     }
   }
 
-  return { resources, resourceTemplates, tools };
+  return hasBody ? bodyFields : undefined;
+}
+
+/**
+ * Extract headers from route parameters and arguments.
+ */
+function extractHeaders(
+  route: OpenAPIRoute,
+  args: Record<string, unknown>,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const param of route.parameters) {
+    if (param.in === "header" && args[param.name] !== undefined) {
+      headers[param.name] = String(args[param.name]);
+    }
+  }
+  return headers;
+}
+
+/**
+ * Substitute path parameters into a URL template.
+ * e.g., "/pets/{petId}" + {petId: "123"} -> "/pets/123"
+ */
+function substitutePathParams(
+  pathTemplate: string,
+  params: Record<string, unknown>,
+): string {
+  return pathTemplate.replace(/\{(\w+)\}/g, (_, key) => {
+    const value = params[key];
+    return value !== undefined ? encodeURIComponent(String(value)) : `{${key}}`;
+  });
 }
 
 export type { FromOpenAPIOptions, HttpClient };

--- a/src/fromOpenAPI.ts
+++ b/src/fromOpenAPI.ts
@@ -1,4 +1,8 @@
-import { buildToolParameters, classifyRoute, extractRoutes } from "./openapi.js";
+import {
+  buildToolParameters,
+  classifyRoute,
+  extractRoutes,
+} from "./openapi.js";
 import type { OpenAPIDocument, OpenAPIRoute } from "./openapi.js";
 
 type HttpClient = {
@@ -135,9 +139,10 @@ function createToolHandler(
     return {
       content: [
         {
-          text: typeof response.data === "string"
-            ? response.data
-            : JSON.stringify(response.data, null, 2),
+          text:
+            typeof response.data === "string"
+              ? response.data
+              : JSON.stringify(response.data, null, 2),
           type: "text" as const,
         },
       ],
@@ -167,9 +172,10 @@ function createResourceHandler(
     });
 
     return {
-      text: typeof response.data === "string"
-        ? response.data
-        : JSON.stringify(response.data, null, 2),
+      text:
+        typeof response.data === "string"
+          ? response.data
+          : JSON.stringify(response.data, null, 2),
     };
   };
 }
@@ -196,14 +202,18 @@ function createResourceHandler(
  */
 export function fromOpenAPI(options: FromOpenAPIOptions) {
   const { client, headers = {}, spec } = options;
-  const baseUrl = options.baseUrl ??
-    (spec as Record<string, unknown> & { servers?: Array<{ url: string }> }).servers?.[0]?.url ??
+  const baseUrl =
+    options.baseUrl ??
+    (spec as Record<string, unknown> & { servers?: Array<{ url: string }> })
+      .servers?.[0]?.url ??
     "http://localhost";
 
   const routes = extractRoutes(spec);
   const tools: Array<{
     description: string;
-    execute: (args: Record<string, unknown>) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
+    execute: (
+      args: Record<string, unknown>,
+    ) => Promise<{ content: Array<{ text: string; type: "text" }> }>;
     name: string;
     parameters: ReturnType<typeof buildToolParameters>["jsonSchema"];
   }> = [];
@@ -261,9 +271,10 @@ export function fromOpenAPI(options: FromOpenAPIOptions) {
               url,
             });
             return {
-              text: typeof response.data === "string"
-                ? response.data
-                : JSON.stringify(response.data, null, 2),
+              text:
+                typeof response.data === "string"
+                  ? response.data
+                  : JSON.stringify(response.data, null, 2),
             };
           },
           uriTemplate: `api://${templateUri}`,

--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -1,0 +1,212 @@
+import { expect, test, describe } from "vitest";
+import { buildToolParameters, classifyRoute, extractRoutes } from "./openapi.js";
+import type { OpenAPIDocument } from "./openapi.js";
+
+const petStoreSpec: OpenAPIDocument = {
+  openapi: "3.0.0",
+  info: { title: "Pet Store", version: "1.0.0" },
+  paths: {
+    "/pets": {
+      get: {
+        operationId: "listPets",
+        summary: "List all pets",
+        parameters: [
+          {
+            name: "limit",
+            in: "query",
+            schema: { type: "integer", minimum: 1, maximum: 100 },
+            description: "Max number of pets to return",
+          },
+        ],
+        responses: { "200": { description: "A list of pets" } },
+      },
+      post: {
+        operationId: "createPet",
+        summary: "Create a pet",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string", description: "Pet name" },
+                  tag: { type: "string" },
+                },
+                required: ["name"],
+              },
+            },
+          },
+        },
+        responses: { "201": { description: "Pet created" } },
+      },
+    },
+    "/pets/{petId}": {
+      get: {
+        operationId: "getPet",
+        summary: "Get a pet by ID",
+        parameters: [
+          {
+            name: "petId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description: "The pet ID",
+          },
+        ],
+        responses: { "200": { description: "A pet" } },
+      },
+      delete: {
+        operationId: "deletePet",
+        summary: "Delete a pet",
+        parameters: [
+          {
+            name: "petId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "204": { description: "Pet deleted" } },
+      },
+    },
+  },
+};
+
+describe("extractRoutes", () => {
+  test("extracts all routes from a spec", () => {
+    const routes = extractRoutes(petStoreSpec);
+    expect(routes).toHaveLength(4);
+    expect(routes.map((r) => r.operationId).sort()).toEqual([
+      "createPet",
+      "deletePet",
+      "getPet",
+      "listPets",
+    ]);
+  });
+
+  test("extracts parameters correctly", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const listPets = routes.find((r) => r.operationId === "listPets")!;
+    expect(listPets.parameters).toHaveLength(1);
+    expect(listPets.parameters[0].name).toBe("limit");
+    expect(listPets.parameters[0].in).toBe("query");
+  });
+
+  test("extracts request body", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const createPet = routes.find((r) => r.operationId === "createPet")!;
+    expect(createPet.requestBody).toBeDefined();
+  });
+});
+
+describe("classifyRoute", () => {
+  test("classifies GET without path params as resource", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const listPets = routes.find((r) => r.operationId === "listPets")!;
+    expect(classifyRoute(listPets)).toBe("resource");
+  });
+
+  test("classifies GET with path params as resourceTemplate", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const getPet = routes.find((r) => r.operationId === "getPet")!;
+    expect(classifyRoute(getPet)).toBe("resourceTemplate");
+  });
+
+  test("classifies POST as tool", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const createPet = routes.find((r) => r.operationId === "createPet")!;
+    expect(classifyRoute(createPet)).toBe("tool");
+  });
+
+  test("classifies DELETE as tool", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const deletePet = routes.find((r) => r.operationId === "deletePet")!;
+    expect(classifyRoute(deletePet)).toBe("tool");
+  });
+});
+
+describe("buildToolParameters", () => {
+  test("builds parameters for a route with query params", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const listPets = routes.find((r) => r.operationId === "listPets")!;
+    const params = buildToolParameters(petStoreSpec, listPets);
+
+    expect(params.jsonSchema).toEqual({
+      type: "object",
+      properties: {
+        limit: {
+          type: "integer",
+          minimum: 1,
+          maximum: 100,
+          description: "Max number of pets to return",
+        },
+      },
+      required: undefined,
+    });
+  });
+
+  test("builds parameters for a route with path params", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const getPet = routes.find((r) => r.operationId === "getPet")!;
+    const params = buildToolParameters(petStoreSpec, getPet);
+
+    expect(params.jsonSchema.properties).toHaveProperty("petId");
+    expect(params.jsonSchema.required).toContain("petId");
+  });
+
+  test("builds parameters for a route with request body", () => {
+    const routes = extractRoutes(petStoreSpec);
+    const createPet = routes.find((r) => r.operationId === "createPet")!;
+    const params = buildToolParameters(petStoreSpec, createPet);
+
+    expect(params.jsonSchema.properties).toHaveProperty("body_name");
+    expect(params.jsonSchema.properties).toHaveProperty("body_tag");
+    expect(params.jsonSchema.required).toContain("body_name");
+  });
+});
+
+describe("$ref resolution", () => {
+  test("resolves $ref in schemas", () => {
+    const specWithRefs: OpenAPIDocument = {
+      openapi: "3.0.0",
+      info: { title: "Ref Test", version: "1.0.0" },
+      paths: {
+        "/items": {
+          post: {
+            operationId: "createItem",
+            summary: "Create an item",
+            requestBody: {
+              required: true,
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Item" },
+                },
+              },
+            },
+            responses: { "201": { description: "Created" } },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Item: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              value: { type: "number" },
+            },
+            required: ["name"],
+          },
+        },
+      },
+    };
+
+    const routes = extractRoutes(specWithRefs);
+    expect(routes).toHaveLength(1);
+
+    const params = buildToolParameters(specWithRefs, routes[0]);
+    expect(params.jsonSchema.properties).toHaveProperty("body_name");
+    expect(params.jsonSchema.properties).toHaveProperty("body_value");
+  });
+});

--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -1,77 +1,79 @@
-import { expect, test, describe } from "vitest";
+import { describe, expect, test } from "vitest";
+
+import type { OpenAPIDocument } from "./openapi.js";
+
 import {
   buildToolParameters,
   classifyRoute,
   extractRoutes,
 } from "./openapi.js";
-import type { OpenAPIDocument } from "./openapi.js";
 
 const petStoreSpec: OpenAPIDocument = {
-  openapi: "3.0.0",
   info: { title: "Pet Store", version: "1.0.0" },
+  openapi: "3.0.0",
   paths: {
     "/pets": {
       get: {
         operationId: "listPets",
-        summary: "List all pets",
         parameters: [
           {
-            name: "limit",
-            in: "query",
-            schema: { type: "integer", minimum: 1, maximum: 100 },
             description: "Max number of pets to return",
+            in: "query",
+            name: "limit",
+            schema: { maximum: 100, minimum: 1, type: "integer" },
           },
         ],
         responses: { "200": { description: "A list of pets" } },
+        summary: "List all pets",
       },
       post: {
         operationId: "createPet",
-        summary: "Create a pet",
         requestBody: {
-          required: true,
           content: {
             "application/json": {
               schema: {
-                type: "object",
                 properties: {
-                  name: { type: "string", description: "Pet name" },
+                  name: { description: "Pet name", type: "string" },
                   tag: { type: "string" },
                 },
                 required: ["name"],
+                type: "object",
               },
             },
           },
+          required: true,
         },
         responses: { "201": { description: "Pet created" } },
+        summary: "Create a pet",
       },
     },
     "/pets/{petId}": {
-      get: {
-        operationId: "getPet",
-        summary: "Get a pet by ID",
-        parameters: [
-          {
-            name: "petId",
-            in: "path",
-            required: true,
-            schema: { type: "string" },
-            description: "The pet ID",
-          },
-        ],
-        responses: { "200": { description: "A pet" } },
-      },
       delete: {
         operationId: "deletePet",
-        summary: "Delete a pet",
         parameters: [
           {
-            name: "petId",
             in: "path",
+            name: "petId",
             required: true,
             schema: { type: "string" },
           },
         ],
         responses: { "204": { description: "Pet deleted" } },
+        summary: "Delete a pet",
+      },
+      get: {
+        operationId: "getPet",
+        parameters: [
+          {
+            description: "The pet ID",
+            in: "path",
+            name: "petId",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "A pet" } },
+        summary: "Get a pet by ID",
       },
     },
   },
@@ -137,16 +139,16 @@ describe("buildToolParameters", () => {
     const params = buildToolParameters(petStoreSpec, listPets);
 
     expect(params.jsonSchema).toEqual({
-      type: "object",
       properties: {
         limit: {
-          type: "integer",
-          minimum: 1,
-          maximum: 100,
           description: "Max number of pets to return",
+          maximum: 100,
+          minimum: 1,
+          type: "integer",
         },
       },
       required: undefined,
+      type: "object",
     });
   });
 
@@ -173,34 +175,34 @@ describe("buildToolParameters", () => {
 describe("$ref resolution", () => {
   test("resolves $ref in schemas", () => {
     const specWithRefs: OpenAPIDocument = {
-      openapi: "3.0.0",
-      info: { title: "Ref Test", version: "1.0.0" },
-      paths: {
-        "/items": {
-          post: {
-            operationId: "createItem",
-            summary: "Create an item",
-            requestBody: {
-              required: true,
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/Item" },
-                },
-              },
-            },
-            responses: { "201": { description: "Created" } },
-          },
-        },
-      },
       components: {
         schemas: {
           Item: {
-            type: "object",
             properties: {
               name: { type: "string" },
               value: { type: "number" },
             },
             required: ["name"],
+            type: "object",
+          },
+        },
+      },
+      info: { title: "Ref Test", version: "1.0.0" },
+      openapi: "3.0.0",
+      paths: {
+        "/items": {
+          post: {
+            operationId: "createItem",
+            requestBody: {
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Item" },
+                },
+              },
+              required: true,
+            },
+            responses: { "201": { description: "Created" } },
+            summary: "Create an item",
           },
         },
       },

--- a/src/openapi.test.ts
+++ b/src/openapi.test.ts
@@ -1,5 +1,9 @@
 import { expect, test, describe } from "vitest";
-import { buildToolParameters, classifyRoute, extractRoutes } from "./openapi.js";
+import {
+  buildToolParameters,
+  classifyRoute,
+  extractRoutes,
+} from "./openapi.js";
 import type { OpenAPIDocument } from "./openapi.js";
 
 const petStoreSpec: OpenAPIDocument = {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -12,17 +12,43 @@ type HttpMethod =
   | "post"
   | "put";
 
+type MediaTypeObject = {
+  schema?: ReferenceObject | SchemaObject;
+};
+
 type OpenAPIDocument = {
   components?: {
-    schemas?: Record<string, SchemaObject | ReferenceObject>;
+    schemas?: Record<string, ReferenceObject | SchemaObject>;
   };
   info: { title: string; version: string };
   openapi: string;
   paths?: Record<string, PathItemObject | ReferenceObject>;
 };
 
-type ReferenceObject = {
-  $ref: string;
+type OpenAPIRoute = {
+  description: string;
+  method: HttpMethod;
+  operationId: string;
+  parameters: ParameterObject[];
+  path: string;
+  requestBody?: RequestBodyObject;
+};
+
+type OperationObject = {
+  description?: string;
+  operationId?: string;
+  parameters?: (ParameterObject | ReferenceObject)[];
+  requestBody?: ReferenceObject | RequestBodyObject;
+  responses?: Record<string, unknown>;
+  summary?: string;
+};
+
+type ParameterObject = {
+  description?: string;
+  in: "cookie" | "header" | "path" | "query";
+  name: string;
+  required?: boolean;
+  schema?: ReferenceObject | SchemaObject;
 };
 
 type PathItemObject = {
@@ -36,21 +62,8 @@ type PathItemObject = {
   put?: OperationObject;
 };
 
-type OperationObject = {
-  description?: string;
-  operationId?: string;
-  parameters?: (ParameterObject | ReferenceObject)[];
-  requestBody?: RequestBodyObject | ReferenceObject;
-  responses?: Record<string, unknown>;
-  summary?: string;
-};
-
-type ParameterObject = {
-  description?: string;
-  in: "cookie" | "header" | "path" | "query";
-  name: string;
-  required?: boolean;
-  schema?: SchemaObject | ReferenceObject;
+type ReferenceObject = {
+  $ref: string;
 };
 
 type RequestBodyObject = {
@@ -58,153 +71,18 @@ type RequestBodyObject = {
   required?: boolean;
 };
 
-type MediaTypeObject = {
-  schema?: SchemaObject | ReferenceObject;
-};
-
 type SchemaObject = {
   default?: unknown;
   description?: string;
   enum?: unknown[];
   format?: string;
-  items?: SchemaObject | ReferenceObject;
+  items?: ReferenceObject | SchemaObject;
   maximum?: number;
   minimum?: number;
-  properties?: Record<string, SchemaObject | ReferenceObject>;
+  properties?: Record<string, ReferenceObject | SchemaObject>;
   required?: string[];
   type?: string;
 };
-
-type OpenAPIRoute = {
-  description: string;
-  method: HttpMethod;
-  operationId: string;
-  parameters: ParameterObject[];
-  path: string;
-  requestBody?: RequestBodyObject;
-};
-
-/**
- * Resolve a $ref to its target object within the spec.
- */
-function resolveRef<T>(spec: OpenAPIDocument, ref: string): T {
-  const parts = ref.replace(/^#\//, "").split("/");
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let current: any = spec;
-  for (const part of parts) {
-    current = current[part];
-    if (current === undefined) {
-      throw new Error(`Could not resolve $ref: ${ref}`);
-    }
-  }
-  return current as T;
-}
-
-/**
- * Dereference an object that might be a $ref.
- */
-function deref<T>(spec: OpenAPIDocument, obj: T | ReferenceObject): T {
-  if (obj && typeof obj === "object" && "$ref" in obj) {
-    return resolveRef<T>(spec, (obj as ReferenceObject).$ref);
-  }
-  return obj as T;
-}
-
-/**
- * Convert an OpenAPI JSON Schema to a plain JSON Schema object
- * suitable for use as tool parameters.
- */
-function openApiSchemaToJsonSchema(
-  spec: OpenAPIDocument,
-  schema: SchemaObject | ReferenceObject,
-): Record<string, unknown> {
-  const resolved = deref<SchemaObject>(spec, schema);
-  const result: Record<string, unknown> = {};
-
-  if (resolved.type) result.type = resolved.type;
-  if (resolved.description) result.description = resolved.description;
-  if (resolved.enum) result.enum = resolved.enum;
-  if (resolved.default !== undefined) result.default = resolved.default;
-  if (resolved.format) result.format = resolved.format;
-  if (resolved.minimum !== undefined) result.minimum = resolved.minimum;
-  if (resolved.maximum !== undefined) result.maximum = resolved.maximum;
-
-  if (resolved.type === "object" && resolved.properties) {
-    result.properties = {};
-    for (const [key, value] of Object.entries(resolved.properties)) {
-      (result.properties as Record<string, unknown>)[key] =
-        openApiSchemaToJsonSchema(spec, value);
-    }
-    if (resolved.required) {
-      result.required = resolved.required;
-    }
-  }
-
-  if (resolved.type === "array" && resolved.items) {
-    result.items = openApiSchemaToJsonSchema(spec, resolved.items);
-  }
-
-  return result;
-}
-
-/**
- * Extract all routes from an OpenAPI spec.
- */
-export function extractRoutes(spec: OpenAPIDocument): OpenAPIRoute[] {
-  const routes: OpenAPIRoute[] = [];
-  const methods: HttpMethod[] = [
-    "get",
-    "post",
-    "put",
-    "patch",
-    "delete",
-    "head",
-    "options",
-  ];
-
-  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
-    if (!pathItem) continue;
-    const resolvedPathItem = deref<PathItemObject>(spec, pathItem);
-
-    for (const method of methods) {
-      const operation = resolvedPathItem[method];
-      if (!operation) continue;
-
-      const operationId =
-        operation.operationId ??
-        `${method}_${path
-          .replace(/[^a-zA-Z0-9]/g, "_")
-          .replace(/_+/g, "_")
-          .replace(/^_|_$/g, "")}`;
-
-      const parameters = (
-        operation.parameters ??
-        resolvedPathItem.parameters ??
-        []
-      ).map((p) => deref<ParameterObject>(spec, p));
-
-      const requestBody = operation.requestBody
-        ? deref<RequestBodyObject>(spec, operation.requestBody)
-        : undefined;
-
-      const summary =
-        operation.summary ??
-        operation.description ??
-        `${method.toUpperCase()} ${path}`;
-
-      routes.push({
-        description: summary,
-        method,
-        operationId,
-        parameters,
-        path,
-        requestBody,
-      });
-    }
-  }
-
-  return routes;
-}
 
 /**
  * Build JSON Schema parameters for a tool from an OpenAPI route.
@@ -280,6 +158,128 @@ export function classifyRoute(
   }
   const hasPathParams = route.parameters.some((p) => p.in === "path");
   return hasPathParams ? "resourceTemplate" : "resource";
+}
+
+/**
+ * Extract all routes from an OpenAPI spec.
+ */
+export function extractRoutes(spec: OpenAPIDocument): OpenAPIRoute[] {
+  const routes: OpenAPIRoute[] = [];
+  const methods: HttpMethod[] = [
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+  ];
+
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    if (!pathItem) continue;
+    const resolvedPathItem = deref<PathItemObject>(spec, pathItem);
+
+    for (const method of methods) {
+      const operation = resolvedPathItem[method];
+      if (!operation) continue;
+
+      const operationId =
+        operation.operationId ??
+        `${method}_${path
+          .replace(/[^a-zA-Z0-9]/g, "_")
+          .replace(/_+/g, "_")
+          .replace(/^_|_$/g, "")}`;
+
+      const parameters = (
+        operation.parameters ??
+        resolvedPathItem.parameters ??
+        []
+      ).map((p) => deref<ParameterObject>(spec, p));
+
+      const requestBody = operation.requestBody
+        ? deref<RequestBodyObject>(spec, operation.requestBody)
+        : undefined;
+
+      const summary =
+        operation.summary ??
+        operation.description ??
+        `${method.toUpperCase()} ${path}`;
+
+      routes.push({
+        description: summary,
+        method,
+        operationId,
+        parameters,
+        path,
+        requestBody,
+      });
+    }
+  }
+
+  return routes;
+}
+
+/**
+ * Dereference an object that might be a $ref.
+ */
+function deref<T>(spec: OpenAPIDocument, obj: ReferenceObject | T): T {
+  if (obj && typeof obj === "object" && "$ref" in obj) {
+    return resolveRef<T>(spec, (obj as ReferenceObject).$ref);
+  }
+  return obj as T;
+}
+
+/**
+ * Convert an OpenAPI JSON Schema to a plain JSON Schema object
+ * suitable for use as tool parameters.
+ */
+function openApiSchemaToJsonSchema(
+  spec: OpenAPIDocument,
+  schema: ReferenceObject | SchemaObject,
+): Record<string, unknown> {
+  const resolved = deref<SchemaObject>(spec, schema);
+  const result: Record<string, unknown> = {};
+
+  if (resolved.type) result.type = resolved.type;
+  if (resolved.description) result.description = resolved.description;
+  if (resolved.enum) result.enum = resolved.enum;
+  if (resolved.default !== undefined) result.default = resolved.default;
+  if (resolved.format) result.format = resolved.format;
+  if (resolved.minimum !== undefined) result.minimum = resolved.minimum;
+  if (resolved.maximum !== undefined) result.maximum = resolved.maximum;
+
+  if (resolved.type === "object" && resolved.properties) {
+    result.properties = {};
+    for (const [key, value] of Object.entries(resolved.properties)) {
+      (result.properties as Record<string, unknown>)[key] =
+        openApiSchemaToJsonSchema(spec, value);
+    }
+    if (resolved.required) {
+      result.required = resolved.required;
+    }
+  }
+
+  if (resolved.type === "array" && resolved.items) {
+    result.items = openApiSchemaToJsonSchema(spec, resolved.items);
+  }
+
+  return result;
+}
+
+/**
+ * Resolve a $ref to its target object within the spec.
+ */
+function resolveRef<T>(spec: OpenAPIDocument, ref: string): T {
+  const parts = ref.replace(/^#\//, "").split("/");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let current: any = spec;
+  for (const part of parts) {
+    current = current[part];
+    if (current === undefined) {
+      throw new Error(`Could not resolve $ref: ${ref}`);
+    }
+  }
+  return current as T;
 }
 
 export type {

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -3,7 +3,14 @@
  * We inline these to avoid adding an external dependency.
  */
 
-type HttpMethod = "delete" | "get" | "head" | "options" | "patch" | "post" | "put";
+type HttpMethod =
+  | "delete"
+  | "get"
+  | "head"
+  | "options"
+  | "patch"
+  | "post"
+  | "put";
 
 type OpenAPIDocument = {
   components?: {
@@ -125,7 +132,8 @@ function openApiSchemaToJsonSchema(
   if (resolved.type === "object" && resolved.properties) {
     result.properties = {};
     for (const [key, value] of Object.entries(resolved.properties)) {
-      (result.properties as Record<string, unknown>)[key] = openApiSchemaToJsonSchema(spec, value);
+      (result.properties as Record<string, unknown>)[key] =
+        openApiSchemaToJsonSchema(spec, value);
     }
     if (resolved.required) {
       result.required = resolved.required;
@@ -144,7 +152,15 @@ function openApiSchemaToJsonSchema(
  */
 export function extractRoutes(spec: OpenAPIDocument): OpenAPIRoute[] {
   const routes: OpenAPIRoute[] = [];
-  const methods: HttpMethod[] = ["get", "post", "put", "patch", "delete", "head", "options"];
+  const methods: HttpMethod[] = [
+    "get",
+    "post",
+    "put",
+    "patch",
+    "delete",
+    "head",
+    "options",
+  ];
 
   for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
     if (!pathItem) continue;
@@ -156,17 +172,25 @@ export function extractRoutes(spec: OpenAPIDocument): OpenAPIRoute[] {
 
       const operationId =
         operation.operationId ??
-        `${method}_${path.replace(/[^a-zA-Z0-9]/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "")}`;
+        `${method}_${path
+          .replace(/[^a-zA-Z0-9]/g, "_")
+          .replace(/_+/g, "_")
+          .replace(/^_|_$/g, "")}`;
 
-      const parameters = (operation.parameters ?? resolvedPathItem.parameters ?? []).map(
-        (p) => deref<ParameterObject>(spec, p),
-      );
+      const parameters = (
+        operation.parameters ??
+        resolvedPathItem.parameters ??
+        []
+      ).map((p) => deref<ParameterObject>(spec, p));
 
       const requestBody = operation.requestBody
         ? deref<RequestBodyObject>(spec, operation.requestBody)
         : undefined;
 
-      const summary = operation.summary ?? operation.description ?? `${method.toUpperCase()} ${path}`;
+      const summary =
+        operation.summary ??
+        operation.description ??
+        `${method.toUpperCase()} ${path}`;
 
       routes.push({
         description: summary,
@@ -199,7 +223,8 @@ export function buildToolParameters(
         : { type: "string" };
       properties[param.name] = {
         ...schema,
-        description: param.description ?? (schema as Record<string, unknown>).description,
+        description:
+          param.description ?? (schema as Record<string, unknown>).description,
       };
       if (param.required) {
         required.push(param.name);
@@ -247,7 +272,9 @@ export function buildToolParameters(
  * - GET with path params -> resource template
  * - Other HTTP methods -> tool
  */
-export function classifyRoute(route: OpenAPIRoute): "resource" | "resourceTemplate" | "tool" {
+export function classifyRoute(
+  route: OpenAPIRoute,
+): "resource" | "resourceTemplate" | "tool" {
   if (route.method !== "get") {
     return "tool";
   }
@@ -255,4 +282,11 @@ export function classifyRoute(route: OpenAPIRoute): "resource" | "resourceTempla
   return hasPathParams ? "resourceTemplate" : "resource";
 }
 
-export type { HttpMethod, OpenAPIDocument, OpenAPIRoute, ParameterObject, RequestBodyObject, SchemaObject };
+export type {
+  HttpMethod,
+  OpenAPIDocument,
+  OpenAPIRoute,
+  ParameterObject,
+  RequestBodyObject,
+  SchemaObject,
+};

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,0 +1,258 @@
+/**
+ * OpenAPI 3.x type definitions (minimal subset needed for MCP conversion).
+ * We inline these to avoid adding an external dependency.
+ */
+
+type HttpMethod = "delete" | "get" | "head" | "options" | "patch" | "post" | "put";
+
+type OpenAPIDocument = {
+  components?: {
+    schemas?: Record<string, SchemaObject | ReferenceObject>;
+  };
+  info: { title: string; version: string };
+  openapi: string;
+  paths?: Record<string, PathItemObject | ReferenceObject>;
+};
+
+type ReferenceObject = {
+  $ref: string;
+};
+
+type PathItemObject = {
+  delete?: OperationObject;
+  get?: OperationObject;
+  head?: OperationObject;
+  options?: OperationObject;
+  parameters?: (ParameterObject | ReferenceObject)[];
+  patch?: OperationObject;
+  post?: OperationObject;
+  put?: OperationObject;
+};
+
+type OperationObject = {
+  description?: string;
+  operationId?: string;
+  parameters?: (ParameterObject | ReferenceObject)[];
+  requestBody?: RequestBodyObject | ReferenceObject;
+  responses?: Record<string, unknown>;
+  summary?: string;
+};
+
+type ParameterObject = {
+  description?: string;
+  in: "cookie" | "header" | "path" | "query";
+  name: string;
+  required?: boolean;
+  schema?: SchemaObject | ReferenceObject;
+};
+
+type RequestBodyObject = {
+  content: Record<string, MediaTypeObject>;
+  required?: boolean;
+};
+
+type MediaTypeObject = {
+  schema?: SchemaObject | ReferenceObject;
+};
+
+type SchemaObject = {
+  default?: unknown;
+  description?: string;
+  enum?: unknown[];
+  format?: string;
+  items?: SchemaObject | ReferenceObject;
+  maximum?: number;
+  minimum?: number;
+  properties?: Record<string, SchemaObject | ReferenceObject>;
+  required?: string[];
+  type?: string;
+};
+
+type OpenAPIRoute = {
+  description: string;
+  method: HttpMethod;
+  operationId: string;
+  parameters: ParameterObject[];
+  path: string;
+  requestBody?: RequestBodyObject;
+};
+
+/**
+ * Resolve a $ref to its target object within the spec.
+ */
+function resolveRef<T>(spec: OpenAPIDocument, ref: string): T {
+  const parts = ref.replace(/^#\//, "").split("/");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let current: any = spec;
+  for (const part of parts) {
+    current = current[part];
+    if (current === undefined) {
+      throw new Error(`Could not resolve $ref: ${ref}`);
+    }
+  }
+  return current as T;
+}
+
+/**
+ * Dereference an object that might be a $ref.
+ */
+function deref<T>(spec: OpenAPIDocument, obj: T | ReferenceObject): T {
+  if (obj && typeof obj === "object" && "$ref" in obj) {
+    return resolveRef<T>(spec, (obj as ReferenceObject).$ref);
+  }
+  return obj as T;
+}
+
+/**
+ * Convert an OpenAPI JSON Schema to a plain JSON Schema object
+ * suitable for use as tool parameters.
+ */
+function openApiSchemaToJsonSchema(
+  spec: OpenAPIDocument,
+  schema: SchemaObject | ReferenceObject,
+): Record<string, unknown> {
+  const resolved = deref<SchemaObject>(spec, schema);
+  const result: Record<string, unknown> = {};
+
+  if (resolved.type) result.type = resolved.type;
+  if (resolved.description) result.description = resolved.description;
+  if (resolved.enum) result.enum = resolved.enum;
+  if (resolved.default !== undefined) result.default = resolved.default;
+  if (resolved.format) result.format = resolved.format;
+  if (resolved.minimum !== undefined) result.minimum = resolved.minimum;
+  if (resolved.maximum !== undefined) result.maximum = resolved.maximum;
+
+  if (resolved.type === "object" && resolved.properties) {
+    result.properties = {};
+    for (const [key, value] of Object.entries(resolved.properties)) {
+      (result.properties as Record<string, unknown>)[key] = openApiSchemaToJsonSchema(spec, value);
+    }
+    if (resolved.required) {
+      result.required = resolved.required;
+    }
+  }
+
+  if (resolved.type === "array" && resolved.items) {
+    result.items = openApiSchemaToJsonSchema(spec, resolved.items);
+  }
+
+  return result;
+}
+
+/**
+ * Extract all routes from an OpenAPI spec.
+ */
+export function extractRoutes(spec: OpenAPIDocument): OpenAPIRoute[] {
+  const routes: OpenAPIRoute[] = [];
+  const methods: HttpMethod[] = ["get", "post", "put", "patch", "delete", "head", "options"];
+
+  for (const [path, pathItem] of Object.entries(spec.paths ?? {})) {
+    if (!pathItem) continue;
+    const resolvedPathItem = deref<PathItemObject>(spec, pathItem);
+
+    for (const method of methods) {
+      const operation = resolvedPathItem[method];
+      if (!operation) continue;
+
+      const operationId =
+        operation.operationId ??
+        `${method}_${path.replace(/[^a-zA-Z0-9]/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "")}`;
+
+      const parameters = (operation.parameters ?? resolvedPathItem.parameters ?? []).map(
+        (p) => deref<ParameterObject>(spec, p),
+      );
+
+      const requestBody = operation.requestBody
+        ? deref<RequestBodyObject>(spec, operation.requestBody)
+        : undefined;
+
+      const summary = operation.summary ?? operation.description ?? `${method.toUpperCase()} ${path}`;
+
+      routes.push({
+        description: summary,
+        method,
+        operationId,
+        parameters,
+        path,
+        requestBody,
+      });
+    }
+  }
+
+  return routes;
+}
+
+/**
+ * Build JSON Schema parameters for a tool from an OpenAPI route.
+ */
+export function buildToolParameters(
+  spec: OpenAPIDocument,
+  route: OpenAPIRoute,
+): { jsonSchema: Record<string, unknown> } {
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+
+  for (const param of route.parameters) {
+    if (param.in === "path" || param.in === "query" || param.in === "header") {
+      const schema = param.schema
+        ? openApiSchemaToJsonSchema(spec, param.schema)
+        : { type: "string" };
+      properties[param.name] = {
+        ...schema,
+        description: param.description ?? (schema as Record<string, unknown>).description,
+      };
+      if (param.required) {
+        required.push(param.name);
+      }
+    }
+  }
+
+  if (route.requestBody) {
+    const content = route.requestBody.content;
+    const jsonContent = content?.["application/json"];
+    if (jsonContent?.schema) {
+      const bodySchema = openApiSchemaToJsonSchema(spec, jsonContent.schema);
+      if (bodySchema.type === "object" && bodySchema.properties) {
+        for (const [key, value] of Object.entries(
+          bodySchema.properties as Record<string, unknown>,
+        )) {
+          properties[`body_${key}`] = value;
+        }
+        if (Array.isArray(bodySchema.required)) {
+          for (const r of bodySchema.required) {
+            required.push(`body_${r}`);
+          }
+        }
+      } else {
+        properties["body"] = bodySchema;
+        if (route.requestBody.required) {
+          required.push("body");
+        }
+      }
+    }
+  }
+
+  return {
+    jsonSchema: {
+      properties,
+      required: required.length > 0 ? required : undefined,
+      type: "object" as const,
+    },
+  };
+}
+
+/**
+ * Classify an OpenAPI route:
+ * - GET without path params -> resource
+ * - GET with path params -> resource template
+ * - Other HTTP methods -> tool
+ */
+export function classifyRoute(route: OpenAPIRoute): "resource" | "resourceTemplate" | "tool" {
+  if (route.method !== "get") {
+    return "tool";
+  }
+  const hasPathParams = route.parameters.some((p) => p.in === "path");
+  return hasPathParams ? "resourceTemplate" : "resource";
+}
+
+export type { HttpMethod, OpenAPIDocument, OpenAPIRoute, ParameterObject, RequestBodyObject, SchemaObject };


### PR DESCRIPTION
## Summary

Implements #42 — automatic conversion of OpenAPI specs to MCP tools, resources, and resource templates.

## What this adds

### `src/openapi.ts` — OpenAPI spec parser
- Inline OpenAPI 3.x type definitions (zero external dependencies)
- `extractRoutes()` — extract all operations from an OpenAPI spec
- `buildToolParameters()` — convert OpenAPI schemas to JSON Schema for tool params
- `classifyRoute()` — classify routes as `resource`, `resourceTemplate`, or `tool`
- Full `$ref` resolution for schemas, parameters, and request bodies

### `src/fromOpenAPI.ts` — High-level converter
- `fromOpenAPI({ spec, client })` → `{ tools, resources, resourceTemplates }`
- GET without path params → MCP resource
- GET with path params → MCP resource template
- POST/PUT/PATCH/DELETE → MCP tool
- Path parameter substitution, query string building, header extraction
- Request body flattening with `body_` prefix convention
- Pluggable HTTP client interface

### `src/openapi.test.ts` — Tests
- Route extraction, classification, parameter building
- `$ref` resolution
- Request body handling

## Usage

```typescript
import { fromOpenAPI } from "fastmcp/openapi";

const spec = JSON.parse(fs.readFileSync("openapi.json", "utf-8"));
const { tools, resources, resourceTemplates } = fromOpenAPI({
  spec,
  client: {
    request: async (config) => {
      const res = await fetch(config.url, {
        method: config.method,
        headers: config.headers,
        body: config.body ? JSON.stringify(config.body) : undefined,
      });
      return { status: res.status, data: await res.json() };
    },
  },
});

const mcp = new FastMCP({ name: "My API", version: "1.0.0" });
tools.forEach((t) => mcp.addTool(t));
resources.forEach((r) => mcp.addResource(r));
```

## Design decisions
- **Zero new dependencies** — OpenAPI types are inlined to keep the dependency tree clean
- **Pluggable HTTP client** — Users bring their own fetch/axios/etc via a simple interface
- **Flat body params** — Request body properties are prefixed with `body_` to avoid collisions with path/query params
- **Conservative classification** — Only GET routes become resources; everything else is a tool