### PR TITLE
feat: add onToolCall callback

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -837,6 +837,64 @@ test("sends logging messages to the client", async () => {
   });
 });
 
+test("tool log calls are forwarded to custom logger", async () => {
+  const customLogger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  await runWithTestServer({
+    run: async ({ client }) => {
+      await client.callTool({
+        arguments: {
+          a: 1,
+          b: 2,
+        },
+        name: "add",
+      });
+
+      expect(customLogger.debug).toHaveBeenCalledWith("debug message", {
+        foo: "bar",
+      });
+      expect(customLogger.error).toHaveBeenCalledWith(
+        "error message",
+        undefined,
+      );
+      expect(customLogger.info).toHaveBeenCalledWith("info message", undefined);
+      expect(customLogger.warn).toHaveBeenCalledWith("warn message", undefined);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        logger: customLogger,
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Add two numbers",
+        execute: async (args, { log }) => {
+          log.debug("debug message", { foo: "bar" });
+          log.error("error message");
+          log.info("info message");
+          log.warn("warn message");
+
+          return String(args.a + args.b);
+        },
+        name: "add",
+        parameters: z.object({
+          a: z.number(),
+          b: z.number(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
 test("adds resources", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -837,14 +837,8 @@ test("sends logging messages to the client", async () => {
   });
 });
 
-test("tool log calls are forwarded to custom logger", async () => {
-  const customLogger = {
-    debug: vi.fn(),
-    error: vi.fn(),
-    info: vi.fn(),
-    log: vi.fn(),
-    warn: vi.fn(),
-  };
+test("onToolCall callback is invoked with tool name and arguments", async () => {
+  const onToolCall = vi.fn();
 
   await runWithTestServer({
     run: async ({ client }) => {
@@ -856,28 +850,21 @@ test("tool log calls are forwarded to custom logger", async () => {
         name: "add",
       });
 
-      expect(customLogger.debug).toHaveBeenCalledWith("debug message", {
-        foo: "bar",
+      expect(onToolCall).toHaveBeenCalledWith({
+        arguments: { a: 1, b: 2 },
+        toolName: "add",
       });
-      expect(customLogger.error).toHaveBeenCalledWith("error message");
-      expect(customLogger.info).toHaveBeenCalledWith("info message");
-      expect(customLogger.warn).toHaveBeenCalledWith("warn message");
     },
     server: async () => {
       const server = new FastMCP({
-        logger: customLogger,
         name: "Test",
+        onToolCall,
         version: "1.0.0",
       });
 
       server.addTool({
         description: "Add two numbers",
-        execute: async (args, { log }) => {
-          log.debug("debug message", { foo: "bar" });
-          log.error("error message");
-          log.info("info message");
-          log.warn("warn message");
-
+        execute: async (args) => {
           return String(args.a + args.b);
         },
         name: "add",
@@ -890,75 +877,6 @@ test("tool log calls are forwarded to custom logger", async () => {
       return server;
     },
   });
-});
-
-test("tool log calls do not go to default console logger", async () => {
-  const consoleSpy = {
-    debug: vi.spyOn(console, "debug"),
-    error: vi.spyOn(console, "error"),
-    info: vi.spyOn(console, "info"),
-    warn: vi.spyOn(console, "warn"),
-  };
-
-  await runWithTestServer({
-    run: async ({ client }) => {
-      // Reset spies after server startup logs
-      consoleSpy.debug.mockClear();
-      consoleSpy.error.mockClear();
-      consoleSpy.info.mockClear();
-      consoleSpy.warn.mockClear();
-
-      await client.callTool({
-        arguments: {
-          a: 1,
-          b: 2,
-        },
-        name: "add",
-      });
-
-      // Tool log calls should NOT be forwarded to console when no custom logger
-      for (const spy of Object.values(consoleSpy)) {
-        for (const call of spy.mock.calls) {
-          expect(call[0]).not.toBe("tool debug");
-          expect(call[0]).not.toBe("tool error");
-          expect(call[0]).not.toBe("tool info");
-          expect(call[0]).not.toBe("tool warn");
-        }
-      }
-    },
-    server: async () => {
-      // No custom logger — uses default console
-      const server = new FastMCP({
-        name: "Test",
-        version: "1.0.0",
-      });
-
-      server.addTool({
-        description: "Add two numbers",
-        execute: async (args, { log }) => {
-          log.debug("tool debug");
-          log.error("tool error");
-          log.info("tool info");
-          log.warn("tool warn");
-
-          return String(args.a + args.b);
-        },
-        name: "add",
-        parameters: z.object({
-          a: z.number(),
-          b: z.number(),
-        }),
-      });
-
-      return server;
-    },
-  });
-
-  // Restore console
-  consoleSpy.debug.mockRestore();
-  consoleSpy.error.mockRestore();
-  consoleSpy.info.mockRestore();
-  consoleSpy.warn.mockRestore();
 });
 
 test("adds resources", async () => {

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -859,12 +859,9 @@ test("tool log calls are forwarded to custom logger", async () => {
       expect(customLogger.debug).toHaveBeenCalledWith("debug message", {
         foo: "bar",
       });
-      expect(customLogger.error).toHaveBeenCalledWith(
-        "error message",
-        undefined,
-      );
-      expect(customLogger.info).toHaveBeenCalledWith("info message", undefined);
-      expect(customLogger.warn).toHaveBeenCalledWith("warn message", undefined);
+      expect(customLogger.error).toHaveBeenCalledWith("error message");
+      expect(customLogger.info).toHaveBeenCalledWith("info message");
+      expect(customLogger.warn).toHaveBeenCalledWith("warn message");
     },
     server: async () => {
       const server = new FastMCP({
@@ -893,6 +890,75 @@ test("tool log calls are forwarded to custom logger", async () => {
       return server;
     },
   });
+});
+
+test("tool log calls do not go to default console logger", async () => {
+  const consoleSpy = {
+    debug: vi.spyOn(console, "debug"),
+    error: vi.spyOn(console, "error"),
+    info: vi.spyOn(console, "info"),
+    warn: vi.spyOn(console, "warn"),
+  };
+
+  await runWithTestServer({
+    run: async ({ client }) => {
+      // Reset spies after server startup logs
+      consoleSpy.debug.mockClear();
+      consoleSpy.error.mockClear();
+      consoleSpy.info.mockClear();
+      consoleSpy.warn.mockClear();
+
+      await client.callTool({
+        arguments: {
+          a: 1,
+          b: 2,
+        },
+        name: "add",
+      });
+
+      // Tool log calls should NOT be forwarded to console when no custom logger
+      for (const spy of Object.values(consoleSpy)) {
+        for (const call of spy.mock.calls) {
+          expect(call[0]).not.toBe("tool debug");
+          expect(call[0]).not.toBe("tool error");
+          expect(call[0]).not.toBe("tool info");
+          expect(call[0]).not.toBe("tool warn");
+        }
+      }
+    },
+    server: async () => {
+      // No custom logger — uses default console
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Add two numbers",
+        execute: async (args, { log }) => {
+          log.debug("tool debug");
+          log.error("tool error");
+          log.info("tool info");
+          log.warn("tool warn");
+
+          return String(args.a + args.b);
+        },
+        name: "add",
+        parameters: z.object({
+          a: z.number(),
+          b: z.number(),
+        }),
+      });
+
+      return server;
+    },
+  });
+
+  // Restore console
+  consoleSpy.debug.mockRestore();
+  consoleSpy.error.mockRestore();
+  consoleSpy.info.mockRestore();
+  consoleSpy.warn.mockRestore();
 });
 
 test("adds resources", async () => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -857,6 +857,14 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
      */
     proxy?: OAuthProxy;
   };
+  /**
+   * Callback invoked when a tool is called.
+   * Use this to log, audit, or track tool usage.
+   */
+  onToolCall?: (context: {
+    arguments: Record<string, unknown>;
+    toolName: string;
+  }) => Promise<void> | void;
 
   ping?: {
     /**
@@ -1088,8 +1096,8 @@ export class FastMCPSession<
   #connectionState: "closed" | "connecting" | "error" | "ready" = "connecting";
   #logger: Logger;
   #loggingLevel: LoggingLevel = "info";
-  #logToolCalls: boolean;
   #needsEventLoopFlush: boolean = false;
+  #onToolCall?: ServerOptions<T>["onToolCall"];
   #pingConfig?: ServerOptions<T>["ping"];
 
   #pingInterval: null | ReturnType<typeof setInterval> = null;
@@ -1118,8 +1126,8 @@ export class FastMCPSession<
     auth,
     instructions,
     logger,
-    logToolCalls,
     name,
+    onToolCall,
     ping,
     prompts,
     resources,
@@ -1134,8 +1142,8 @@ export class FastMCPSession<
     auth?: T;
     instructions?: string;
     logger: Logger;
-    logToolCalls?: boolean;
     name: string;
+    onToolCall?: ServerOptions<T>["onToolCall"];
     ping?: ServerOptions<T>["ping"];
     prompts: Prompt<T>[];
     resources: Resource<T>[];
@@ -1151,7 +1159,7 @@ export class FastMCPSession<
 
     this.#auth = auth;
     this.#logger = logger;
-    this.#logToolCalls = logToolCalls ?? false;
+    this.#onToolCall = onToolCall;
     this.#pingConfig = ping;
     this.#rootsConfig = roots;
     this.#sessionId = sessionId;
@@ -2001,11 +2009,6 @@ export class FastMCPSession<
 
         const log = {
           debug: (message: string, context?: SerializableValue) => {
-            if (this.#logToolCalls) {
-              this.#logger.debug(
-                ...(context !== undefined ? [message, context] : [message]),
-              );
-            }
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2015,11 +2018,6 @@ export class FastMCPSession<
             });
           },
           error: (message: string, context?: SerializableValue) => {
-            if (this.#logToolCalls) {
-              this.#logger.error(
-                ...(context !== undefined ? [message, context] : [message]),
-              );
-            }
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2029,11 +2027,6 @@ export class FastMCPSession<
             });
           },
           info: (message: string, context?: SerializableValue) => {
-            if (this.#logToolCalls) {
-              this.#logger.info(
-                ...(context !== undefined ? [message, context] : [message]),
-              );
-            }
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2043,11 +2036,6 @@ export class FastMCPSession<
             });
           },
           warn: (message: string, context?: SerializableValue) => {
-            if (this.#logToolCalls) {
-              this.#logger.warn(
-                ...(context !== undefined ? [message, context] : [message]),
-              );
-            }
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2085,6 +2073,13 @@ export class FastMCPSession<
             );
           }
         };
+
+        if (this.#onToolCall) {
+          await this.#onToolCall({
+            arguments: (args ?? {}) as Record<string, unknown>,
+            toolName: request.params.name,
+          });
+        }
 
         const executeToolPromise = tool.execute(args, {
           client: {
@@ -2241,7 +2236,6 @@ export class FastMCP<
   #honoApp = new Hono();
   #httpStreamServer: null | SSEServer = null;
   #logger: Logger;
-  #logToolCalls: boolean;
   #options: ServerOptions<T>;
   #prompts: InputPrompt<T>[] = [];
   #resources: Resource<T>[] = [];
@@ -2255,7 +2249,6 @@ export class FastMCP<
     super();
 
     this.#options = options;
-    this.#logToolCalls = !!options.logger;
     this.#logger = options.logger || console;
 
     // If auth provider is specified, use it to configure authenticate and oauth
@@ -2612,8 +2605,8 @@ export class FastMCP<
         auth,
         instructions: this.#options.instructions,
         logger: this.#logger,
-        logToolCalls: this.#logToolCalls,
         name: this.#options.name,
+        onToolCall: this.#options.onToolCall,
         ping: this.#options.ping,
         prompts: this.#prompts,
         resources: this.#resources,
@@ -2844,8 +2837,8 @@ export class FastMCP<
       auth,
       instructions: this.#options.instructions,
       logger: this.#logger,
-      logToolCalls: this.#logToolCalls,
       name: this.#options.name,
+      onToolCall: this.#options.onToolCall,
       ping: this.#options.ping,
       prompts: this.#prompts,
       resources: this.#resources,

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1086,6 +1086,7 @@ export class FastMCPSession<
   #capabilities: ServerCapabilities = {};
   #clientCapabilities?: ClientCapabilities;
   #connectionState: "closed" | "connecting" | "error" | "ready" = "connecting";
+  #logToolCalls: boolean;
   #logger: Logger;
   #loggingLevel: LoggingLevel = "info";
   #needsEventLoopFlush: boolean = false;
@@ -1116,6 +1117,7 @@ export class FastMCPSession<
   constructor({
     auth,
     instructions,
+    logToolCalls,
     logger,
     name,
     ping,
@@ -1131,6 +1133,7 @@ export class FastMCPSession<
   }: {
     auth?: T;
     instructions?: string;
+    logToolCalls?: boolean;
     logger: Logger;
     name: string;
     ping?: ServerOptions<T>["ping"];
@@ -1147,6 +1150,7 @@ export class FastMCPSession<
     super();
 
     this.#auth = auth;
+    this.#logToolCalls = logToolCalls ?? false;
     this.#logger = logger;
     this.#pingConfig = ping;
     this.#rootsConfig = roots;
@@ -1997,7 +2001,11 @@ export class FastMCPSession<
 
         const log = {
           debug: (message: string, context?: SerializableValue) => {
-            this.#logger.debug(message, context);
+            if (this.#logToolCalls) {
+              this.#logger.debug(
+                ...(context !== undefined ? [message, context] : [message]),
+              );
+            }
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2007,7 +2015,11 @@ export class FastMCPSession<
             });
           },
           error: (message: string, context?: SerializableValue) => {
-            this.#logger.error(message, context);
+            if (this.#logToolCalls) {
+              this.#logger.error(
+                ...(context !== undefined ? [message, context] : [message]),
+              );
+            }
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2017,7 +2029,11 @@ export class FastMCPSession<
             });
           },
           info: (message: string, context?: SerializableValue) => {
-            this.#logger.info(message, context);
+            if (this.#logToolCalls) {
+              this.#logger.info(
+                ...(context !== undefined ? [message, context] : [message]),
+              );
+            }
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2027,7 +2043,11 @@ export class FastMCPSession<
             });
           },
           warn: (message: string, context?: SerializableValue) => {
-            this.#logger.warn(message, context);
+            if (this.#logToolCalls) {
+              this.#logger.warn(
+                ...(context !== undefined ? [message, context] : [message]),
+              );
+            }
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2220,6 +2240,7 @@ export class FastMCP<
   #authenticate: Authenticate<T> | undefined;
   #honoApp = new Hono();
   #httpStreamServer: null | SSEServer = null;
+  #logToolCalls: boolean;
   #logger: Logger;
   #options: ServerOptions<T>;
   #prompts: InputPrompt<T>[] = [];
@@ -2234,6 +2255,7 @@ export class FastMCP<
     super();
 
     this.#options = options;
+    this.#logToolCalls = !!options.logger;
     this.#logger = options.logger || console;
 
     // If auth provider is specified, use it to configure authenticate and oauth
@@ -2589,6 +2611,7 @@ export class FastMCP<
       const session = new FastMCPSession<T>({
         auth,
         instructions: this.#options.instructions,
+        logToolCalls: this.#logToolCalls,
         logger: this.#logger,
         name: this.#options.name,
         ping: this.#options.ping,
@@ -2820,6 +2843,7 @@ export class FastMCP<
     return new FastMCPSession<T>({
       auth,
       instructions: this.#options.instructions,
+      logToolCalls: this.#logToolCalls,
       logger: this.#logger,
       name: this.#options.name,
       ping: this.#options.ping,

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1086,9 +1086,9 @@ export class FastMCPSession<
   #capabilities: ServerCapabilities = {};
   #clientCapabilities?: ClientCapabilities;
   #connectionState: "closed" | "connecting" | "error" | "ready" = "connecting";
-  #logToolCalls: boolean;
   #logger: Logger;
   #loggingLevel: LoggingLevel = "info";
+  #logToolCalls: boolean;
   #needsEventLoopFlush: boolean = false;
   #pingConfig?: ServerOptions<T>["ping"];
 
@@ -1117,8 +1117,8 @@ export class FastMCPSession<
   constructor({
     auth,
     instructions,
-    logToolCalls,
     logger,
+    logToolCalls,
     name,
     ping,
     prompts,
@@ -1133,8 +1133,8 @@ export class FastMCPSession<
   }: {
     auth?: T;
     instructions?: string;
-    logToolCalls?: boolean;
     logger: Logger;
+    logToolCalls?: boolean;
     name: string;
     ping?: ServerOptions<T>["ping"];
     prompts: Prompt<T>[];
@@ -1150,8 +1150,8 @@ export class FastMCPSession<
     super();
 
     this.#auth = auth;
-    this.#logToolCalls = logToolCalls ?? false;
     this.#logger = logger;
+    this.#logToolCalls = logToolCalls ?? false;
     this.#pingConfig = ping;
     this.#rootsConfig = roots;
     this.#sessionId = sessionId;
@@ -2240,8 +2240,8 @@ export class FastMCP<
   #authenticate: Authenticate<T> | undefined;
   #honoApp = new Hono();
   #httpStreamServer: null | SSEServer = null;
-  #logToolCalls: boolean;
   #logger: Logger;
+  #logToolCalls: boolean;
   #options: ServerOptions<T>;
   #prompts: InputPrompt<T>[] = [];
   #resources: Resource<T>[] = [];
@@ -2611,8 +2611,8 @@ export class FastMCP<
       const session = new FastMCPSession<T>({
         auth,
         instructions: this.#options.instructions,
-        logToolCalls: this.#logToolCalls,
         logger: this.#logger,
+        logToolCalls: this.#logToolCalls,
         name: this.#options.name,
         ping: this.#options.ping,
         prompts: this.#prompts,
@@ -2843,8 +2843,8 @@ export class FastMCP<
     return new FastMCPSession<T>({
       auth,
       instructions: this.#options.instructions,
-      logToolCalls: this.#logToolCalls,
       logger: this.#logger,
+      logToolCalls: this.#logToolCalls,
       name: this.#options.name,
       ping: this.#options.ping,
       prompts: this.#prompts,

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1997,6 +1997,7 @@ export class FastMCPSession<
 
         const log = {
           debug: (message: string, context?: SerializableValue) => {
+            this.#logger.debug(message, context);
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2006,6 +2007,7 @@ export class FastMCPSession<
             });
           },
           error: (message: string, context?: SerializableValue) => {
+            this.#logger.error(message, context);
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2015,6 +2017,7 @@ export class FastMCPSession<
             });
           },
           info: (message: string, context?: SerializableValue) => {
+            this.#logger.info(message, context);
             this.#server.sendLoggingMessage({
               data: {
                 context,
@@ -2024,6 +2027,7 @@ export class FastMCPSession<
             });
           },
           warn: (message: string, context?: SerializableValue) => {
+            this.#logger.warn(message, context);
             this.#server.sendLoggingMessage({
               data: {
                 context,


### PR DESCRIPTION
## Summary

- Add `onToolCall` callback option to `ServerOptions`, invoked when a tool is called
- Consumers can use it to log, audit, or track tool usage however they prefer

## Changes

- **`src/FastMCP.ts`**: Add `onToolCall` option to `ServerOptions`, pass it through to `FastMCPSession`, and invoke it before tool execution with `{ toolName, arguments }`
- **`src/FastMCP.test.ts`**: Add test verifying `onToolCall` is invoked with correct tool name and arguments

## Testing

- All tests pass
- Linting passes (Prettier + ESLint)
- Build succeeds

Fixes #163