### PR TITLE
chore: update code example with current get-jwks and fast-jwt API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1773,11 +1773,11 @@ const server = new FastMCP({
           const publicKey = await getJwks.getPublicKey({
             kid: header.kid,
             alg: header.alg,
-            domain: 'https://auth.example.com',
-          })
-          return publicKey
+            domain: "https://auth.example.com",
+          });
+          return publicKey;
         },
-        algorithms: ['RS256'],
+        algorithms: ["RS256"],
       });
 
       // Verify the JWT token

--- a/README.md
+++ b/README.md
@@ -1729,14 +1729,9 @@ const server = new FastMCP({
 FastMCP also supports OAuth discovery endpoints for direct integration with OAuth providers, supporting both **MCP Specification 2025-03-26** and **MCP Specification 2025-06-18**. This provides standard discovery endpoints that comply with RFC 8414 (OAuth 2.0 Authorization Server Metadata) and RFC 9470 (OAuth 2.0 Protected Resource Metadata):
 
 ```ts
-import { FastMCP, DiscoveryDocumentCache } from "fastmcp";
-import { buildGetJwks } from "get-jwks";
-import fastJwt from "fast-jwt";
-
-// Create a cache for discovery documents (reuse across requests)
-const discoveryCache = new DiscoveryDocumentCache({
-  ttl: 3600000, // Cache for 1 hour (default)
-});
+import { FastMCP } from "fastmcp";
+import buildGetJwks from "get-jwks";
+import fastJwt, { type DecodedJwt } from "fast-jwt";
 
 const server = new FastMCP({
   name: "My Server",
@@ -1769,39 +1764,20 @@ const server = new FastMCP({
 
     // Validate OAuth JWT access token using OpenID Connect discovery
     try {
-      // Fetch and cache the discovery document
-      const discoveryUrl =
-        "https://auth.example.com/.well-known/openid-configuration";
-      // Alternative: Use OAuth authorization server metadata endpoint
-      // const discoveryUrl = 'https://auth.example.com/.well-known/oauth-authorization-server';
+      // Create JWKS client for token verification
+      const getJwks = buildGetJwks();
 
-      const config = (await discoveryCache.get(discoveryUrl)) as {
-        jwks_uri: string;
-        issuer: string;
-      };
-      const jwksUri = config.jwks_uri;
-      const issuer = config.issuer;
-
-      // Create JWKS client for token verification using discovered endpoint
-      const getJwks = buildGetJwks({
-        jwksUrl: jwksUri,
-        cache: true,
-        rateLimit: true,
-      });
-
-      // Create JWT verifier with JWKS and discovered issuer
+      // Create JWT verifier
       const verify = fastJwt.createVerifier({
-        key: async (token) => {
-          const { header } = fastJwt.decode(token, { complete: true });
-          const jwk = await getJwks.getJwk({
+        async key({ header }: DecodedJwt) {
+          const publicKey = await getJwks.getPublicKey({
             kid: header.kid,
             alg: header.alg,
-          });
-          return jwk;
+            domain: 'https://auth.example.com',
+          })
+          return publicKey
         },
-        algorithms: ["RS256", "ES256"],
-        issuer: issuer,
-        audience: "mcp://my-server",
+        algorithms: ['RS256'],
       });
 
       // Verify the JWT token
@@ -1839,7 +1815,7 @@ Clients discover protected resource metadata using the following search order:
 
 Both the sub-path and root endpoints return identical metadata, ensuring compatibility with all MCP client implementations.
 
-For JWT token validation, you can use libraries like [`get-jwks`](https://github.com/nearform/get-jwks) and [`@fastify/jwt`](https://github.com/fastify/fastify-jwt) for OAuth JWT tokens.
+For JWT token validation, you can use libraries like [`get-jwks`](https://github.com/nearform/get-jwks) and [`fast-jwt`](https://github.com/nearform/fast-jwt) for OAuth JWT tokens.
 
 #### Passing Headers Through Context
 


### PR DESCRIPTION
Following your code example I quickly noticed it was out of date with the current APIs from `get-jwks` and `fast-jwt`. I had to go to their respective documentation to know how to use them in my project which is fine but it's nicer to have it all updated in one place.

So, this is just a quick update to your code example for the OAuth Discovery Endpoints section.