### PR TITLE
feat: add non-interactive tool calls to fastmcp dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2310,6 +2310,14 @@ npx fastmcp dev server.ts
 
 This will run your server with [`mcp-cli`](https://github.com/wong2/mcp-cli) for testing and debugging your MCP server in the terminal.
 
+To call a tool non-interactively (for example, in scripts or automated tests), pass `--tool` and optional JSON `--args`:
+
+```bash
+npx fastmcp dev server.ts --tool add --args '{"a":1,"b":2}'
+```
+
+This prints the tool result as JSON and exits, instead of opening the interactive inspector.
+
 ### Inspect with `MCP Inspector`
 
 Another way is to use the official [`MCP Inspector`](https://modelcontextprotocol.io/docs/tools/inspector) to inspect your server with a Web UI:

--- a/README.md
+++ b/README.md
@@ -2316,7 +2316,7 @@ To call a tool non-interactively (for example, in scripts or automated tests), p
 npx fastmcp dev server.ts --tool add --args '{"a":1,"b":2}'
 ```
 
-This prints the tool result as JSON and exits, instead of opening the interactive inspector.
+This prints the tool result as JSON and exits, instead of opening the interactive inspector. `--watch` has no effect in this mode, since the server is started for a single call.
 
 ### Inspect with `MCP Inspector`
 

--- a/src/bin/devCommand.test.ts
+++ b/src/bin/devCommand.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDevCommand,
+  buildDevConfig,
+  DEV_SERVER_NAME,
+} from "./devCommand.js";
+
+describe("buildDevCommand", () => {
+  it("launches the interactive inspector when no tool is given", () => {
+    expect(buildDevCommand({ file: "server.ts" })).toBe(
+      "npx @wong2/mcp-cli npx tsx server.ts",
+    );
+  });
+
+  it("adds --watch to the interactive command", () => {
+    expect(buildDevCommand({ file: "server.ts", watch: true })).toBe(
+      "npx @wong2/mcp-cli npx tsx --watch server.ts",
+    );
+  });
+
+  it("builds a non-interactive call-tool command", () => {
+    expect(
+      buildDevCommand({
+        configPath: "/tmp/cfg.json",
+        file: "server.ts",
+        tool: "add",
+      }),
+    ).toBe(
+      `npx @wong2/mcp-cli -c '/tmp/cfg.json' call-tool '${DEV_SERVER_NAME}:add'`,
+    );
+  });
+
+  it("forwards tool args via --args", () => {
+    expect(
+      buildDevCommand({
+        configPath: "/tmp/cfg.json",
+        file: "server.ts",
+        tool: "add",
+        toolArgs: '{"a":1,"b":2}',
+      }),
+    ).toBe(
+      `npx @wong2/mcp-cli -c '/tmp/cfg.json' call-tool '${DEV_SERVER_NAME}:add' --args '{"a":1,"b":2}'`,
+    );
+  });
+
+  it("escapes single quotes in tool args", () => {
+    const command = buildDevCommand({
+      configPath: "/tmp/cfg.json",
+      file: "server.ts",
+      tool: "echo",
+      toolArgs: `{"text":"it's"}`,
+    });
+
+    expect(command).toContain(`--args '{"text":"it'\\''s"}'`);
+  });
+
+  it("requires a config path in non-interactive mode", () => {
+    expect(() => buildDevCommand({ file: "server.ts", tool: "add" })).toThrow(
+      /configPath is required/,
+    );
+  });
+});
+
+describe("buildDevConfig", () => {
+  it("registers the dev server with an inline tsx command", () => {
+    const config = JSON.parse(buildDevConfig("server.ts", false));
+
+    expect(config.mcpServers[DEV_SERVER_NAME]).toEqual({
+      args: ["tsx", "server.ts"],
+      command: "npx",
+    });
+  });
+
+  it("includes --watch in the config when watch is enabled", () => {
+    const config = JSON.parse(buildDevConfig("server.ts", true));
+
+    expect(config.mcpServers[DEV_SERVER_NAME].args).toEqual([
+      "tsx",
+      "--watch",
+      "server.ts",
+    ]);
+  });
+});

--- a/src/bin/devCommand.test.ts
+++ b/src/bin/devCommand.test.ts
@@ -8,15 +8,24 @@ import {
 
 describe("buildDevCommand", () => {
   it("launches the interactive inspector when no tool is given", () => {
-    expect(buildDevCommand({ file: "server.ts" })).toBe(
-      "npx @wong2/mcp-cli npx tsx server.ts",
-    );
+    expect(buildDevCommand({ file: "server.ts" })).toEqual([
+      "npx",
+      "@wong2/mcp-cli",
+      "npx",
+      "tsx",
+      "server.ts",
+    ]);
   });
 
   it("adds --watch to the interactive command", () => {
-    expect(buildDevCommand({ file: "server.ts", watch: true })).toBe(
-      "npx @wong2/mcp-cli npx tsx --watch server.ts",
-    );
+    expect(buildDevCommand({ file: "server.ts", watch: true })).toEqual([
+      "npx",
+      "@wong2/mcp-cli",
+      "npx",
+      "tsx",
+      "--watch",
+      "server.ts",
+    ]);
   });
 
   it("builds a non-interactive call-tool command", () => {
@@ -26,9 +35,14 @@ describe("buildDevCommand", () => {
         file: "server.ts",
         tool: "add",
       }),
-    ).toBe(
-      `npx @wong2/mcp-cli -c '/tmp/cfg.json' call-tool '${DEV_SERVER_NAME}:add'`,
-    );
+    ).toEqual([
+      "npx",
+      "@wong2/mcp-cli",
+      "-c",
+      "/tmp/cfg.json",
+      "call-tool",
+      `${DEV_SERVER_NAME}:add`,
+    ]);
   });
 
   it("forwards tool args via --args", () => {
@@ -39,12 +53,19 @@ describe("buildDevCommand", () => {
         tool: "add",
         toolArgs: '{"a":1,"b":2}',
       }),
-    ).toBe(
-      `npx @wong2/mcp-cli -c '/tmp/cfg.json' call-tool '${DEV_SERVER_NAME}:add' --args '{"a":1,"b":2}'`,
-    );
+    ).toEqual([
+      "npx",
+      "@wong2/mcp-cli",
+      "-c",
+      "/tmp/cfg.json",
+      "call-tool",
+      `${DEV_SERVER_NAME}:add`,
+      "--args",
+      '{"a":1,"b":2}',
+    ]);
   });
 
-  it("escapes single quotes in tool args", () => {
+  it("passes tool args through verbatim, without shell quoting", () => {
     const command = buildDevCommand({
       configPath: "/tmp/cfg.json",
       file: "server.ts",
@@ -52,7 +73,17 @@ describe("buildDevCommand", () => {
       toolArgs: `{"text":"it's"}`,
     });
 
-    expect(command).toContain(`--args '{"text":"it'\\''s"}'`);
+    expect(command.at(-1)).toBe(`{"text":"it's"}`);
+  });
+
+  it("keeps paths containing spaces intact", () => {
+    const command = buildDevCommand({
+      configPath: "/tmp/my configs/cfg.json",
+      file: "server.ts",
+      tool: "add",
+    });
+
+    expect(command).toContain("/tmp/my configs/cfg.json");
   });
 
   it("requires a config path in non-interactive mode", () => {
@@ -64,7 +95,7 @@ describe("buildDevCommand", () => {
 
 describe("buildDevConfig", () => {
   it("registers the dev server with an inline tsx command", () => {
-    const config = JSON.parse(buildDevConfig("server.ts", false));
+    const config = JSON.parse(buildDevConfig("server.ts"));
 
     expect(config.mcpServers[DEV_SERVER_NAME]).toEqual({
       args: ["tsx", "server.ts"],
@@ -72,13 +103,9 @@ describe("buildDevConfig", () => {
     });
   });
 
-  it("includes --watch in the config when watch is enabled", () => {
-    const config = JSON.parse(buildDevConfig("server.ts", true));
+  it("never watches, because a non-interactive call runs the server once", () => {
+    const config = JSON.parse(buildDevConfig("server.ts"));
 
-    expect(config.mcpServers[DEV_SERVER_NAME].args).toEqual([
-      "tsx",
-      "--watch",
-      "server.ts",
-    ]);
+    expect(config.mcpServers[DEV_SERVER_NAME].args).not.toContain("--watch");
   });
 });

--- a/src/bin/devCommand.ts
+++ b/src/bin/devCommand.ts
@@ -1,0 +1,96 @@
+export type DevCommandOptions = {
+  /**
+   * Path to a temporary mcp-cli config file that registers the dev server.
+   * Only used in non-interactive mode (when `tool` is set).
+   */
+  configPath?: string;
+  /**
+   * Path to the server file to run.
+   */
+  file: string;
+  /**
+   * Name of the tool to call non-interactively. When omitted, the dev
+   * command launches the interactive mcp-cli inspector instead.
+   */
+  tool?: string;
+  /**
+   * JSON string of arguments forwarded to the tool via mcp-cli `--args`.
+   * Only used in non-interactive mode.
+   */
+  toolArgs?: string;
+  /**
+   * Watch the file for changes and restart the server.
+   */
+  watch?: boolean;
+};
+
+/**
+ * The server name registered in the generated mcp-cli config. mcp-cli
+ * addresses non-interactive targets as `<server-name>:<tool>`.
+ */
+export const DEV_SERVER_NAME = "dev";
+
+const shellQuote = (value: string): string =>
+  `'${value.replace(/'/g, `'\\''`)}'`;
+
+/**
+ * Build the JSON config that registers the dev server with mcp-cli so it can
+ * be invoked non-interactively. mcp-cli's non-interactive mode resolves the
+ * server by name from a config file's `mcpServers` map, so an inline command
+ * cannot be passed directly alongside `call-tool`.
+ */
+export const buildDevConfig = (file: string, watch: boolean): string => {
+  const args = watch ? ["tsx", "--watch", file] : ["tsx", file];
+
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [DEV_SERVER_NAME]: {
+          args,
+          command: "npx",
+        },
+      },
+    },
+    null,
+    2,
+  );
+};
+
+/**
+ * Build the shell command that the dev command runs.
+ *
+ * - Without `tool`: launches the interactive @wong2/mcp-cli inspector
+ *   against an inline `npx tsx <file>` server (existing behaviour).
+ * - With `tool`: runs @wong2/mcp-cli in non-interactive mode against a
+ *   generated config file, calling the named tool and forwarding `--args`.
+ */
+export const buildDevCommand = (options: DevCommandOptions): string => {
+  const { configPath, file, tool, toolArgs, watch = false } = options;
+
+  if (tool) {
+    if (!configPath) {
+      throw new Error(
+        "configPath is required when calling a tool non-interactively",
+      );
+    }
+
+    const parts = [
+      "npx",
+      "@wong2/mcp-cli",
+      "-c",
+      shellQuote(configPath),
+      "call-tool",
+      shellQuote(`${DEV_SERVER_NAME}:${tool}`),
+    ];
+
+    if (toolArgs !== undefined) {
+      parts.push("--args", shellQuote(toolArgs));
+    }
+
+    return parts.join(" ");
+  }
+
+  return watch
+    ? `npx @wong2/mcp-cli npx tsx --watch ${file}`
+    : `npx @wong2/mcp-cli npx tsx ${file}`;
+};

--- a/src/bin/devCommand.ts
+++ b/src/bin/devCommand.ts
@@ -19,7 +19,8 @@ export type DevCommandOptions = {
    */
   toolArgs?: string;
   /**
-   * Watch the file for changes and restart the server.
+   * Watch the file for changes and restart the server. Only used in
+   * interactive mode; a non-interactive call runs the server once.
    */
   watch?: boolean;
 };
@@ -30,23 +31,21 @@ export type DevCommandOptions = {
  */
 export const DEV_SERVER_NAME = "dev";
 
-const shellQuote = (value: string): string =>
-  `'${value.replace(/'/g, `'\\''`)}'`;
-
 /**
  * Build the JSON config that registers the dev server with mcp-cli so it can
  * be invoked non-interactively. mcp-cli's non-interactive mode resolves the
  * server by name from a config file's `mcpServers` map, so an inline command
  * cannot be passed directly alongside `call-tool`.
+ *
+ * The server is never started in watch mode here: a non-interactive call
+ * connects, calls one tool, and exits, so there is nothing to restart into.
  */
-export const buildDevConfig = (file: string, watch: boolean): string => {
-  const args = watch ? ["tsx", "--watch", file] : ["tsx", file];
-
-  return JSON.stringify(
+export const buildDevConfig = (file: string): string =>
+  JSON.stringify(
     {
       mcpServers: {
         [DEV_SERVER_NAME]: {
-          args,
+          args: ["tsx", file],
           command: "npx",
         },
       },
@@ -54,17 +53,23 @@ export const buildDevConfig = (file: string, watch: boolean): string => {
     null,
     2,
   );
-};
 
 /**
- * Build the shell command that the dev command runs.
+ * Build the argv that the dev command runs.
+ *
+ * This is an argv array rather than a shell string so that nothing has to be
+ * quoted: file paths, tool names and JSON `--args` are passed to the child
+ * process verbatim. Quoting through a shell would be wrong on Windows, where
+ * cmd.exe treats single quotes as literal characters rather than as quoting.
  *
  * - Without `tool`: launches the interactive @wong2/mcp-cli inspector
  *   against an inline `npx tsx <file>` server (existing behaviour).
  * - With `tool`: runs @wong2/mcp-cli in non-interactive mode against a
  *   generated config file, calling the named tool and forwarding `--args`.
  */
-export const buildDevCommand = (options: DevCommandOptions): string => {
+export const buildDevCommand = (
+  options: DevCommandOptions,
+): [string, ...string[]] => {
   const { configPath, file, tool, toolArgs, watch = false } = options;
 
   if (tool) {
@@ -74,23 +79,23 @@ export const buildDevCommand = (options: DevCommandOptions): string => {
       );
     }
 
-    const parts = [
+    return [
       "npx",
       "@wong2/mcp-cli",
       "-c",
-      shellQuote(configPath),
+      configPath,
       "call-tool",
-      shellQuote(`${DEV_SERVER_NAME}:${tool}`),
+      `${DEV_SERVER_NAME}:${tool}`,
+      ...(toolArgs === undefined ? [] : ["--args", toolArgs]),
     ];
-
-    if (toolArgs !== undefined) {
-      parts.push("--args", shellQuote(toolArgs));
-    }
-
-    return parts.join(" ");
   }
 
-  return watch
-    ? `npx @wong2/mcp-cli npx tsx --watch ${file}`
-    : `npx @wong2/mcp-cli npx tsx ${file}`;
+  return [
+    "npx",
+    "@wong2/mcp-cli",
+    "npx",
+    "tsx",
+    ...(watch ? ["--watch"] : []),
+    file,
+  ];
 };

--- a/src/bin/fastmcp.ts
+++ b/src/bin/fastmcp.ts
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
 import { execa } from "execa";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
+
+import { buildDevCommand, buildDevConfig } from "./devCommand.js";
 
 await yargs(hideBin(process.argv))
   .scriptName("fastmcp")
@@ -14,6 +19,19 @@ await yargs(hideBin(process.argv))
         .positional("file", {
           demandOption: true,
           describe: "The path to the server file",
+          type: "string",
+        })
+
+        .option("args", {
+          describe:
+            "JSON arguments passed to the tool (requires --tool), e.g. '{\"a\":1}'",
+          type: "string",
+        })
+
+        .option("tool", {
+          alias: "t",
+          describe:
+            "Call a tool non-interactively instead of launching the inspector",
           type: "string",
         })
 
@@ -33,10 +51,33 @@ await yargs(hideBin(process.argv))
     },
 
     async (argv) => {
+      let configDir: string | undefined;
+
       try {
-        const command = argv.watch
-          ? `npx @wong2/mcp-cli npx tsx --watch ${argv.file}`
-          : `npx @wong2/mcp-cli npx tsx ${argv.file}`;
+        if (argv.args !== undefined && !argv.tool) {
+          console.error("[FastMCP Error] --args requires --tool");
+          process.exit(1);
+        }
+
+        let configPath: string | undefined;
+
+        if (argv.tool) {
+          configDir = await mkdtemp(join(tmpdir(), "fastmcp-dev-"));
+          configPath = join(configDir, "mcp-cli.json");
+          await writeFile(
+            configPath,
+            buildDevConfig(argv.file, argv.watch),
+            "utf8",
+          );
+        }
+
+        const command = buildDevCommand({
+          configPath,
+          file: argv.file,
+          tool: argv.tool,
+          toolArgs: argv.args,
+          watch: argv.watch,
+        });
 
         if (argv.verbose) {
           console.log(`[FastMCP] Starting server: ${command}`);
@@ -44,6 +85,10 @@ await yargs(hideBin(process.argv))
           console.log(
             `[FastMCP] Watch mode: ${argv.watch ? "enabled" : "disabled"}`,
           );
+
+          if (argv.tool) {
+            console.log(`[FastMCP] Tool: ${argv.tool}`);
+          }
         }
 
         await execa({
@@ -63,6 +108,10 @@ await yargs(hideBin(process.argv))
         }
 
         process.exit(1);
+      } finally {
+        if (configDir) {
+          await rm(configDir, { force: true, recursive: true });
+        }
       }
     },
   )

--- a/src/bin/fastmcp.ts
+++ b/src/bin/fastmcp.ts
@@ -56,7 +56,14 @@ await yargs(hideBin(process.argv))
       try {
         if (argv.args !== undefined && !argv.tool) {
           console.error("[FastMCP Error] --args requires --tool");
-          process.exit(1);
+          process.exitCode = 1;
+          return;
+        }
+
+        if (argv.tool && argv.watch) {
+          console.warn(
+            "[FastMCP] --watch is ignored when calling a tool with --tool: the server runs for a single call.",
+          );
         }
 
         let configPath: string | undefined;
@@ -64,14 +71,10 @@ await yargs(hideBin(process.argv))
         if (argv.tool) {
           configDir = await mkdtemp(join(tmpdir(), "fastmcp-dev-"));
           configPath = join(configDir, "mcp-cli.json");
-          await writeFile(
-            configPath,
-            buildDevConfig(argv.file, argv.watch),
-            "utf8",
-          );
+          await writeFile(configPath, buildDevConfig(argv.file), "utf8");
         }
 
-        const command = buildDevCommand({
+        const [command, ...commandArgs] = buildDevCommand({
           configPath,
           file: argv.file,
           tool: argv.tool,
@@ -80,7 +83,9 @@ await yargs(hideBin(process.argv))
         });
 
         if (argv.verbose) {
-          console.log(`[FastMCP] Starting server: ${command}`);
+          console.log(
+            `[FastMCP] Starting server: ${[command, ...commandArgs].join(" ")}`,
+          );
           console.log(`[FastMCP] File: ${argv.file}`);
           console.log(
             `[FastMCP] Watch mode: ${argv.watch ? "enabled" : "disabled"}`,
@@ -91,12 +96,11 @@ await yargs(hideBin(process.argv))
           }
         }
 
-        await execa({
-          shell: true,
+        await execa(command, commandArgs, {
           stderr: "inherit",
           stdin: "inherit",
           stdout: "inherit",
-        })`${command}`;
+        });
       } catch (error) {
         console.error(
           "[FastMCP Error] Failed to start development server:",
@@ -107,7 +111,9 @@ await yargs(hideBin(process.argv))
           console.error("[FastMCP Debug] Stack trace:", error.stack);
         }
 
-        process.exit(1);
+        // Not process.exit(): that would skip the `finally` block below and
+        // leak the temporary config directory on every failed tool call.
+        process.exitCode = 1;
       } finally {
         if (configDir) {
           await rm(configDir, { force: true, recursive: true });


### PR DESCRIPTION
`fastmcp dev` only opened the interactive `mcp-cli` flow, which made it awkward to script a single tool call while developing a server.
This adds `--tool` and `--args` for non-interactive tool calls while leaving the existing interactive path unchanged. The command writes a temporary `mcp-cli` config for the dev server, calls the selected tool, and cleans up the temp directory afterward.
I checked the helper tests, full Vitest run with 372 passing tests, TypeScript, ESLint, Prettier, build, and a built CLI smoke test that called an `add-zod` tool successfully. `--args` without `--tool` also returns the expected error.

Fixes #96