### PR TITLE
fix: skip progress notification when client sent no progressToken

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -650,6 +650,48 @@ test(
   },
 );
 
+test("reportProgress is a no-op when the client did not request progress", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const onError = vi.fn();
+      client.onerror = onError;
+
+      // No onprogress is passed, so the client sends no progressToken.
+      const result = (await client.callTool({
+        arguments: { a: 1, b: 2 },
+        name: "add",
+      })) as ContentResult;
+
+      await delay(100);
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(result.content).toEqual([{ text: "3", type: "text" }]);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Add two numbers",
+        execute: async (args, { reportProgress }) => {
+          await reportProgress({ progress: 0, total: 10 });
+
+          return String(args.a + args.b);
+        },
+        name: "add",
+        parameters: z.object({
+          a: z.number(),
+          b: z.number(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
 test("sets logging levels", async () => {
   await runWithTestServer({
     run: async ({ client, session }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1985,6 +1985,14 @@ export class FastMCPSession<
 
       try {
         const reportProgress = async (progress: Progress) => {
+          // Progress notifications must reference the progressToken supplied by
+          // the client in the initiating request. If the client did not request
+          // progress, there is nothing to associate the update with, and sending
+          // a notification without a token produces an invalid message.
+          if (progressToken === undefined) {
+            return;
+          }
+
           try {
             await this.#server.notification({
               method: "notifications/progress",


### PR DESCRIPTION
## Problem

A tool can call `context.reportProgress()` without knowing whether the client opted into progress updates. When the client does **not** pass a progress token (i.e. no `onprogress` callback, so `request.params._meta.progressToken` is absent), `reportProgress` still emits:

```ts
await this.#server.notification({
  method: "notifications/progress",
  params: { ...progress, progressToken }, // progressToken is undefined
});
```

`progressToken` is a **required** field on `notifications/progress` (`ProgressNotificationParamsSchema` in the SDK). The client validates incoming notifications against that schema, so the notification fails to parse and the error is surfaced through the client's `onerror` handler:

```
Uncaught error in notification handler: ZodError ... path: ["params","progressToken"] ... Invalid input
```

So a perfectly normal tool that reports progress breaks any client that didn't request progress.

## Root cause

`reportProgress` always sends the notification, even when there is no token to associate it with.

## Fix

Make `reportProgress` a no-op when `progressToken` is `undefined`. This matches the MCP spec: progress notifications reference the token from the initiating request, so when the client didn't supply one there is nothing to report against. Using a strict `=== undefined` check preserves valid `0` / `"0"` tokens.

## Testing

- Added a regression test (`reportProgress is a no-op when the client did not request progress`) that calls a progress-reporting tool from a client without `onprogress` and asserts `client.onerror` is never called. It fails on `main` and passes with this change.
- Existing progress tests (`tracks tool progress`, `reports multiple progress updates without buffering`) still pass, so the normal opt-in path is unchanged.
- `prettier --check`, `eslint`, and `tsc --noEmit` all pass on the changed files.