### PR TITLE
feat: support structured tool output

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,66 @@ When creating tools that don't require parameters, you have two options:
 >
 > Both approaches are fully compatible with all MCP clients, including Cursor. FastMCP automatically generates the proper schema in both cases.
 
+#### Structured Tool Output
+
+Tools can declare an `outputSchema` and return structured data. FastMCP exposes that value as MCP `structuredContent`, while also returning a JSON text fallback for clients that only render text content.
+
+```typescript
+server.addTool({
+  name: "get-weather",
+  description: "Get weather for a city",
+  parameters: z.object({
+    city: z.string(),
+  }),
+  outputSchema: z.object({
+    temperature: z.number(),
+    humidity: z.number(),
+  }),
+  execute: async ({ city }) => {
+    const weather = await getWeather(city);
+
+    return {
+      temperature: weather.temperature,
+      humidity: weather.humidity,
+    };
+  },
+});
+```
+
+You can also return explicit text content and structured content together:
+
+```typescript
+server.addTool({
+  name: "get-weather",
+  description: "Get weather for a city",
+  parameters: z.object({
+    city: z.string(),
+  }),
+  outputSchema: z.object({
+    temperature: z.number(),
+    humidity: z.number(),
+  }),
+  execute: async ({ city }) => {
+    const weather = await getWeather(city);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `${city}: ${weather.temperature}F`,
+        },
+      ],
+      structuredContent: {
+        temperature: weather.temperature,
+        humidity: weather.humidity,
+      },
+    };
+  },
+});
+```
+
+When `outputSchema` is provided, FastMCP validates `structuredContent` before sending the tool result. Invalid structured output is returned to the client as a tool error instead of silently violating the advertised schema.
+
 #### Tool Authorization
 
 You can control which tools are available to authenticated users by adding an optional `canAccess` function to a tool's definition. This function receives the authentication context and should return `true` if the user is allowed to access the tool.

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4701,6 +4701,150 @@ test("adds tools with outputSchema", async () => {
   });
 });
 
+test("returns structuredContent for tool output that matches outputSchema", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {
+            city: "San Francisco",
+          },
+          name: "get-weather",
+        }),
+      ).toEqual({
+        content: [
+          {
+            text: JSON.stringify({ humidity: 65, temperature: 72 }),
+            type: "text",
+          },
+        ],
+        structuredContent: {
+          humidity: 65,
+          temperature: 72,
+        },
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Get weather for a city",
+        execute: async () => {
+          return { humidity: 65, temperature: 72 };
+        },
+        name: "get-weather",
+        outputSchema: z.object({
+          humidity: z.number(),
+          temperature: z.number(),
+        }),
+        parameters: z.object({
+          city: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("validates explicit structuredContent against outputSchema", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {
+            city: "San Francisco",
+          },
+          name: "get-weather",
+        }),
+      ).toEqual({
+        content: [{ text: "Weather: 72F", type: "text" }],
+        structuredContent: {
+          humidity: 65,
+          temperature: 72,
+        },
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Get weather for a city",
+        execute: async () => {
+          return {
+            content: [{ text: "Weather: 72F", type: "text" }],
+            structuredContent: { humidity: 65, temperature: 72 },
+          };
+        },
+        name: "get-weather",
+        outputSchema: z.object({
+          humidity: z.number(),
+          temperature: z.number(),
+        }),
+        parameters: z.object({
+          city: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("returns an error when structuredContent fails outputSchema validation", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {
+            city: "San Francisco",
+          },
+          name: "get-weather",
+        }),
+      ).toEqual({
+        content: [
+          {
+            text: expect.stringContaining(
+              "structured output validation failed",
+            ),
+            type: "text",
+          },
+        ],
+        isError: true,
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Get weather for a city",
+        execute: async () => {
+          return { humidity: "65", temperature: 72 };
+        },
+        name: "get-weather",
+        outputSchema: z.object({
+          humidity: z.number(),
+          temperature: z.number(),
+        }),
+        parameters: z.object({
+          city: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
 test("tools without outputSchema omit it from listing", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -383,12 +383,14 @@ const ContentZodSchema = z.discriminatedUnion("type", [
 type ContentResult = {
   content: Content[];
   isError?: boolean;
+  structuredContent?: Record<string, unknown>;
 };
 
 const ContentResultZodSchema = z
   .object({
     content: ContentZodSchema.array(),
     isError: z.boolean().optional(),
+    structuredContent: z.record(z.string(), z.unknown()).optional(),
   })
   .strict() satisfies z.ZodType<ContentResult>;
 
@@ -944,6 +946,7 @@ type Tool<
     | ImageContent
     | ResourceContent
     | ResourceLink
+    | StandardSchemaV1.InferOutput<OutputParams>
     | string
     | TextContent
     | void
@@ -1443,6 +1446,17 @@ export class FastMCPSession<
     });
   }
 
+  #formatSchemaIssues(issues: readonly StandardSchemaV1.Issue[]): string {
+    return this.#utils?.formatInvalidParamsErrorMessage
+      ? this.#utils.formatInvalidParamsErrorMessage(issues)
+      : issues
+          .map((issue) => {
+            const path = issue.path?.join(".") || "root";
+            return `${path}: ${issue.message}`;
+          })
+          .join(", ");
+  }
+
   #getPingConfig(transport: Transport): {
     enabled: boolean;
     intervalMs: number;
@@ -1465,6 +1479,26 @@ export class FastMCPSession<
       intervalMs: pingConfig.intervalMs || 5000,
       logLevel: pingConfig.logLevel || "debug",
     };
+  }
+
+  async #validateStructuredContent(
+    tool: Tool<T>,
+    value: Record<string, unknown>,
+    toolName: string,
+  ): Promise<Record<string, unknown>> {
+    if (!tool.outputSchema) {
+      return value;
+    }
+
+    const parsed = await tool.outputSchema["~standard"].validate(value);
+
+    if (parsed.issues) {
+      throw new UserError(
+        `Tool '${toolName}' structured output validation failed: ${this.#formatSchemaIssues(parsed.issues)}. Please check the result matches the tool's outputSchema.`,
+      );
+    }
+
+    return parsed.value as Record<string, unknown>;
   }
 
   private addPrompt(inputPrompt: InputPrompt<T>) {
@@ -1626,13 +1660,11 @@ export class FastMCPSession<
       });
     });
   }
-
   private setupErrorHandling() {
     this.#server.onerror = (error) => {
       this.#logger.error("[FastMCP error]", error);
     };
   }
-
   private setupLoggingHandlers() {
     this.#server.setRequestHandler(SetLevelRequestSchema, (request) => {
       this.#loggingLevel = request.params.level;
@@ -1721,6 +1753,7 @@ export class FastMCPSession<
       }
     });
   }
+
   private setupResourceHandlers() {
     let cachedResourcesList: ListResourcesResult["resources"] | null = null;
 
@@ -1829,6 +1862,7 @@ export class FastMCPSession<
       },
     );
   }
+
   private setupResourceTemplateHandlers() {
     let cachedResourceTemplatesList:
       | ListResourceTemplatesResult["resourceTemplates"]
@@ -1858,6 +1892,7 @@ export class FastMCPSession<
       },
     );
   }
+
   private setupRootsHandlers() {
     if (this.#rootsConfig?.enabled === false) {
       this.#logger.debug(
@@ -1904,6 +1939,7 @@ export class FastMCPSession<
       );
     }
   }
+
   private setupToolHandlers(tools: Tool<T>[]) {
     const toolsMap = new Map(tools.map((tool) => [tool.name, tool]));
     let cachedToolsList: ListToolsResult["tools"] | null = null;
@@ -1961,14 +1997,7 @@ export class FastMCPSession<
         );
 
         if (parsed.issues) {
-          const friendlyErrors = this.#utils?.formatInvalidParamsErrorMessage
-            ? this.#utils.formatInvalidParamsErrorMessage(parsed.issues)
-            : parsed.issues
-                .map((issue) => {
-                  const path = issue.path?.join(".") || "root";
-                  return `${path}: ${issue.message}`;
-                })
-                .join(", ");
+          const friendlyErrors = this.#formatSchemaIssues(parsed.issues);
 
           throw new McpError(
             ErrorCode.InvalidParams,
@@ -2121,6 +2150,7 @@ export class FastMCPSession<
           | ContentResult
           | ImageContent
           | null
+          | Record<string, unknown>
           | ResourceContent
           | ResourceLink
           | string
@@ -2142,6 +2172,30 @@ export class FastMCPSession<
         } else if ("type" in maybeStringResult) {
           result = ContentResultZodSchema.parse({
             content: [maybeStringResult],
+          });
+        } else if ("content" in maybeStringResult) {
+          result = ContentResultZodSchema.parse(maybeStringResult);
+          if (result.structuredContent !== undefined && tool.outputSchema) {
+            result.structuredContent = await this.#validateStructuredContent(
+              tool,
+              result.structuredContent,
+              request.params.name,
+            );
+          }
+        } else if (tool.outputSchema) {
+          const structuredContent = await this.#validateStructuredContent(
+            tool,
+            maybeStringResult,
+            request.params.name,
+          );
+          result = ContentResultZodSchema.parse({
+            content: [
+              {
+                text: JSON.stringify(structuredContent),
+                type: "text",
+              },
+            ],
+            structuredContent,
           });
         } else {
           result = ContentResultZodSchema.parse(maybeStringResult);


### PR DESCRIPTION
## What changed

Closes #81 and covers the structuredContent foundation needed for #261.

This adds first-class structured tool output support:

- `ContentResult` can now include `structuredContent`
- tools with `outputSchema` can return a plain object, which FastMCP sends as MCP `structuredContent`
- FastMCP also emits a JSON text fallback for clients that only render `content`
- explicit `{ content, structuredContent }` tool results are supported
- structured output is validated against `outputSchema` before returning to the client
- invalid structured output becomes a tool error instead of silently violating the advertised schema
- README docs now show both plain structured returns and explicit text + structured returns

## Why

FastMCP already advertises `outputSchema` in `tools/list`, but successful tool calls could not return structured content through the normal execute path. That meant tool authors had to serialize JSON into text even when clients could consume typed output directly.

This keeps the existing string/content behavior intact while making `outputSchema` useful at runtime.

## Validation

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/FastMCP.ts src/FastMCP.test.ts`
- `./node_modules/.bin/prettier --check src/FastMCP.ts src/FastMCP.test.ts README.md`
- `bun test src/FastMCP.test.ts -t "outputSchema|structuredContent"` — 5 passing tests

Note: Vitest under the local Codex macOS Node runtime could not start because Rollup's native optional dependency was rejected by local code-signing policy. The same focused tests pass under Bun, and the code passes TypeScript/lint/prettier.
