### PR TITLE
fix(auth): handle non-JSON error responses from upstream OAuth providers

### DIFF
--- a/src/auth/OAuthProxy.token-parsing.test.ts
+++ b/src/auth/OAuthProxy.token-parsing.test.ts
@@ -414,4 +414,79 @@ describe("OAuthProxy - Token Response Parsing", () => {
       proxy.destroy();
     });
   });
+
+  describe("upstream error response handling", () => {
+    it("should handle non-JSON error from upstream token endpoint without crashing", async () => {
+      // Disable token swap so exchangeRefreshToken goes through handlePassthroughRefresh
+      const proxy = new OAuthProxy({
+        ...baseConfig,
+        enableTokenSwap: false,
+      });
+
+      // Mock global fetch to return an HTML error page (e.g. load balancer 502)
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = async () =>
+        new Response("<html><body>502 Bad Gateway</body></html>", {
+          headers: { "Content-Type": "text/html" },
+          status: 502,
+          statusText: "Bad Gateway",
+        });
+
+      try {
+        // OAuthProxyError uses `code` as the Error message, and stores
+        // the human-readable text in `description`. Verify both.
+        const err = await proxy
+          .exchangeRefreshToken({
+            client_id: "test-client",
+            grant_type: "refresh_token",
+            refresh_token: "test-refresh-token",
+          })
+          .catch((e: any) => e);
+
+        expect(err.name).toBe("OAuthProxyError");
+        expect(err.description).toMatch(/Upstream returned HTTP 502/);
+      } finally {
+        globalThis.fetch = originalFetch;
+        proxy.destroy();
+      }
+    });
+
+    it("should still parse JSON error bodies from upstream when available", async () => {
+      const proxy = new OAuthProxy({
+        ...baseConfig,
+        enableTokenSwap: false,
+      });
+
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = async () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_grant",
+            error_description: "Refresh token expired",
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 400,
+            statusText: "Bad Request",
+          },
+        );
+
+      try {
+        const err = await proxy
+          .exchangeRefreshToken({
+            client_id: "test-client",
+            grant_type: "refresh_token",
+            refresh_token: "expired-token",
+          })
+          .catch((e: any) => e);
+
+        expect(err.name).toBe("OAuthProxyError");
+        expect(err.code).toBe("invalid_grant");
+        expect(err.description).toBe("Refresh token expired");
+      } finally {
+        globalThis.fetch = originalFetch;
+        proxy.destroy();
+      }
+    });
+  });
 });

--- a/src/auth/OAuthProxy.token-parsing.test.ts
+++ b/src/auth/OAuthProxy.token-parsing.test.ts
@@ -433,8 +433,7 @@ describe("OAuthProxy - Token Response Parsing", () => {
         });
 
       try {
-        // OAuthProxyError uses `code` as the Error message, and stores
-        // the human-readable text in `description`. Verify both.
+        // For HTTP-level errors (non-OAuth), description contains the HTTP status.
         const err = await proxy
           .exchangeRefreshToken({
             client_id: "test-client",

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -638,14 +638,19 @@ export class OAuthProxy {
     });
 
     if (!tokenResponse.ok) {
-      const error = (await tokenResponse.json()) as {
-        error?: string;
-        error_description?: string;
-      };
-      throw new OAuthProxyError(
-        error.error || "server_error",
-        error.error_description,
-      );
+      let errorCode = "server_error";
+      let errorDescription: string | undefined;
+      try {
+        const error = (await tokenResponse.json()) as {
+          error?: string;
+          error_description?: string;
+        };
+        errorCode = error.error || "server_error";
+        errorDescription = error.error_description;
+      } catch {
+        errorDescription = `Upstream returned HTTP ${tokenResponse.status} ${tokenResponse.statusText}`;
+      }
+      throw new OAuthProxyError(errorCode, errorDescription);
     }
 
     const tokens = await this.parseTokenResponse(tokenResponse);
@@ -818,14 +823,19 @@ export class OAuthProxy {
     });
 
     if (!tokenResponse.ok) {
-      const error = (await tokenResponse.json()) as {
-        error?: string;
-        error_description?: string;
-      };
-      throw new OAuthProxyError(
-        error.error || "invalid_grant",
-        error.error_description,
-      );
+      let errorCode = "invalid_grant";
+      let errorDescription: string | undefined;
+      try {
+        const error = (await tokenResponse.json()) as {
+          error?: string;
+          error_description?: string;
+        };
+        errorCode = error.error || "invalid_grant";
+        errorDescription = error.error_description;
+      } catch {
+        errorDescription = `Upstream returned HTTP ${tokenResponse.status} ${tokenResponse.statusText}`;
+      }
+      throw new OAuthProxyError(errorCode, errorDescription);
     }
 
     const tokens = await this.parseTokenResponse(tokenResponse);
@@ -1251,14 +1261,20 @@ export class OAuthProxy {
     });
 
     if (!tokenResponse.ok) {
-      const error = (await tokenResponse.json()) as {
-        error?: string;
-        error_description?: string;
-      };
-      throw new OAuthProxyError(
-        error.error || "invalid_grant",
-        error.error_description || "Upstream refresh failed",
-      );
+      let errorCode = "invalid_grant";
+      let errorDescription: string | undefined = "Upstream refresh failed";
+      try {
+        const error = (await tokenResponse.json()) as {
+          error?: string;
+          error_description?: string;
+        };
+        errorCode = error.error || "invalid_grant";
+        errorDescription =
+          error.error_description || "Upstream refresh failed";
+      } catch {
+        errorDescription = `Upstream returned HTTP ${tokenResponse.status} ${tokenResponse.statusText}`;
+      }
+      throw new OAuthProxyError(errorCode, errorDescription);
     }
 
     const tokens = await this.parseTokenResponse(tokenResponse);

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -1269,8 +1269,7 @@ export class OAuthProxy {
           error_description?: string;
         };
         errorCode = error.error || "invalid_grant";
-        errorDescription =
-          error.error_description || "Upstream refresh failed";
+        errorDescription = error.error_description || "Upstream refresh failed";
       } catch {
         errorDescription = `Upstream returned HTTP ${tokenResponse.status} ${tokenResponse.statusText}`;
       }


### PR DESCRIPTION
Ran into this while setting up a fastmcp server behind an AWS ALB with a Google OAuth provider. During a callback, the upstream token endpoint timed out and the load balancer returned an HTML 502 page. Instead of a clean OAuth error, the server crashed with `SyntaxError: Unexpected token < in JSON at position 0` — because the three error paths in `OAuthProxy` call `tokenResponse.json()` unconditionally.

The same file already handles this correctly on the success path — `parseTokenResponse` (line 1129) checks content-type before deciding how to parse. The three error-handling blocks at lines 640, 825, and 1263 skip this entirely and assume the error body is always JSON.

**Before:** When an upstream provider returns a non-JSON error (HTML from load balancers, nginx, Cloudflare challenge pages), `tokenResponse.json()` throws a `SyntaxError` that escapes the OAuth flow. The user sees a raw JSON parse error with no indication of the actual problem.

**After:** Each error path wraps `tokenResponse.json()` in try-catch. If the body isn't valid JSON, the error description falls back to the HTTP status code and status text (e.g., `"Upstream returned HTTP 502 Bad Gateway"`). When the upstream *does* return a JSON error body, the error code and description are still parsed normally.

### Tests

Added two tests to `OAuthProxy.token-parsing.test.ts`:

- **"should handle non-JSON error from upstream token endpoint without crashing"** — mocks `fetch` to return an HTML 502 response; verifies `OAuthProxyError` with the right description. This test fails on the current code (proving the bug).
- **"should still parse JSON error bodies from upstream when available"** — mocks `fetch` to return a JSON 400 with `invalid_grant`; verifies both the error code and description are preserved.

All 20 token-parsing tests pass.