### PR TITLE
fix: allow HEAD method for /health and /ready endpoints

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -243,6 +243,33 @@ test("health and ready endpoints respond to HEAD requests", async () => {
   }
 });
 
+test("ready endpoint returns 503 for HEAD when not ready", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  // A non-stateless server with no connected sessions reports not-ready.
+  await server.start({
+    httpStream: { port },
+    transportType: "httpStream",
+  });
+
+  try {
+    // HEAD must preserve the 503 status (with an empty body) so load-balancer
+    // probes still see the not-ready signal, not just a 200 from /health.
+    const response = await fetch(`http://localhost:${port}/ready`, {
+      method: "HEAD",
+    });
+    expect(response.status).toBe(503);
+    expect(await response.text()).toBe("");
+  } finally {
+    await server.stop();
+  }
+});
+
 test("calls a tool", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -210,6 +210,39 @@ test("health endpoint returns ok", async () => {
   }
 });
 
+test("health and ready endpoints respond to HEAD requests", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    health: { message: "healthy", path: "/healthz" },
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  await server.start({
+    httpStream: { port, stateless: true },
+    transportType: "httpStream",
+  });
+
+  try {
+    // Load balancers and uptime probes commonly issue HEAD requests against
+    // health endpoints; they must return the same status as GET with no body.
+    const healthResponse = await fetch(`http://localhost:${port}/healthz`, {
+      method: "HEAD",
+    });
+    expect(healthResponse.status).toBe(200);
+    expect(await healthResponse.text()).toBe("");
+
+    const readyResponse = await fetch(`http://localhost:${port}/ready`, {
+      method: "HEAD",
+    });
+    expect(readyResponse.status).toBe(200);
+    expect(await readyResponse.text()).toBe("");
+  } finally {
+    await server.stop();
+  }
+});
+
 test("calls a tool", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2915,18 +2915,28 @@ export class FastMCP<
       const url = new URL(req.url || "", `http://${host}`);
 
       try {
-        if (req.method === "GET" && url.pathname === path) {
+        if (
+          (req.method === "GET" || req.method === "HEAD") &&
+          url.pathname === path
+        ) {
           res
             .writeHead(healthConfig.status ?? 200, {
               "Content-Type": "text/plain",
             })
-            .end(healthConfig.message ?? "✓ Ok");
+            .end(
+              req.method === "HEAD"
+                ? undefined
+                : (healthConfig.message ?? "✓ Ok"),
+            );
 
           return;
         }
 
         // Enhanced readiness check endpoint
-        if (req.method === "GET" && url.pathname === "/ready") {
+        if (
+          (req.method === "GET" || req.method === "HEAD") &&
+          url.pathname === "/ready"
+        ) {
           if (isStateless) {
             // In stateless mode, we're always ready if the server is running
             const response = {
@@ -2940,7 +2950,9 @@ export class FastMCP<
               .writeHead(200, {
                 "Content-Type": "application/json",
               })
-              .end(JSON.stringify(response));
+              .end(
+                req.method === "HEAD" ? undefined : JSON.stringify(response),
+              );
           } else {
             const readySessions = this.#sessions.filter(
               (s) => s.isReady,
@@ -2963,7 +2975,9 @@ export class FastMCP<
               .writeHead(allReady ? 200 : 503, {
                 "Content-Type": "application/json",
               })
-              .end(JSON.stringify(response));
+              .end(
+                req.method === "HEAD" ? undefined : JSON.stringify(response),
+              );
           }
 
           return;


### PR DESCRIPTION
## What

`/health` and `/ready` only matched `GET`, so a `HEAD` request fell through to the unhandled-request handler and returned `404`. Load balancers, uptime monitors, and container orchestrators commonly probe health endpoints with `HEAD` (cheaper than `GET`), so they saw the endpoint as down.

Closes #178.

## Change

- Extend the `/health` and `/ready` guards to accept `HEAD` as well as `GET`.
- For `HEAD`, respond headers-only (no body) per HTTP/1.1, preserving the status code — including `/ready`'s `503` when sessions aren't ready, so HEAD probes still get the readiness signal.

## Test

Adds a regression test that starts an httpStream server (stateless, for a deterministic `/ready` 200) and asserts `HEAD /health` and `HEAD /ready` both return `200` with an empty body. Verified it fails on `main` (404) and passes with the change. `pnpm test` and `pnpm lint` green.