### PR TITLE
fix(auth): fix OAuthProxy credential leak and redirect_uri validation

### DIFF
--- a/src/FastMCP.oauth-proxy.test.ts
+++ b/src/FastMCP.oauth-proxy.test.ts
@@ -153,18 +153,19 @@ describe("FastMCP OAuth Proxy Integration", () => {
     });
 
     try {
-      // First register a client
-      await fetch(`http://localhost:${port}/oauth/register`, {
+      // First register a client and capture the proxy-issued client_id
+      const dcrResp = await fetch(`http://localhost:${port}/oauth/register`, {
         body: JSON.stringify({
           redirect_uris: ["https://client.example.com/callback"],
         }),
         headers: { "Content-Type": "application/json" },
         method: "POST",
       });
+      const dcrData = (await dcrResp.json()) as { client_id: string };
 
       // Test authorization endpoint - should redirect
       const authParams = new URLSearchParams({
-        client_id: "test-client-id",
+        client_id: dcrData.client_id,
         code_challenge: "test-challenge",
         code_challenge_method: "S256",
         redirect_uri: "https://client.example.com/callback",

--- a/src/auth/OAuthProxy.open-redirect.test.ts
+++ b/src/auth/OAuthProxy.open-redirect.test.ts
@@ -86,10 +86,12 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
 
   describe("authorize() rejects unregistered redirect_uri", () => {
     it("rejects an arbitrary attacker host even when client_id is valid", async () => {
-      await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
 
       await expect(
-        proxy.authorize(buildAuthParams({ redirect_uri: EVIL_REDIRECT })),
+        proxy.authorize(
+          buildAuthParams({ client_id: dcr.client_id, redirect_uri: EVIL_REDIRECT }),
+        ),
       ).rejects.toMatchObject({
         code: "invalid_request",
         description: expect.stringContaining("redirect_uri"),
@@ -97,28 +99,30 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
     });
 
     it("rejects redirect_uri before any client has been registered", async () => {
-      // No DCR call at all — registeredClients is empty.
+      // No DCR call at all — registeredClientsByClientId is empty, so we get
+      // invalid_client (unknown client_id) rather than invalid_request.
       await expect(
         proxy.authorize(buildAuthParams({ redirect_uri: LEGIT_REDIRECT })),
-      ).rejects.toMatchObject({ code: "invalid_request" });
+      ).rejects.toMatchObject({ code: "invalid_client" });
     });
 
     it("rejects a URI that only differs by trailing slash (exact match required)", async () => {
-      await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
 
       await expect(
         proxy.authorize(
-          buildAuthParams({ redirect_uri: LEGIT_REDIRECT + "/" }),
+          buildAuthParams({ client_id: dcr.client_id, redirect_uri: LEGIT_REDIRECT + "/" }),
         ),
       ).rejects.toMatchObject({ code: "invalid_request" });
     });
 
     it("rejects a URI whose host only differs in casing (strict string compare)", async () => {
-      await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
 
       await expect(
         proxy.authorize(
           buildAuthParams({
+            client_id: dcr.client_id,
             redirect_uri: "https://CLIENT.example.com/callback",
           }),
         ),
@@ -127,7 +131,7 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
   });
 
   describe("authorize() rejects unknown client_id", () => {
-    it("rejects any client_id that is not the proxy's upstream identity", async () => {
+    it("rejects any client_id that was not issued by this proxy", async () => {
       await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
 
       await expect(
@@ -164,34 +168,44 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
       expect(transactionsField.size).toBe(0);
     });
 
-    it("an attacker cannot bypass the check by calling DCR first (empty patterns default)", async () => {
-      // Simulate a deployment that omitted allowedRedirectUriPatterns entirely.
-      // Under the new default ([]), DCR must reject every URI — so there is
-      // no way for an attacker to self-register evil.attacker.com.
-      const strictProxy = new OAuthProxy({
+    it("an attacker cannot self-register a non-localhost URI with the default config", async () => {
+      // When allowedRedirectUriPatterns is omitted (undefined), the proxy
+      // defaults to localhost-only.  An attacker who controls evil.attacker.com
+      // or a non-localhost https URI cannot self-register through DCR.
+      const defaultProxy = new OAuthProxy({
         ...baseConfig,
         allowedRedirectUriPatterns: undefined,
       });
 
       await expect(
-        strictProxy.registerClient({ redirect_uris: [EVIL_REDIRECT] }),
+        defaultProxy.registerClient({ redirect_uris: [EVIL_REDIRECT] }),
       ).rejects.toMatchObject({ code: "invalid_redirect_uri" });
 
+      // Non-localhost https URI is also rejected under the default.
       await expect(
-        strictProxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] }),
+        defaultProxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] }),
       ).rejects.toMatchObject({ code: "invalid_redirect_uri" });
 
-      strictProxy.destroy();
+      // A localhost URI IS accepted (needed for MCP clients with dynamic ports).
+      await expect(
+        defaultProxy.registerClient({
+          redirect_uris: ["http://localhost:54321/callback"],
+        }),
+      ).resolves.toBeDefined();
+
+      defaultProxy.destroy();
     });
   });
 
   describe("handleCallback() defense-in-depth", () => {
     it("refuses to 302 if the stored clientCallbackUrl is no longer registered", async () => {
-      await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
       mockUpstreamTokenEndpoint();
 
       // Start a legitimate transaction.
-      const authResp = await proxy.authorize(buildAuthParams());
+      const authResp = await proxy.authorize(
+        buildAuthParams({ client_id: dcr.client_id }),
+      );
       expect(authResp.status).toBe(302);
       const upstreamUrl = new URL(authResp.headers.get("Location")!);
       const transactionId = upstreamUrl.searchParams.get("state")!;
@@ -224,9 +238,11 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
         ...baseConfig,
         consentRequired: true,
       });
-      await consentProxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await consentProxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
 
-      const authResp = await consentProxy.authorize(buildAuthParams());
+      const authResp = await consentProxy.authorize(
+        buildAuthParams({ client_id: dcr.client_id }),
+      );
       // Consent HTML response is a 200, not a 302.
       expect(authResp.status).toBe(200);
 
@@ -257,7 +273,7 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
   });
 
   describe("exchangeAuthorizationCode() rejects unknown client_id", () => {
-    it("rejects a token exchange that does not name the upstream client_id", async () => {
+    it("rejects a token exchange with an unregistered client_id", async () => {
       await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
 
       await expect(
@@ -273,10 +289,12 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
 
   describe("happy path still works for registered clients", () => {
     it("a properly-registered client completes the full authorize -> callback flow", async () => {
-      await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
       mockUpstreamTokenEndpoint();
 
-      const authResp = await proxy.authorize(buildAuthParams());
+      const authResp = await proxy.authorize(
+        buildAuthParams({ client_id: dcr.client_id }),
+      );
       expect(authResp.status).toBe(302);
       const upstreamUrl = new URL(authResp.headers.get("Location")!);
       expect(upstreamUrl.origin + upstreamUrl.pathname).toBe(
@@ -305,7 +323,7 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
         ...baseConfig,
         allowedRedirectUriPatterns: ["https://client.example.com/*"],
       });
-      await multi.registerClient({
+      const dcr = await multi.registerClient({
         redirect_uris: [
           "https://client.example.com/a",
           "https://client.example.com/b",
@@ -314,7 +332,10 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
 
       await expect(
         multi.authorize(
-          buildAuthParams({ redirect_uri: "https://client.example.com/b" }),
+          buildAuthParams({
+            client_id: dcr.client_id,
+            redirect_uri: "https://client.example.com/b",
+          }),
         ),
       ).resolves.toBeDefined();
 

--- a/src/auth/OAuthProxy.open-redirect.test.ts
+++ b/src/auth/OAuthProxy.open-redirect.test.ts
@@ -86,11 +86,16 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
 
   describe("authorize() rejects unregistered redirect_uri", () => {
     it("rejects an arbitrary attacker host even when client_id is valid", async () => {
-      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({
+        redirect_uris: [LEGIT_REDIRECT],
+      });
 
       await expect(
         proxy.authorize(
-          buildAuthParams({ client_id: dcr.client_id, redirect_uri: EVIL_REDIRECT }),
+          buildAuthParams({
+            client_id: dcr.client_id,
+            redirect_uri: EVIL_REDIRECT,
+          }),
         ),
       ).rejects.toMatchObject({
         code: "invalid_request",
@@ -107,17 +112,24 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
     });
 
     it("rejects a URI that only differs by trailing slash (exact match required)", async () => {
-      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({
+        redirect_uris: [LEGIT_REDIRECT],
+      });
 
       await expect(
         proxy.authorize(
-          buildAuthParams({ client_id: dcr.client_id, redirect_uri: LEGIT_REDIRECT + "/" }),
+          buildAuthParams({
+            client_id: dcr.client_id,
+            redirect_uri: LEGIT_REDIRECT + "/",
+          }),
         ),
       ).rejects.toMatchObject({ code: "invalid_request" });
     });
 
     it("rejects a URI whose host only differs in casing (strict string compare)", async () => {
-      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({
+        redirect_uris: [LEGIT_REDIRECT],
+      });
 
       await expect(
         proxy.authorize(
@@ -199,7 +211,9 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
 
   describe("handleCallback() defense-in-depth", () => {
     it("refuses to 302 if the stored clientCallbackUrl is no longer registered", async () => {
-      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({
+        redirect_uris: [LEGIT_REDIRECT],
+      });
       mockUpstreamTokenEndpoint();
 
       // Start a legitimate transaction.
@@ -238,7 +252,9 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
         ...baseConfig,
         consentRequired: true,
       });
-      const dcr = await consentProxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await consentProxy.registerClient({
+        redirect_uris: [LEGIT_REDIRECT],
+      });
 
       const authResp = await consentProxy.authorize(
         buildAuthParams({ client_id: dcr.client_id }),
@@ -289,7 +305,9 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
 
   describe("happy path still works for registered clients", () => {
     it("a properly-registered client completes the full authorize -> callback flow", async () => {
-      const dcr = await proxy.registerClient({ redirect_uris: [LEGIT_REDIRECT] });
+      const dcr = await proxy.registerClient({
+        redirect_uris: [LEGIT_REDIRECT],
+      });
       mockUpstreamTokenEndpoint();
 
       const authResp = await proxy.authorize(

--- a/src/auth/OAuthProxy.token-swap.test.ts
+++ b/src/auth/OAuthProxy.token-swap.test.ts
@@ -97,8 +97,8 @@ describe("OAuthProxy - Token Swap Pattern", () => {
         tokenType: "Bearer",
       };
 
-      // Register a client
-      await proxy.registerClient({
+      // Register a client — capture the proxy-issued client_id
+      const dcr = await proxy.registerClient({
         redirect_uris: ["https://client.example.com/callback"],
       });
 
@@ -107,7 +107,7 @@ describe("OAuthProxy - Token Swap Pattern", () => {
 
       // Create a transaction and authorization code manually
       const transaction = await (proxy as any).createTransaction({
-        client_id: "upstream-client-id",
+        client_id: dcr.client_id,
         code_challenge: pkce.challenge,
         code_challenge_method: "S256",
         redirect_uri: "https://client.example.com/callback",
@@ -122,7 +122,7 @@ describe("OAuthProxy - Token Swap Pattern", () => {
 
       // Exchange authorization code
       const tokenRequest: TokenRequest = {
-        client_id: "upstream-client-id",
+        client_id: dcr.client_id,
         code: authCode,
         code_verifier: pkce.verifier,
         grant_type: "authorization_code",
@@ -160,14 +160,14 @@ describe("OAuthProxy - Token Swap Pattern", () => {
         tokenType: "Bearer",
       };
 
-      await proxy.registerClient({
+      const dcr = await proxy.registerClient({
         redirect_uris: ["https://client.example.com/callback"],
       });
 
       const pkce = PKCEUtils.generatePair("S256");
 
       const transaction = await (proxy as any).createTransaction({
-        client_id: "upstream-client-id",
+        client_id: dcr.client_id,
         code_challenge: pkce.challenge,
         code_challenge_method: "S256",
         redirect_uri: "https://client.example.com/callback",
@@ -181,7 +181,7 @@ describe("OAuthProxy - Token Swap Pattern", () => {
       );
 
       const response = await proxy.exchangeAuthorizationCode({
-        client_id: "upstream-client-id",
+        client_id: dcr.client_id,
         code: authCode,
         code_verifier: pkce.verifier,
         grant_type: "authorization_code",
@@ -226,14 +226,14 @@ describe("OAuthProxy - Token Swap Pattern", () => {
         tokenType: "Bearer",
       };
 
-      await proxy.registerClient({
+      const dcr = await proxy.registerClient({
         redirect_uris: ["https://client.example.com/callback"],
       });
 
       const pkce = PKCEUtils.generatePair("S256");
 
       const transaction = await (proxy as any).createTransaction({
-        client_id: "upstream-client-id",
+        client_id: dcr.client_id,
         code_challenge: pkce.challenge,
         code_challenge_method: "S256",
         redirect_uri: "https://client.example.com/callback",
@@ -247,17 +247,18 @@ describe("OAuthProxy - Token Swap Pattern", () => {
       );
 
       const response = await proxy.exchangeAuthorizationCode({
-        client_id: "upstream-client-id",
+        client_id: dcr.client_id,
         code: authCode,
         code_verifier: pkce.verifier,
         grant_type: "authorization_code",
         redirect_uri: "https://client.example.com/callback",
       });
 
-      // Verify JWT is valid
+      // Verify JWT is valid and carries the proxy-issued client_id (not the
+      // upstream provider's credentials).
       const validation = await jwtIssuer.verify(response.access_token);
       expect(validation.valid).toBe(true);
-      expect(validation.claims?.client_id).toBe("upstream-client-id");
+      expect(validation.claims?.client_id).toBe(dcr.client_id);
       expect(validation.claims?.scope).toEqual(["read", "write"]);
 
       // Load upstream tokens
@@ -324,14 +325,14 @@ describe("OAuthProxy - Token Swap Pattern", () => {
         tokenType: "Bearer",
       };
 
-      await proxy.registerClient({
+      const dcr = await proxy.registerClient({
         redirect_uris: ["https://client.example.com/callback"],
       });
 
       const pkce = PKCEUtils.generatePair("S256");
 
       const transaction = await (proxy as any).createTransaction({
-        client_id: "upstream-client-id",
+        client_id: dcr.client_id,
         code_challenge: pkce.challenge,
         code_challenge_method: "S256",
         redirect_uri: "https://client.example.com/callback",
@@ -345,7 +346,7 @@ describe("OAuthProxy - Token Swap Pattern", () => {
       );
 
       const response = await proxy.exchangeAuthorizationCode({
-        client_id: "upstream-client-id",
+        client_id: dcr.client_id,
         code: authCode,
         code_verifier: pkce.verifier,
         grant_type: "authorization_code",
@@ -545,14 +546,14 @@ describe("OAuthProxy - Upstream Token Storage TTL", () => {
     proxy: OAuthProxy,
     upstreamTokens: UpstreamTokenSet,
   ) {
-    await proxy.registerClient({
+    const dcr = await proxy.registerClient({
       redirect_uris: ["https://client.example.com/callback"],
     });
 
     const pkce = PKCEUtils.generatePair("S256");
 
     const transaction = await (proxy as any).createTransaction({
-      client_id: "upstream-client-id",
+      client_id: dcr.client_id,
       code_challenge: pkce.challenge,
       code_challenge_method: "S256",
       redirect_uri: "https://client.example.com/callback",
@@ -566,7 +567,7 @@ describe("OAuthProxy - Upstream Token Storage TTL", () => {
     );
 
     return proxy.exchangeAuthorizationCode({
-      client_id: "upstream-client-id",
+      client_id: dcr.client_id,
       code: authCode,
       code_verifier: pkce.verifier,
       grant_type: "authorization_code",
@@ -836,14 +837,14 @@ describe("OAuthProxy - Swap Mode Refresh Token", () => {
       ...upstreamTokens,
     };
 
-    await proxy.registerClient({
+    const dcr = await proxy.registerClient({
       redirect_uris: ["https://client.example.com/callback"],
     });
 
     const pkce = PKCEUtils.generatePair("S256");
 
     const transaction = await (proxy as any).createTransaction({
-      client_id: "upstream-client-id",
+      client_id: dcr.client_id,
       code_challenge: pkce.challenge,
       code_challenge_method: "S256",
       redirect_uri: "https://client.example.com/callback",
@@ -857,7 +858,7 @@ describe("OAuthProxy - Swap Mode Refresh Token", () => {
     );
 
     return proxy.exchangeAuthorizationCode({
-      client_id: "upstream-client-id",
+      client_id: dcr.client_id,
       code: authCode,
       code_verifier: pkce.verifier,
       grant_type: "authorization_code",

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -49,17 +49,15 @@ export class OAuthProxy {
   private config: OAuthProxyConfig;
   private consentManager: ConsentManager;
   private jwtIssuer?: JWTIssuer;
+  /** Keyed by redirect_uri for defence-in-depth checks in handleCallback/handleConsent */
   private registeredClients: Map<string, ProxyDCRClient> = new Map();
+  /** Keyed by proxy-issued client_id for authorize/token-exchange lookups */
+  private registeredClientsByClientId: Map<string, ProxyDCRClient> = new Map();
   private tokenStorage: TokenStorage;
   private transactions: Map<string, OAuthTransaction> = new Map();
 
   constructor(config: OAuthProxyConfig) {
     this.config = {
-      // Empty by default. Framework users must explicitly configure the URIs they
-      // trust, per RFC 6819 §4.1.5. The previous default (`["https://*", "http://localhost:*"]`)
-      // allowed open DCR registration of any https URL, enabling CWE-601 open-redirect
-      // attacks against /oauth/authorize.
-      allowedRedirectUriPatterns: [],
       authorizationCodeTtl: DEFAULT_AUTHORIZATION_CODE_TTL,
       consentRequired: true,
       enableTokenSwap: true, // Enabled by default for security
@@ -138,16 +136,20 @@ export class OAuthProxy {
     }
 
     // RFC 6749 §5.2 - reject unknown clients with invalid_client.
-    // The proxy exposes a single upstream identity; any other client_id is rejected.
-    if (params.client_id !== this.config.upstreamClientId) {
+    // MCP clients receive a proxy-issued client_id during DCR (not the upstream
+    // provider's credentials), so we look up by that proxy client_id.
+    const registeredClient = this.registeredClientsByClientId.get(
+      params.client_id,
+    );
+    if (!registeredClient) {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
     }
 
-    // RFC 6749 §3.1.2.3 / RFC 6819 §4.1.5 - the redirect_uri MUST match one
-    // previously registered by the client (exact string comparison). Skipping
-    // this check is CWE-601: an attacker can steal an authorization code by
-    // passing their own URL as redirect_uri.
-    if (!this.registeredClients.has(params.redirect_uri)) {
+    // RFC 6749 §3.1.2.3 / RFC 6819 §4.1.5 - the redirect_uri MUST be one
+    // that was registered by this specific client. Skipping this check is
+    // CWE-601: an attacker can steal an authorization code by passing their
+    // own URL as redirect_uri.
+    if (!registeredClient.redirectUris.includes(params.redirect_uri)) {
       throw new OAuthProxyError(
         "invalid_request",
         "redirect_uri is not registered for this client",
@@ -189,6 +191,7 @@ export class OAuthProxy {
     this.transactions.clear();
     this.clientCodes.clear();
     this.registeredClients.clear();
+    this.registeredClientsByClientId.clear();
   }
 
   /**
@@ -204,10 +207,10 @@ export class OAuthProxy {
       );
     }
 
-    // RFC 6749 §5.2 - reject unknown clients. The proxy exposes a single
-    // upstream identity; any other client_id is rejected here as well as at
-    // authorize(), so stolen codes cannot be exchanged by arbitrary callers.
-    if (request.client_id !== this.config.upstreamClientId) {
+    // RFC 6749 §5.2 - reject unknown clients. Only proxy-issued client_ids
+    // (obtained via DCR) are accepted, so stolen codes cannot be exchanged by
+    // arbitrary callers.
+    if (!this.registeredClientsByClientId.has(request.client_id)) {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
     }
 
@@ -521,12 +524,17 @@ export class OAuthProxy {
       }
     }
 
-    // Store client registration (indexed by primary redirect URI)
-    const clientId = this.config.upstreamClientId;
+    // Generate proxy-specific credentials for this MCP client.
+    // We deliberately do NOT return the upstream provider's client_id/secret here:
+    // exposing those would (a) leak credentials to every MCP client and (b) let a
+    // client bypass the proxy and talk directly to the upstream provider.
+    const proxyClientId = randomBytes(16).toString("hex");
+    const proxyClientSecret = randomBytes(32).toString("base64url");
+
     const client: ProxyDCRClient = {
       callbackUrl: request.redirect_uris[0],
-      clientId,
-      clientSecret: this.config.upstreamClientSecret,
+      clientId: proxyClientId,
+      clientSecret: proxyClientSecret,
       metadata: {
         client_name: request.client_name,
         client_uri: request.client_uri,
@@ -540,23 +548,26 @@ export class OAuthProxy {
         software_version: request.software_version,
         tos_uri: request.tos_uri,
       },
+      redirectUris: request.redirect_uris,
       registeredAt: new Date(),
     };
 
-    // Store registration under every presented redirect_uri so that authorize()
-    // can validate each one exactly (RFC 6749 §3.1.2.3). The previous code only
-    // stored the first URI, silently dropping the rest.
+    // Index by proxy client_id for authorize/token-exchange lookups.
+    this.registeredClientsByClientId.set(proxyClientId, client);
+
+    // Also index by every redirect_uri for defence-in-depth checks in
+    // handleCallback/handleConsent (RFC 6749 §3.1.2.3).
     for (const uri of request.redirect_uris) {
       this.registeredClients.set(uri, client);
     }
 
-    // Return RFC 7591 compliant response
+    // Return RFC 7591 compliant response with proxy-issued credentials.
     const response: DCRResponse = {
-      client_id: clientId,
+      client_id: proxyClientId,
       client_id_issued_at: Math.floor(Date.now() / 1000),
       // Echo back optional metadata
       client_name: request.client_name,
-      client_secret: this.config.upstreamClientSecret,
+      client_secret: proxyClientSecret,
       client_secret_expires_at: 0, // Never expires
       client_uri: request.client_uri,
       contacts: request.contacts,
@@ -1355,14 +1366,17 @@ export class OAuthProxy {
   /**
    * Validate a redirect URI against the configured allow-list.
    *
-   * Returns `true` only if the URI is syntactically valid AND matches one of
-   * the explicitly configured `allowedRedirectUriPatterns`. An empty or unset
-   * pattern list means DCR will reject every URI — framework users must
-   * opt-in by listing the exact URIs (or wildcards) they trust.
+   * Behaviour by configuration value:
+   *   - `undefined` (not set): allow localhost/127.0.0.1 only — safe default
+   *     that covers the common MCP use-case of dynamic loopback ports without
+   *     opening the proxy to arbitrary redirect URIs.
+   *   - `[]` (empty array): reject every URI — opt-in strict mode for deployments
+   *     that want full control and will configure patterns explicitly.
+   *   - `["pattern", ...]`: accept URIs matching any of the glob patterns.
    *
-   * Prior versions also fell back to allowing any https URL or localhost,
-   * which enabled attackers to DCR an arbitrary URL and then abuse it via
-   * /oauth/authorize (CWE-601). Do not re-introduce that fallback.
+   * Prior versions defaulted to `["https://*", "http://localhost:*"]` which
+   * matched any https URL, enabling CWE-601 open-redirect / authorization-code
+   * theft. Do not loosen the default beyond loopback addresses.
    */
   private validateRedirectUri(uri: string): boolean {
     try {
@@ -1371,12 +1385,20 @@ export class OAuthProxy {
       return false;
     }
 
-    const patterns = this.config.allowedRedirectUriPatterns || [];
-    if (patterns.length === 0) {
+    const patterns = this.config.allowedRedirectUriPatterns;
+
+    // Explicitly set to empty array → strict mode, reject everything.
+    if (Array.isArray(patterns) && patterns.length === 0) {
       return false;
     }
 
-    return patterns.some((pattern) => this.matchesPattern(uri, pattern));
+    // Not configured → localhost-only default (covers MCP dynamic loopback ports).
+    const effectivePatterns = patterns ?? [
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+    ];
+
+    return effectivePatterns.some((pattern) => this.matchesPattern(uri, pattern));
   }
 }
 

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -1398,7 +1398,9 @@ export class OAuthProxy {
       "http://127.0.0.1:*",
     ];
 
-    return effectivePatterns.some((pattern) => this.matchesPattern(uri, pattern));
+    return effectivePatterns.some((pattern) =>
+      this.matchesPattern(uri, pattern),
+    );
   }
 }
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -207,15 +207,17 @@ export interface OAuthProxyConfig {
    * matches one of these patterns (exact string or glob with `*` / `?`);
    * otherwise the registration is rejected with `invalid_redirect_uri`. Once
    * registered, the same exact URI must be echoed back at /oauth/authorize —
-   * the proxy performs exact string comparison per RFC 6749 §3.1.2.3.
+   * the proxy performs an exact per-client match per RFC 6749 §3.1.2.3.
    *
-   * Default: `[]` (DCR rejects everything — explicit opt-in required).
+   * Behaviour by value:
+   *   - `undefined` (default): allow `http://localhost:*` and `http://127.0.0.1:*`
+   *     only. Covers the standard MCP use-case of dynamic loopback ports.
+   *   - `[]` (empty array): DCR rejects every URI — use for deployments that
+   *     configure patterns explicitly and want no implicit fallback.
+   *   - `["pattern", ...]`: accept URIs matching any glob pattern in the list.
    *
-   * Prior versions defaulted to `["https://*", "http://localhost:*"]` with an
-   * implicit fallback that allowed any https URL. This enabled CWE-601
-   * open-redirect / authorization-code theft: an attacker could DCR their own
-   * URL and then steal victim codes via /oauth/authorize. Do not loosen this
-   * default without understanding that threat model.
+   * Do not widen the default beyond loopback addresses — allowing arbitrary
+   * https URLs enables CWE-601 open-redirect / authorization-code theft.
    */
   allowedRedirectUriPatterns?: string[];
   /** Authorization code TTL in seconds (default: 300) */
@@ -313,14 +315,16 @@ export interface PKCEPair {
  * Dynamic client registration data
  */
 export interface ProxyDCRClient {
-  /** Registered callback URL */
+  /** Primary (first) registered callback URL */
   callbackUrl: string;
-  /** Generated or assigned client ID */
+  /** Proxy-issued client ID (not the upstream provider's client_id) */
   clientId: string;
-  /** Client secret (optional) */
+  /** Proxy-issued client secret (not the upstream provider's client_secret) */
   clientSecret?: string;
   /** Client metadata from registration request */
   metadata?: DCRClientMetadata;
+  /** All redirect URIs registered by this client */
+  redirectUris: string[];
   /** Client registration timestamp */
   registeredAt: Date;
 }


### PR DESCRIPTION
Addresses Issue: OAuth Proxy #201 https://github.com/punkpeye/fastmcp/issues/201

[ypxing](https://github.com/ypxing) please test that this addresses your concerns

- Generate proxy-specific client_id/client_secret per DCR registration instead of returning upstream provider credentials to MCP clients
- Add registeredClientsByClientId map for O(1) client lookup
- Fix authorize() and exchangeAuthorizationCode() to validate against proxy-issued client IDs (not the upstream client_id)
- Fix validateRedirectUri() default: undefined → localhost-only (not [])
- Add redirectUris array to ProxyDCRClient for per-client URI validation
- Update all tests to use DCR-returned proxy client_id

Closes CWE-601 open-redirect and upstream credential exposure.