### PR TITLE
feat(auth): support extra authorization params in OAuthProxy

### DIFF
--- a/docs/oauth-proxy-guide.md
+++ b/docs/oauth-proxy-guide.md
@@ -265,6 +265,7 @@ interface OAuthProxyConfig {
   consentRequired?: boolean; // default: true
   consentSigningKey?: string; // auto-generated if not provided
   allowedRedirectUriPatterns?: string[];
+  extraAuthorizationParams?: Record<string, string>; // provider-specific params
   transactionTtl?: number; // seconds, default: 600
   authorizationCodeTtl?: number; // seconds, default: 300
 
@@ -279,6 +280,28 @@ interface OAuthProxyConfig {
   tokenVerifier?: TokenVerifier; // custom JWT verification
 }
 ```
+
+### Extra Authorization Parameters
+
+Some providers require non-standard parameters on the authorization request.
+Google, for example, only issues a `refresh_token` when the request includes
+`access_type=offline` — without it, access expires after one hour and can
+never be renewed:
+
+```typescript
+const authProxy = new OAuthProxy({
+  // ... other config
+  extraAuthorizationParams: {
+    access_type: "offline", // Google: issue a refresh_token
+    prompt: "consent", // Google: re-issue refresh_token on re-auth
+  },
+});
+```
+
+These parameters are appended to the upstream authorization URL. Core OAuth
+parameters managed by the proxy (`client_id`, `redirect_uri`, `response_type`,
+`state`, `scope`, `code_challenge`, `code_challenge_method`) cannot be
+overridden — entries with those keys are ignored.
 
 ### Redirect URI Patterns
 

--- a/src/auth/OAuthProxy.extra-authorization-params.test.ts
+++ b/src/auth/OAuthProxy.extra-authorization-params.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for `extraAuthorizationParams` (issue #276).
+ *
+ * Providers like Google only issue a refresh_token when the authorization
+ * request carries provider-specific parameters (`access_type=offline`,
+ * `prompt=consent`). `OAuthProxy` must be able to append such parameters to
+ * the upstream authorization URL, while never letting them override the
+ * core OAuth parameters the proxy controls (client_id, redirect_uri, ...).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AuthorizationParams, OAuthProxyConfig } from "./types.js";
+
+import { OAuthProxy } from "./OAuthProxy.js";
+
+const CLIENT_REDIRECT = "https://client.example.com/callback";
+
+const baseConfig: OAuthProxyConfig = {
+  allowedRedirectUriPatterns: ["https://client.example.com/*"],
+  baseUrl: "http://localhost:4200",
+  consentRequired: false,
+  scopes: ["openid", "email"],
+  upstreamAuthorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  upstreamClientId: "upstream-client-id",
+  upstreamClientSecret: "upstream-client-secret",
+  upstreamTokenEndpoint: "https://oauth2.googleapis.com/token",
+};
+
+/**
+ * Register a client via DCR, run authorize(), and return the parsed
+ * upstream authorization URL from the redirect Location header.
+ */
+async function getUpstreamAuthorizationUrl(proxy: OAuthProxy): Promise<URL> {
+  const dcr = await proxy.registerClient({
+    redirect_uris: [CLIENT_REDIRECT],
+  });
+
+  const response = await proxy.authorize({
+    client_id: dcr.client_id,
+    redirect_uri: CLIENT_REDIRECT,
+    response_type: "code",
+    state: "client-state",
+  } as AuthorizationParams);
+
+  expect(response.status).toBe(302);
+  const location = response.headers.get("Location");
+  expect(location).toBeTruthy();
+  return new URL(location!);
+}
+
+describe("OAuthProxy extraAuthorizationParams", () => {
+  let proxy: OAuthProxy;
+
+  afterEach(() => {
+    proxy.destroy();
+  });
+
+  it("appends configured extra params to the upstream authorization URL", async () => {
+    proxy = new OAuthProxy({
+      ...baseConfig,
+      extraAuthorizationParams: {
+        access_type: "offline",
+        prompt: "consent",
+      },
+    });
+
+    const authUrl = await getUpstreamAuthorizationUrl(proxy);
+
+    expect(authUrl.searchParams.get("access_type")).toBe("offline");
+    expect(authUrl.searchParams.get("prompt")).toBe("consent");
+  });
+
+  it("leaves the authorization URL unchanged when not configured", async () => {
+    proxy = new OAuthProxy(baseConfig);
+
+    const authUrl = await getUpstreamAuthorizationUrl(proxy);
+
+    expect([...authUrl.searchParams.keys()].sort()).toEqual([
+      "client_id",
+      "code_challenge",
+      "code_challenge_method",
+      "redirect_uri",
+      "response_type",
+      "scope",
+      "state",
+    ]);
+  });
+
+  it("does not let extra params override core OAuth parameters", async () => {
+    proxy = new OAuthProxy({
+      ...baseConfig,
+      extraAuthorizationParams: {
+        access_type: "offline",
+        client_id: "attacker-client-id",
+        code_challenge: "attacker-challenge",
+        code_challenge_method: "plain",
+        redirect_uri: "https://evil.example.com/steal",
+        response_type: "token",
+        scope: "attacker-scope",
+        state: "attacker-state",
+      },
+    });
+
+    const authUrl = await getUpstreamAuthorizationUrl(proxy);
+
+    // The benign extra param still goes through...
+    expect(authUrl.searchParams.get("access_type")).toBe("offline");
+
+    // ...but every proxy-controlled parameter keeps its original value.
+    expect(authUrl.searchParams.get("client_id")).toBe("upstream-client-id");
+    expect(authUrl.searchParams.get("redirect_uri")).toBe(
+      "http://localhost:4200/oauth/callback",
+    );
+    expect(authUrl.searchParams.get("response_type")).toBe("code");
+    expect(authUrl.searchParams.get("state")).not.toBe("attacker-state");
+    expect(authUrl.searchParams.get("scope")).not.toBe("attacker-scope");
+    expect(authUrl.searchParams.get("code_challenge")).not.toBe(
+      "attacker-challenge",
+    );
+    expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("keeps proxy PKCE intact even when forwardPkce is false and extras try to inject a challenge", async () => {
+    proxy = new OAuthProxy({
+      ...baseConfig,
+      extraAuthorizationParams: {
+        code_challenge: "attacker-challenge",
+      },
+      forwardPkce: false,
+    });
+
+    const authUrl = await getUpstreamAuthorizationUrl(proxy);
+
+    expect(authUrl.searchParams.get("code_challenge")).not.toBe(
+      "attacker-challenge",
+    );
+    expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+});

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -39,6 +39,21 @@ import {
 } from "./utils/tokenStore.js";
 
 /**
+ * Authorization request parameters owned by the proxy. Entries in
+ * `extraAuthorizationParams` with these keys are ignored so configuration
+ * can never override the security-critical core of the upstream request.
+ */
+const RESERVED_AUTHORIZATION_PARAMS: ReadonlySet<string> = new Set([
+  "client_id",
+  "code_challenge",
+  "code_challenge_method",
+  "redirect_uri",
+  "response_type",
+  "scope",
+  "state",
+]);
+
+/**
  * OAuth 2.1 Proxy
  * Acts as transparent intermediary between MCP clients and upstream OAuth providers
  */
@@ -1254,6 +1269,18 @@ export class OAuthProxy {
    */
   private redirectToUpstream(transaction: OAuthTransaction): Response {
     const authUrl = new URL(this.config.upstreamAuthorizationEndpoint);
+
+    // Provider-specific extras (e.g. Google's access_type=offline) go first
+    // so the proxy-controlled core parameters below always win on conflict.
+    if (this.config.extraAuthorizationParams) {
+      for (const [key, value] of Object.entries(
+        this.config.extraAuthorizationParams,
+      )) {
+        if (!RESERVED_AUTHORIZATION_PARAMS.has(key)) {
+          authUrl.searchParams.set(key, value);
+        }
+      }
+    }
 
     authUrl.searchParams.set("client_id", this.config.upstreamClientId);
     authUrl.searchParams.set(

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -241,6 +241,18 @@ export interface OAuthProxyConfig {
   enableTokenSwap?: boolean;
   /** Encryption key for token storage (default: auto-generated). Set to false to disable encryption. */
   encryptionKey?: false | string;
+  /**
+   * Extra query parameters appended to the upstream authorization URL.
+   * Required by providers such as Google, which only issues a refresh_token
+   * when the authorization request carries `access_type=offline` (and
+   * re-issues it on re-auth with `prompt=consent`). Without these, access
+   * expires after the upstream token TTL and can never be renewed.
+   *
+   * Core OAuth parameters managed by the proxy (client_id, redirect_uri,
+   * response_type, state, scope, code_challenge, code_challenge_method)
+   * cannot be overridden — entries with those keys are ignored.
+   */
+  extraAuthorizationParams?: Record<string, string>;
   /** Forward client's PKCE to upstream (default: false) */
   forwardPkce?: boolean;
   /** Secret key for signing JWTs when token swap is enabled */


### PR DESCRIPTION
Closes #276

## Problem

`OAuthProxy.redirectToUpstream()` builds the upstream authorization URL with only the core OAuth parameters. Providers like Google require extra parameters on the authorization request — `access_type=offline` to issue a `refresh_token` at all, and `prompt=consent` to re-issue it on re-auth. Without them, the stored Google access token expires after 1 hour and can never be renewed.

## Solution

Adds an `extraAuthorizationParams` option to `OAuthProxyConfig`, exactly as proposed in the issue:

```typescript
new OAuthProxy({
  // ...
  extraAuthorizationParams: {
    access_type: "offline",
    prompt: "consent",
  },
});
```

### Safety

- Extra params are applied **before** the proxy sets its core parameters, so the proxy-controlled values always win on conflict.
- Reserved keys (`client_id`, `redirect_uri`, `response_type`, `state`, `scope`, `code_challenge`, `code_challenge_method`) are additionally filtered out, so configuration can never override the security-critical core of the request.
- When the option is not set, behavior is unchanged (covered by a test asserting the exact parameter set).

## Testing

- New `src/auth/OAuthProxy.extra-authorization-params.test.ts` (4 tests): params appended; unchanged behavior without config; reserved keys cannot be overridden; proxy PKCE stays intact.
- Full auth suite green (178 tests), `prettier` / `eslint` / `tsc --noEmit` clean.
- Docs updated in `docs/oauth-proxy-guide.md`.
