### PR TITLE
feat: add cors option to httpStream config

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,46 @@ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -node
 
 See the [https-server example](src/examples/https-server.ts) for a complete demonstration.
 
+##### CORS Configuration
+
+By default, FastMCP enables CORS with a standard set of allowed headers. You can customize the CORS behavior by passing a `cors` option:
+
+```ts
+server.start({
+  transportType: "httpStream",
+  httpStream: {
+    port: 8080,
+    cors: {
+      origin: "http://localhost:3000",
+      allowedHeaders: [
+        "Content-Type",
+        "Authorization",
+        "Accept",
+        "Mcp-Session-Id",
+        "Mcp-Protocol-Version",
+        "Last-Event-Id",
+        "X-Custom-Header",
+      ],
+      credentials: true,
+    },
+  },
+});
+```
+
+The `cors` option accepts:
+
+- `true` (default) - enable CORS with default settings
+- `false` - disable CORS entirely
+- An object with these fields:
+  - `origin` - a string, array of strings, or a function `(origin: string) => boolean`
+  - `allowedHeaders` - a string or array of strings
+  - `methods` - array of allowed HTTP methods
+  - `exposedHeaders` - array of headers to expose
+  - `credentials` - boolean to allow credentials
+  - `maxAge` - preflight cache duration in seconds
+
+The `CorsOptions` type is exported from `fastmcp` for convenience.
+
 #### Custom HTTP Routes
 
 FastMCP allows you to add custom HTTP routes alongside MCP endpoints, enabling you to build comprehensive HTTP services that include REST APIs, webhooks, admin interfaces, and more - all within the same server process.

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4731,3 +4731,78 @@ test("tools without outputSchema omit it from listing", async () => {
     },
   });
 });
+
+test("httpStream forwards custom cors allowedHeaders to mcp-proxy", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  await server.start({
+    httpStream: {
+      cors: {
+        allowedHeaders: [
+          "Content-Type",
+          "Authorization",
+          "Accept",
+          "Mcp-Session-Id",
+          "Mcp-Protocol-Version",
+          "Last-Event-Id",
+          "X-Custom-Header",
+        ],
+      },
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      headers: {
+        "Access-Control-Request-Headers": "X-Custom-Header, Content-Type",
+        "Access-Control-Request-Method": "POST",
+        Origin: "http://example.com",
+      },
+      method: "OPTIONS",
+    });
+
+    const allowHeaders = response.headers.get("access-control-allow-headers");
+
+    expect(allowHeaders).toContain("X-Custom-Header");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("httpStream respects cors: false by not setting CORS headers", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  await server.start({
+    httpStream: {
+      cors: false,
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      headers: {
+        "Access-Control-Request-Method": "POST",
+        Origin: "http://example.com",
+      },
+      method: "OPTIONS",
+    });
+
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  } finally {
+    await server.stop();
+  }
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -34,7 +34,7 @@ import { readFile } from "fs/promises";
 import Fuse from "fuse.js";
 import { Hono } from "hono";
 import http from "http";
-import { startHTTPServer } from "mcp-proxy";
+import { type CorsOptions, startHTTPServer } from "mcp-proxy";
 import { StrictEventEmitter } from "strict-event-emitter-types";
 import { setTimeout as delay } from "timers/promises";
 import { fetch } from "undici";
@@ -2565,6 +2565,7 @@ export class FastMCP<
   public async start(
     options?: Partial<{
       httpStream: {
+        cors?: boolean | CorsOptions;
         enableJsonResponse?: boolean;
         endpoint?: `/${string}`;
         eventStore?: EventStore;
@@ -2660,6 +2661,7 @@ export class FastMCP<
 
         this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
           ...(this.#authenticate ? { authenticate: this.#authenticate } : {}),
+          cors: httpConfig.cors,
           createServer: async (request) => {
             let auth: T | undefined;
 
@@ -2725,6 +2727,7 @@ export class FastMCP<
         // Regular mode with session management
         this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
           ...(this.#authenticate ? { authenticate: this.#authenticate } : {}),
+          cors: httpConfig.cors,
           createServer: async (request) => {
             let auth: T | undefined;
 
@@ -3287,6 +3290,7 @@ export class FastMCP<
   #parseRuntimeConfig(
     overrides?: Partial<{
       httpStream: {
+        cors?: boolean | CorsOptions;
         enableJsonResponse?: boolean;
         endpoint?: `/${string}`;
         eventStore?: EventStore;
@@ -3302,6 +3306,7 @@ export class FastMCP<
   ):
     | {
         httpStream: {
+          cors?: boolean | CorsOptions;
           enableJsonResponse?: boolean;
           endpoint: `/${string}`;
           eventStore?: EventStore;
@@ -3357,6 +3362,7 @@ export class FastMCP<
         statelessArg === "true" ||
         envStateless === "true" ||
         false;
+      const cors = overrides?.httpStream?.cors;
       const eventStore = overrides?.httpStream?.eventStore;
       const sslCa = overrides?.httpStream?.sslCa;
       const sslCert = overrides?.httpStream?.sslCert;
@@ -3364,6 +3370,7 @@ export class FastMCP<
 
       return {
         httpStream: {
+          cors,
           enableJsonResponse,
           endpoint: endpoint as `/${string}`,
           eventStore,
@@ -3460,6 +3467,7 @@ export type {
   Content,
   ContentResult,
   Context,
+  CorsOptions,
   FastMCPEvents,
   FastMCPSessionAuth,
   FastMCPSessionEvents,


### PR DESCRIPTION
mcp-proxy accepts a `cors` parameter but FastMCP does not pass it through.
Custom headers fail CORS preflight and there is no way to fix it from
userland since mcp-proxy handles OPTIONS before Hono middleware runs.

Adds `cors?: boolean | CorsOptions` to the httpStream start options.

### What changed

- `src/FastMCP.ts` - parse and forward `cors` to both `startHTTPServer`
  call sites, re-export `CorsOptions`
- `src/FastMCP.test.ts` - custom allowed headers test, disabled CORS test
- `README.md` - usage example and option reference

### Usage

```ts
server.start({
  transportType: "httpStream",
  httpStream: {
    port: 8080,
    cors: {
      origin: "http://localhost:3000",
      allowedHeaders: ["Content-Type", "X-My-Header"],
      credentials: true,
    },
  },
});
```