### PR TITLE
feat: add outputSchema support for structured tool responses — closes #207

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -125,7 +125,7 @@ test("adds tools", async () => {
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (args) => {
+        execute: async (_args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -175,7 +175,7 @@ test("adds tools with Zod v4 schema", async () => {
 
       server.addTool({
         description: "Add two numbers (using Zod v4 schema)",
-        execute: async (args) => {
+        execute: async (_args) => {
           return String(args.a + args.b);
         },
         name: "add-zod-v4",
@@ -233,7 +233,7 @@ test("calls a tool", async () => {
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (args) => {
+        execute: async (_args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -696,7 +696,7 @@ test("handles tool timeout", async () => {
 
       server.addTool({
         description: "Add two numbers with potential timeout",
-        execute: async (args) => {
+        execute: async (_args) => {
           console.log(`Adding ${args.a} and ${args.b}`);
 
           if (args.a > 1000 || args.b > 1000) {
@@ -1009,7 +1009,7 @@ test("embedded resources work in tools", async () => {
 
       server.addTool({
         description: "Get user profile data",
-        execute: async (args) => {
+        execute: async (_args) => {
           return {
             content: [
               {
@@ -1193,7 +1193,7 @@ test("embedded resources work with URI templates and query parameters", async ()
       server.addTool({
         description:
           "Get search resource data using embedded function with query parameters",
-        execute: async (args) => {
+        execute: async (_args) => {
           return {
             content: [
               {
@@ -1303,7 +1303,7 @@ test("embedded resources work with complex URI template patterns", async () => {
       server.addTool({
         description:
           "Get user data using complex URI templates with path and query parameters",
-        execute: async (args) => {
+        execute: async (_args) => {
           return {
             content: [
               {
@@ -1947,7 +1947,7 @@ test(
 
     server.addTool({
       description: "Add two numbers",
-      execute: async (args) => {
+      execute: async (_args) => {
         return String(args.a + args.b);
       },
       name: "add",
@@ -2159,7 +2159,7 @@ test("throws ErrorCode.InvalidParams if tool parameters do not match zod schema"
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (args) => {
+        execute: async (_args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -2217,7 +2217,7 @@ test("server remains usable after InvalidParams error", async () => {
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (args) => {
+        execute: async (_args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -2242,7 +2242,7 @@ test("allows new clients to connect after a client disconnects", async () => {
 
   server.addTool({
     description: "Add two numbers",
-    execute: async (args) => {
+    execute: async (_args) => {
       return String(args.a + args.b);
     },
     name: "add",
@@ -2352,7 +2352,7 @@ test("closing event source does not produce error", async () => {
 
   server.addTool({
     description: "Add two numbers",
-    execute: async (args) => {
+    execute: async (_args) => {
       return String(args.a + args.b);
     },
     name: "add",
@@ -3363,7 +3363,7 @@ test("HTTP Stream: calls a tool", { timeout: 20000 }, async () => {
 
   server.addTool({
     description: "Add two numbers",
-    execute: async (args) => {
+    execute: async (_args) => {
       return String(args.a + args.b);
     },
     name: "add",
@@ -3474,7 +3474,7 @@ test("uses `formatInvalidParamsErrorMessage` callback to build ErrorCode.Invalid
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (args) => {
+        execute: async (_args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -3499,7 +3499,7 @@ test("stateless mode works correctly", async () => {
 
   server.addTool({
     description: "Add two numbers",
-    execute: async (args) => {
+    execute: async (_args) => {
       return String(args.a + args.b);
     },
     name: "add",
@@ -4641,7 +4641,7 @@ test("adds tools with outputSchema", async () => {
 
       server.addTool({
         description: "Get weather for a city",
-        execute: async (args) => {
+        execute: async (_args) => {
           return JSON.stringify({ humidity: 65, temperature: 72 });
         },
         name: "get-weather",

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4629,7 +4629,7 @@ test("adds tools with outputSchema", async () => {
           humidity: { type: "number" },
           temperature: { type: "number" },
         },
-        required: ["temperature", "humidity"],
+        required: ["humidity", "temperature"],
         type: "object",
       });
     },

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -125,7 +125,7 @@ test("adds tools", async () => {
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (_args) => {
+        execute: async (args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -175,7 +175,7 @@ test("adds tools with Zod v4 schema", async () => {
 
       server.addTool({
         description: "Add two numbers (using Zod v4 schema)",
-        execute: async (_args) => {
+        execute: async (args) => {
           return String(args.a + args.b);
         },
         name: "add-zod-v4",
@@ -233,7 +233,7 @@ test("calls a tool", async () => {
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (_args) => {
+        execute: async (args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -696,7 +696,7 @@ test("handles tool timeout", async () => {
 
       server.addTool({
         description: "Add two numbers with potential timeout",
-        execute: async (_args) => {
+        execute: async (args) => {
           console.log(`Adding ${args.a} and ${args.b}`);
 
           if (args.a > 1000 || args.b > 1000) {
@@ -1009,7 +1009,7 @@ test("embedded resources work in tools", async () => {
 
       server.addTool({
         description: "Get user profile data",
-        execute: async (_args) => {
+        execute: async (args) => {
           return {
             content: [
               {
@@ -1193,7 +1193,7 @@ test("embedded resources work with URI templates and query parameters", async ()
       server.addTool({
         description:
           "Get search resource data using embedded function with query parameters",
-        execute: async (_args) => {
+        execute: async (args) => {
           return {
             content: [
               {
@@ -1303,7 +1303,7 @@ test("embedded resources work with complex URI template patterns", async () => {
       server.addTool({
         description:
           "Get user data using complex URI templates with path and query parameters",
-        execute: async (_args) => {
+        execute: async (args) => {
           return {
             content: [
               {
@@ -1947,7 +1947,7 @@ test(
 
     server.addTool({
       description: "Add two numbers",
-      execute: async (_args) => {
+      execute: async (args) => {
         return String(args.a + args.b);
       },
       name: "add",
@@ -2159,7 +2159,7 @@ test("throws ErrorCode.InvalidParams if tool parameters do not match zod schema"
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (_args) => {
+        execute: async (args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -2217,7 +2217,7 @@ test("server remains usable after InvalidParams error", async () => {
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (_args) => {
+        execute: async (args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -2242,7 +2242,7 @@ test("allows new clients to connect after a client disconnects", async () => {
 
   server.addTool({
     description: "Add two numbers",
-    execute: async (_args) => {
+    execute: async (args) => {
       return String(args.a + args.b);
     },
     name: "add",
@@ -2352,7 +2352,7 @@ test("closing event source does not produce error", async () => {
 
   server.addTool({
     description: "Add two numbers",
-    execute: async (_args) => {
+    execute: async (args) => {
       return String(args.a + args.b);
     },
     name: "add",
@@ -3363,7 +3363,7 @@ test("HTTP Stream: calls a tool", { timeout: 20000 }, async () => {
 
   server.addTool({
     description: "Add two numbers",
-    execute: async (_args) => {
+    execute: async (args) => {
       return String(args.a + args.b);
     },
     name: "add",
@@ -3474,7 +3474,7 @@ test("uses `formatInvalidParamsErrorMessage` callback to build ErrorCode.Invalid
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (_args) => {
+        execute: async (args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -3499,7 +3499,7 @@ test("stateless mode works correctly", async () => {
 
   server.addTool({
     description: "Add two numbers",
-    execute: async (_args) => {
+    execute: async (args) => {
       return String(args.a + args.b);
     },
     name: "add",
@@ -4641,7 +4641,7 @@ test("adds tools with outputSchema", async () => {
 
       server.addTool({
         description: "Get weather for a city",
-        execute: async (_args) => {
+        execute: async () => {
           return JSON.stringify({ humidity: 65, temperature: 72 });
         },
         name: "get-weather",

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4605,3 +4605,87 @@ test("OAuth config with only protectedResource returns Bearer WWW-Authenticate",
     await server.stop();
   }
 });
+
+test("adds tools with outputSchema", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const { tools } = await client.listTools();
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe("get-weather");
+      expect(tools[0].inputSchema).toEqual({
+        $schema: "http://json-schema.org/draft-07/schema#",
+        additionalProperties: false,
+        properties: {
+          city: { type: "string" },
+        },
+        required: ["city"],
+        type: "object",
+      });
+      // outputSchema should be present in the raw response
+      expect((tools[0] as Record<string, unknown>).outputSchema).toEqual({
+        $schema: "http://json-schema.org/draft-07/schema#",
+        additionalProperties: false,
+        properties: {
+          humidity: { type: "number" },
+          temperature: { type: "number" },
+        },
+        required: ["temperature", "humidity"],
+        type: "object",
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Get weather for a city",
+        execute: async (args) => {
+          return JSON.stringify({ humidity: 65, temperature: 72 });
+        },
+        name: "get-weather",
+        outputSchema: z.object({
+          humidity: z.number(),
+          temperature: z.number(),
+        }),
+        parameters: z.object({
+          city: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("tools without outputSchema omit it from listing", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const { tools } = await client.listTools();
+      expect(tools).toHaveLength(1);
+      expect(
+        (tools[0] as Record<string, unknown>).outputSchema,
+      ).toBeUndefined();
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "A simple tool",
+        execute: async () => {
+          return "hello";
+        },
+        name: "greet",
+        parameters: z.object({
+          name: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -940,6 +940,7 @@ type Tool<
     | void
   >;
   name: string;
+  outputSchema?: Params;
   parameters?: Params;
   timeoutMs?: number;
 };
@@ -1913,6 +1914,9 @@ export class FastMCPSession<
                   type: "object",
                 }) as SDKTool["inputSchema"],
             name: tool.name,
+            ...(tool.outputSchema && {
+              outputSchema: await toJsonSchema(tool.outputSchema),
+            }),
             // Pass through _meta for MCP ext-apps UI support (issue #229)
             ...(tool._meta && { _meta: tool._meta }),
           };

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -901,6 +901,7 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
 type Tool<
   T extends FastMCPSessionAuth,
   Params extends ToolParameters = ToolParameters,
+  OutputParams extends ToolParameters = ToolParameters,
 > = {
   /**
    * MCP ext-apps metadata for linking interactive UI components.
@@ -940,7 +941,7 @@ type Tool<
     | void
   >;
   name: string;
-  outputSchema?: Params;
+  outputSchema?: OutputParams;
   parameters?: Params;
   timeoutMs?: number;
 };
@@ -1915,7 +1916,9 @@ export class FastMCPSession<
                 }) as SDKTool["inputSchema"],
             name: tool.name,
             ...(tool.outputSchema && {
-              outputSchema: await toJsonSchema(tool.outputSchema),
+              outputSchema: (await toJsonSchema(
+                tool.outputSchema,
+              )) as SDKTool["inputSchema"],
             }),
             // Pass through _meta for MCP ext-apps UI support (issue #229)
             ...(tool._meta && { _meta: tool._meta }),


### PR DESCRIPTION
## Summary

Adds optional `outputSchema` support to tool definitions, as requested in #207.

This allows tools to declare the expected structure of their output using Zod schemas (or any Standard Schema), which gets converted to JSON Schema and included in the `listTools` response.

## Changes

- **`Tool` type**: Added optional `outputSchema?: Params` field
- **Listing handler**: When `outputSchema` is present, converts it via `toJsonSchema()` and includes it in the tool listing response
- **Backward compatible**: Tools without `outputSchema` behave exactly as before — no changes to existing API

## MCP Spec Context

The MCP specification (2025-03-26) supports `outputSchema` on tools for structured responses. This enables clients to validate tool output and provide better UX for structured data.

## Tests

- ✅ Tool with `outputSchema` includes converted schema in listing
- ✅ Tool without `outputSchema` omits it from listing (no regression)

Closes #207