### PR TITLE
fix: avoid client capability warning in stateless mode

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -3611,6 +3611,73 @@ test("stateless mode works correctly", async () => {
   }
 });
 
+test("stateless mode does not warn when client capabilities are unavailable", async () => {
+  const port = await getRandomPort();
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+
+  const server = new FastMCP({
+    logger,
+    name: "Test server",
+    version: "1.0.0",
+  });
+
+  server.addTool({
+    description: "Add two numbers",
+    execute: async (args) => {
+      return String(args.a + args.b);
+    },
+    name: "add",
+    parameters: z.object({
+      a: z.number(),
+      b: z.number(),
+    }),
+  });
+
+  await server.start({
+    httpStream: {
+      port,
+      stateless: true,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const client = new Client(
+      {
+        name: "Test client",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${port}/mcp`),
+    );
+
+    await client.connect(transport);
+    await client.callTool({
+      arguments: { a: 5, b: 7 },
+      name: "add",
+    });
+
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("could not infer client capabilities"),
+    );
+
+    await client.close();
+  } finally {
+    await server.stop();
+  }
+});
+
 test("stateless mode health check includes mode indicator", async () => {
   const port = await getRandomPort();
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1114,13 +1114,13 @@ export class FastMCPSession<
 
   #server: Server;
 
-  #stateless: boolean;
-
   /**
    * Session ID from the Mcp-Session-Id header (HTTP transports only).
    * Used to track per-session state across multiple requests.
    */
   #sessionId?: string;
+
+  #stateless: boolean;
 
   #utils?: ServerOptions<T>["utils"];
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1114,6 +1114,8 @@ export class FastMCPSession<
 
   #server: Server;
 
+  #stateless: boolean;
+
   /**
    * Session ID from the Mcp-Session-Id header (HTTP transports only).
    * Used to track per-session state across multiple requests.
@@ -1134,6 +1136,7 @@ export class FastMCPSession<
     resourcesTemplates,
     roots,
     sessionId,
+    stateless = false,
     tools,
     transportType,
     utils,
@@ -1150,6 +1153,7 @@ export class FastMCPSession<
     resourcesTemplates: InputResourceTemplate<T>[];
     roots?: ServerOptions<T>["roots"];
     sessionId?: string;
+    stateless?: boolean;
     tools: Tool<T>[];
     transportType?: "httpStream" | "stdio";
     utils?: ServerOptions<T>["utils"];
@@ -1163,6 +1167,7 @@ export class FastMCPSession<
     this.#pingConfig = ping;
     this.#rootsConfig = roots;
     this.#sessionId = sessionId;
+    this.#stateless = stateless;
     this.#needsEventLoopFlush = transportType === "httpStream";
 
     if (tools.length) {
@@ -1256,25 +1261,27 @@ export class FastMCPSession<
         }
       }
 
-      let attempt = 0;
-      const maxAttempts = 10;
-      const retryDelay = 100;
+      if (!this.#stateless) {
+        let attempt = 0;
+        const maxAttempts = 10;
+        const retryDelay = 100;
 
-      while (attempt++ < maxAttempts) {
-        const capabilities = this.#server.getClientCapabilities();
+        while (attempt++ < maxAttempts) {
+          const capabilities = this.#server.getClientCapabilities();
 
-        if (capabilities) {
-          this.#clientCapabilities = capabilities;
-          break;
+          if (capabilities) {
+            this.#clientCapabilities = capabilities;
+            break;
+          }
+
+          await delay(retryDelay);
         }
 
-        await delay(retryDelay);
-      }
-
-      if (!this.#clientCapabilities) {
-        this.#logger.warn(
-          `[FastMCP warning] could not infer client capabilities after ${maxAttempts} attempts. Connection may be unstable.`,
-        );
+        if (!this.#clientCapabilities) {
+          this.#logger.warn(
+            `[FastMCP warning] could not infer client capabilities after ${maxAttempts} attempts. Connection may be unstable.`,
+          );
+        }
       }
 
       if (
@@ -2680,7 +2687,7 @@ export class FastMCP<
 
             // In stateless mode, create a new session for each request
             // without persisting it in the sessions array
-            return this.#createSession(auth, sessionId);
+            return this.#createSession(auth, sessionId, true);
           },
           enableJsonResponse: httpConfig.enableJsonResponse,
           eventStore: httpConfig.eventStore,
@@ -2812,7 +2819,11 @@ export class FastMCP<
    * Creates a new FastMCPSession instance with the current configuration.
    * Used both for regular sessions and stateless requests.
    */
-  #createSession(auth?: T, sessionId?: string): FastMCPSession<T> {
+  #createSession(
+    auth?: T,
+    sessionId?: string,
+    stateless = false,
+  ): FastMCPSession<T> {
     // Check if authentication failed
     if (
       auth &&
@@ -2845,6 +2856,7 @@ export class FastMCP<
       resourcesTemplates: this.#resourcesTemplates,
       roots: this.#options.roots,
       sessionId,
+      stateless,
       tools: allowedTools,
       transportType: "httpStream",
       utils: this.#options.utils,


### PR DESCRIPTION
## Summary
- pass stateless mode through to `FastMCPSession`
- skip client capability polling in stateless HTTP sessions, where initialize and tool requests can be handled by different server instances
- add a regression test covering the warning behavior

Fixes #142.

## Verification
- `corepack pnpm vitest run src/FastMCP.test.ts -t "stateless mode does not warn|stateless mode works correctly"`
- `corepack pnpm exec tsc --noEmit`