### PR TITLE
feat: support returning structuredContent from tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,39 @@ server.addTool({
 });
 ```
 
+#### Returning structured content
+
+Declare an `outputSchema` and return `structuredContent` to give clients a typed
+object in addition to the human-readable `content`. MCP clients surface
+`structuredContent` to the model directly, so it does not have to parse data out of
+a text block. For backward compatibility you should still return a `content` block
+(typically the serialized JSON), as the MCP specification recommends.
+
+```js
+server.addTool({
+  name: "get_weather",
+  description: "Get the weather for a city",
+  parameters: z.object({
+    city: z.string(),
+  }),
+  outputSchema: z.object({
+    humidity: z.number(),
+    temperature: z.number(),
+  }),
+  execute: async (args) => {
+    const data = { humidity: 65, temperature: 72 };
+
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+      structuredContent: data,
+    };
+  },
+});
+```
+
+When `outputSchema` is provided, MCP clients validate the returned
+`structuredContent` against it.
+
 #### Custom Logger
 
 FastMCP allows you to provide a custom logger implementation to control how the server logs messages. This is useful for integrating with existing logging infrastructure or customizing log formatting.

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4701,6 +4701,56 @@ test("adds tools with outputSchema", async () => {
   });
 });
 
+test("returns structuredContent alongside content", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      // The SDK client validates structuredContent against the tool's
+      // outputSchema, so this round-trip also exercises that validation.
+      expect(
+        await client.callTool({
+          arguments: { city: "Paris" },
+          name: "get-weather",
+        }),
+      ).toEqual({
+        content: [
+          {
+            text: JSON.stringify({ humidity: 65, temperature: 72 }),
+            type: "text",
+          },
+        ],
+        structuredContent: { humidity: 65, temperature: 72 },
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Get weather for a city",
+        execute: async () => {
+          const data = { humidity: 65, temperature: 72 };
+          return {
+            content: [{ text: JSON.stringify(data), type: "text" }],
+            structuredContent: data,
+          };
+        },
+        name: "get-weather",
+        outputSchema: z.object({
+          humidity: z.number(),
+          temperature: z.number(),
+        }),
+        parameters: z.object({
+          city: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
 test("tools without outputSchema omit it from listing", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -383,12 +383,20 @@ const ContentZodSchema = z.discriminatedUnion("type", [
 type ContentResult = {
   content: Content[];
   isError?: boolean;
+  /**
+   * Structured tool output that conforms to the tool's `outputSchema`.
+   * Surfaced to MCP clients alongside `content` so the model receives a typed
+   * object instead of having to parse it out of the text block.
+   * See https://github.com/modelcontextprotocol/typescript-sdk/pull/454
+   */
+  structuredContent?: { [key: string]: unknown };
 };
 
 const ContentResultZodSchema = z
   .object({
     content: ContentZodSchema.array(),
     isError: z.boolean().optional(),
+    structuredContent: z.record(z.string(), z.unknown()).optional(),
   })
   .strict() satisfies z.ZodType<ContentResult>;
 


### PR DESCRIPTION
## What

Allows tools to return `structuredContent` alongside `content`, so a tool that declares an `outputSchema` can actually return matching structured output.

## Why

FastMCP already advertises a tool's `outputSchema` in the `tools/list` response, but the result validator `ContentResultZodSchema` is `.strict()` and silently dropped/rejected any `structuredContent` field. The net effect today:

- A tool can declare `outputSchema` but has no supported way to return structured output on success (the only place `structuredContent` ever reached the wire was the `UserError.extras` error path).
- Spec-compliant clients validate a result's `structuredContent` against the declared `outputSchema` (see modelcontextprotocol/typescript-sdk#454, shipped in `@modelcontextprotocol/sdk` 1.x) — so the declared schema had nothing to validate against.

Closes #81.

## Change

- Add an optional `structuredContent?: { [key: string]: unknown }` field to the `ContentResult` type and to `ContentResultZodSchema`.
- `content` stays required, matching the MCP `CallToolResult` shape and the spec's backward-compat guidance (a tool returning structured content should also return a serialized `content` block).

This is a minimal, additive change — the `execute` return union already includes `ContentResult`, so `return { content, structuredContent }` now flows straight through instead of being stripped by the strict schema.

## Usage

```ts
server.addTool({
  name: "get_weather",
  parameters: z.object({ city: z.string() }),
  outputSchema: z.object({ humidity: z.number(), temperature: z.number() }),
  execute: async () => {
    const data = { humidity: 65, temperature: 72 };
    return {
      content: [{ type: "text", text: JSON.stringify(data) }],
      structuredContent: data,
    };
  },
});
```

## Tests

Adds a round-trip test that returns `structuredContent` and asserts it on the `callTool` result — which also exercises the SDK client's output-schema validation. Full `src/FastMCP.test.ts` suite (79 tests) passes; `tsc --noEmit`, `eslint`, and `prettier --check` are clean.

## Docs

Adds a "Returning structured content" section to the README.