### PR TITLE
docs: add create-mcp-server CLI as alternative to boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ npx fastmcp inspect src/examples/addition.ts
 
 If you are looking for a boilerplate repository to build your own MCP server, check out [fastmcp-boilerplate](https://github.com/punkpeye/fastmcp-boilerplate).
 
+Alternatively, you can scaffold a new project from the command line using `create-mcp-server`:
+
+```bash
+# For more options, see https://github.com/agentailor/create-mcp-server
+npx @agentailor/create-mcp-server --framework=fastmcp
+```
+
 ### Remote Server Options
 
 FastMCP supports multiple transport options for remote communication, allowing an MCP hosted on a remote machine to be accessed over the network.


### PR DESCRIPTION
I'm the author of create-mcp-server, a CLI that scaffolds MCP server projects. I added FastMCP as a supported framework alongside the official sdk a while back, and thought it'd be useful to mention it in the README as an alternative to cloning the boilerplate.

npx @agentailor/create-mcp-server --framework=fastmcp
Happy to adjust the wording if needed.