### PR TITLE
Add plugin.yaml for agent discovery & registry

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,47 @@
+# plugin.yaml — FastMCP Agent Plugin Manifest
+# This file makes FastMCP discoverable as an agent plugin.
+# Learn more: https://list.agenium.net/plugins
+
+name: fastmcp
+display_name: FastMCP
+version: "1.0.0"
+description: >
+  TypeScript framework for building MCP (Model Context Protocol) servers
+  with automatic tool discovery, type-safe schemas, and zero boilerplate.
+
+author:
+  name: punkpeye
+  url: https://github.com/punkpeye
+
+repository: https://github.com/punkpeye/fastmcp
+license: MIT
+
+categories:
+  - mcp-servers
+  - developer-tools
+  - frameworks
+
+tags:
+  - mcp
+  - model-context-protocol
+  - typescript
+  - agent-tools
+  - server-framework
+
+capabilities:
+  - tool-serving
+  - resource-providing
+  - prompt-templates
+
+install:
+  npm: fastmcp
+
+runtime:
+  language: typescript
+  min_node: "18"
+
+discovery:
+  protocol: mcp
+  transport:
+    - stdio
+    - sse

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -40,8 +40,8 @@ runtime:
   language: typescript
   min_node: "18"
 
-discovery:
-  protocol: mcp
-  transport:
+protocols:
+  - mcp
+transport:
     - stdio
     - sse


### PR DESCRIPTION
## What

Adds a `plugin.yaml` manifest file that describes FastMCP as a discoverable agent plugin.

## Why

The AI agent ecosystem is growing fast, but there's no standard way for tools and frameworks to declare themselves as discoverable plugins. A `plugin.yaml` at the repo root lets registries, package managers, and other agents automatically find and understand what FastMCP offers.

**Think of it like:**
- `package.json` for npm
- `pyproject.toml` for Python
- `plugin.yaml` for agent tools

## What it includes

- **Metadata**: name, description, author, license
- **Capabilities**: what FastMCP can do (tool-serving, resources, prompts)
- **Install info**: how to install (`npm install fastmcp`)
- **Discovery**: protocol and transport support (MCP stdio/SSE)
- **Categories & tags**: for search and filtering

## Impact

- Zero code changes — just a metadata file
- No dependencies added
- Makes FastMCP easier to find in agent registries
- Standard format other projects are also adopting

---

*Part of an effort to standardize agent plugin discovery across the ecosystem. [Learn more about plugin.yaml](https://list.agenium.net/plugins)*