### PR TITLE
fix(auth): persist OAuth proxy state

### DIFF
--- a/docs/oauth-advanced-features.md
+++ b/docs/oauth-advanced-features.md
@@ -311,9 +311,10 @@ const encryptionKey = await JWTIssuer.deriveKey(
 
 ### Storage Backend Selection
 
-- **MemoryTokenStorage**: Fast but loses data on restart. Good for development.
-- **DiskStore**: Persistent but slower. Good for single-server production.
+- **MemoryTokenStorage**: Fast but loses data on restart, and per-process. Good for development.
+- **DiskStore**: Persistent but slower. Good for single-host production, including several processes sharing one directory.
 - **EncryptedTokenStorage**: Additional overhead for encryption. Use when storing sensitive data.
+- **Custom (Redis/database)**: Required to run instances on more than one host. Must implement `take` — see [Running Multiple Instances](oauth-proxy-guide.md#running-multiple-instances).
 
 ### Cleanup Intervals
 

--- a/docs/oauth-proxy-features.md
+++ b/docs/oauth-proxy-features.md
@@ -203,8 +203,10 @@ Ready-to-use provider implementations:
 
 Background processes maintain system health:
 
-- Expired transactions automatically removed
-- Authorization codes deleted after use or expiration
+- Transactions and authorization codes are written with a TTL derived from their
+  expiry, and reclaimed by the storage backend
+- Authorization codes are consumed on first use; a small marker is kept until
+  the code would have expired, so a replay reports "already used"
 - Token mappings cleaned up based on TTL
 - Configurable cleanup intervals (default: 60 seconds)
 
@@ -276,8 +278,16 @@ interface TokenStorage {
   get(key: string): Promise<unknown | null>;
   delete(key: string): Promise<void>;
   cleanup(): Promise<void>;
+  /** Atomic get + delete. Optional, but required to run more than one instance. */
+  take?(key: string): Promise<unknown | null>;
 }
 ```
+
+Your implementation must honour `ttl` — transactions and authorization codes
+are written with one derived from their expiry, and a backend that ignores it
+never reclaims them. Implement `take` if more than one process shares the
+storage; see
+[Running Multiple Instances](oauth-proxy-guide.md#running-multiple-instances).
 
 #### Forward PKCE Mode
 
@@ -433,13 +443,18 @@ Built-in debugging capabilities:
 - Server-side proxy only (no client-side OAuth handler)
 - HS256 JWT signing only (no RS256/ES256 yet)
 - No built-in token revocation endpoint
-- No built-in distributed locking for multi-server deployments
+- No general-purpose distributed locking; single-use enforcement for
+  authorization codes and transactions relies on `TokenStorage.take`
 
 ### Storage Considerations
 
-- In-memory storage doesn't persist across restarts
-- DiskStore is single-server only (no distributed support)
-- Large-scale deployments may need Redis/database backends
+- In-memory storage doesn't persist across restarts, and is per-process, so it
+  only works for a single instance
+- DiskStore is host-local: processes sharing one directory are safe (it claims
+  entries with an atomic `rename()`), but it is not a network-distributed store
+- Multi-instance deployments need a shared backend (Redis/database) that
+  implements `take` — see
+  [Running Multiple Instances](oauth-proxy-guide.md#running-multiple-instances)
 
 ### Provider Support
 

--- a/docs/oauth-proxy-guide.md
+++ b/docs/oauth-proxy-guide.md
@@ -606,6 +606,12 @@ class RedisTokenStorage implements TokenStorage {
   async cleanup(): Promise<void> {
     // Redis handles TTL automatically
   }
+
+  // Optional, but required to run more than one instance — see below.
+  async take(key: string): Promise<unknown | null> {
+    const value = await this.redis.getdel(key);
+    return value ? JSON.parse(value) : null;
+  }
 }
 
 const authProxy = new OAuthProxy({
@@ -613,6 +619,62 @@ const authProxy = new OAuthProxy({
   tokenStorage: new RedisTokenStorage(redisClient),
 });
 ```
+
+Two requirements your implementation must meet:
+
+- **Honour `ttl`.** Transactions and authorization codes are written with a TTL
+  derived from their expiry. A backend that ignores it never reclaims them.
+  Expired entries are still rejected on read, so this is a storage leak rather
+  than a security hole — but it is an unbounded one.
+- **Implement `take` if more than one process shares the storage.** See the
+  next section.
+
+### Running Multiple Instances
+
+All proxy state — client registrations, in-flight transactions, and issued
+authorization codes — lives in the configured `TokenStorage`, so several
+instances behind a load balancer can serve different legs of the same OAuth
+flow. Three things have to line up:
+
+**1. Share the storage.** Every instance must point at the same backend.
+`MemoryTokenStorage` (the default) is per-process, so it only works for a
+single instance.
+
+**2. Share the key material.** `encryptionKey`, `consentSigningKey`, and
+`jwtSigningKey` are each auto-generated per instance when you don't supply
+them. Two instances then write state the other cannot read, and the failures
+are indirect: decryption returns `null`, so a valid request comes back as
+`invalid_client` or "Invalid or expired state" rather than as a key error. Set
+all three explicitly, from the same secret source:
+
+```typescript
+const authProxy = new OAuthProxy({
+  // ... other config
+  consentSigningKey: process.env.OAUTH_CONSENT_SIGNING_KEY,
+  encryptionKey: process.env.OAUTH_ENCRYPTION_KEY,
+  jwtSigningKey: process.env.OAUTH_JWT_SIGNING_KEY,
+  tokenStorage: new RedisTokenStorage(redisClient),
+});
+```
+
+**3. Implement `TokenStorage.take`.** Authorization codes and transactions are
+single-use (RFC 6749 §4.1.2). The proxy consumes them through `take`, which
+must atomically return a value and delete it so that at most one caller
+receives it. Without it the proxy falls back to a non-atomic get + delete, and
+two concurrent requests landing on different instances can both redeem the same
+authorization code.
+
+Most backends have a primitive for this:
+
+| Backend  | Implementation                                   |
+| -------- | ------------------------------------------------ |
+| Redis    | `GETDEL key`                                     |
+| DynamoDB | `DeleteItem` with `ReturnValues: "ALL_OLD"`      |
+| SQL      | `DELETE FROM ... WHERE key = $1 RETURNING value` |
+
+The bundled `MemoryTokenStorage` and `DiskStore` both implement it —
+`DiskStore` claims entries with an atomic `rename()`, so several processes
+sharing one directory are safe.
 
 ### JWKS Token Verification
 
@@ -953,6 +1015,12 @@ const authProxy = new OAuthProxy({
   // ...
 });
 ```
+
+8. **If You Run More Than One Instance**
+
+Share the token storage and the key material across instances, and implement
+`TokenStorage.take` so authorization codes stay single-use. See
+[Running Multiple Instances](#running-multiple-instances).
 
 ### Environment Variables
 

--- a/docs/oauth-proxy-guide.md
+++ b/docs/oauth-proxy-guide.md
@@ -676,6 +676,12 @@ The bundled `MemoryTokenStorage` and `DiskStore` both implement it —
 `DiskStore` claims entries with an atomic `rename()`, so several processes
 sharing one directory are safe.
 
+Because codes are consumed at the start of the exchange, a token request that
+then fails validation — wrong `client_id`, bad PKCE `code_verifier` — spends
+the code. The client has to restart at `/oauth/authorize` rather than retry the
+same code. That is deliberate: a code presented without the matching verifier
+has most likely leaked, so it should not stay redeemable.
+
 ### JWKS Token Verification
 
 For distributed systems or when you need to verify tokens using public keys (RS256/ES256), use JWKS (JSON Web Key Set) verification.

--- a/src/auth/OAuthProxy.consent.test.ts
+++ b/src/auth/OAuthProxy.consent.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The consent endpoint is the only place a user's explicit approval is
+ * recorded, so it has to fail closed: an submission that does not clearly say
+ * "approve" must not be treated as one.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { OAuthProxy, OAuthProxyError } from "./OAuthProxy.js";
+import { MemoryTokenStorage } from "./utils/tokenStore.js";
+
+const CALLBACK_URL = "https://client.example.com/callback";
+
+const baseConfig = {
+  allowedRedirectUriPatterns: ["https://client.example.com/*"],
+  baseUrl: "https://proxy.example.com",
+  consentRequired: true,
+  upstreamAuthorizationEndpoint: "https://provider.com/oauth/authorize",
+  upstreamClientId: "upstream-client-id",
+  upstreamClientSecret: "upstream-client-secret",
+  upstreamTokenEndpoint: "https://provider.com/oauth/token",
+};
+
+describe("OAuthProxy consent action handling", () => {
+  const proxies: OAuthProxy[] = [];
+  const storages: MemoryTokenStorage[] = [];
+
+  afterEach(() => {
+    for (const proxy of proxies) {
+      proxy.destroy();
+    }
+    proxies.length = 0;
+
+    for (const storage of storages) {
+      storage.destroy();
+    }
+    storages.length = 0;
+  });
+
+  /** Drives authorize() up to the consent screen and returns its transaction. */
+  const startConsentFlow = async () => {
+    const tokenStorage = new MemoryTokenStorage();
+    storages.push(tokenStorage);
+
+    const proxy = new OAuthProxy({ ...baseConfig, tokenStorage });
+    proxies.push(proxy);
+
+    const dcr = await proxy.registerClient({ redirect_uris: [CALLBACK_URL] });
+    const response = await proxy.authorize({
+      client_id: dcr.client_id,
+      redirect_uri: CALLBACK_URL,
+      response_type: "code",
+      state: "client-state",
+    });
+    expect(response.status).toBe(200);
+
+    const transactionId = /name="transaction_id" value="([^"]+)"/.exec(
+      await response.text(),
+    )?.[1];
+    expect(transactionId).toBeTruthy();
+
+    return { proxy, transactionId: transactionId! };
+  };
+
+  const submitConsent = (
+    proxy: OAuthProxy,
+    body: Record<string, string>,
+  ): Promise<Response> =>
+    proxy.handleConsent(
+      new Request(`${baseConfig.baseUrl}/oauth/consent`, {
+        body: new URLSearchParams(body).toString(),
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      }),
+    );
+
+  it.each([
+    ["omitted", {}],
+    ["empty", { action: "" }],
+    ["unrecognised", { action: "maybe" }],
+    ["approve with different casing", { action: "Approve" }],
+  ])("rejects a submission whose action is %s", async (_label, fields) => {
+    const { proxy, transactionId } = await startConsentFlow();
+
+    // Any of these used to fall through to the approve branch and redirect the
+    // user upstream without them having agreed to anything.
+    await expect(
+      submitConsent(proxy, { ...fields, transaction_id: transactionId }),
+    ).rejects.toMatchObject({
+      code: "invalid_request",
+      description: "action must be 'approve' or 'deny'",
+    });
+  });
+
+  it("rejects an unrecognised action before looking up the transaction", async () => {
+    const { proxy } = await startConsentFlow();
+
+    // A bad action is rejected on its own terms, so the response cannot be
+    // used to probe which transaction ids exist.
+    await expect(
+      submitConsent(proxy, {
+        action: "maybe",
+        transaction_id: "not-a-real-transaction",
+      }),
+    ).rejects.toMatchObject({
+      code: "invalid_request",
+      description: "action must be 'approve' or 'deny'",
+    });
+  });
+
+  it("redirects upstream on approve", async () => {
+    const { proxy, transactionId } = await startConsentFlow();
+
+    const response = await submitConsent(proxy, {
+      action: "approve",
+      transaction_id: transactionId,
+    });
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("Location") ?? "");
+    expect(location.origin + location.pathname).toBe(
+      baseConfig.upstreamAuthorizationEndpoint,
+    );
+  });
+
+  it("redirects back to the client with access_denied on deny", async () => {
+    const { proxy, transactionId } = await startConsentFlow();
+
+    const response = await submitConsent(proxy, {
+      action: "deny",
+      transaction_id: transactionId,
+    });
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("Location") ?? "");
+    expect(location.origin + location.pathname).toBe(CALLBACK_URL);
+    expect(location.searchParams.get("error")).toBe("access_denied");
+
+    // The transaction is gone, so the denial cannot be re-submitted as an
+    // approval.
+    await expect(
+      submitConsent(proxy, {
+        action: "approve",
+        transaction_id: transactionId,
+      }),
+    ).rejects.toBeInstanceOf(OAuthProxyError);
+  });
+});

--- a/src/auth/OAuthProxy.open-redirect.test.ts
+++ b/src/auth/OAuthProxy.open-redirect.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Regression tests for CWE-601 open-redirect / authorization-code theft in
  * OAuthProxy. See the SECURITY advisory for the full threat model.
@@ -17,9 +16,50 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { AuthorizationParams, UpstreamTokenSet } from "./types.js";
+import type {
+  AuthorizationParams,
+  TokenStorage,
+  UpstreamTokenSet,
+} from "./types.js";
 
 import { OAuthProxy, OAuthProxyError } from "./OAuthProxy.js";
+
+/**
+ * Proxy state lives in the TokenStorage, so tests that need to tamper with a
+ * stored transaction reach in through this rather than through proxy
+ * internals. Values are held as-is (the proxy is configured with
+ * `encryptionKey: false`) so a test can read a record, modify it, and put it
+ * back the way a compromised backend would.
+ */
+class InspectableTokenStorage implements TokenStorage {
+  private store = new Map<string, unknown>();
+
+  async cleanup(): Promise<void> {}
+
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  async get(key: string): Promise<null | unknown> {
+    return this.store.get(key) ?? null;
+  }
+
+  keys(prefix: string): string[] {
+    return [...this.store.keys()].filter((key) => key.startsWith(prefix));
+  }
+
+  async save(key: string, value: unknown): Promise<void> {
+    this.store.set(key, value);
+  }
+
+  async take(key: string): Promise<null | unknown> {
+    const value = this.store.get(key) ?? null;
+    this.store.delete(key);
+    return value;
+  }
+}
+
+const TRANSACTION_PREFIX = "transaction:";
 
 const baseConfig = {
   allowedRedirectUriPatterns: ["https://client.example.com/*"],
@@ -79,9 +119,15 @@ function mockUpstreamTokenEndpoint() {
 
 describe("OAuthProxy CWE-601 open-redirect regression", () => {
   let proxy: OAuthProxy;
+  let storage: InspectableTokenStorage;
 
   beforeEach(() => {
-    proxy = new OAuthProxy(baseConfig);
+    storage = new InspectableTokenStorage();
+    proxy = new OAuthProxy({
+      ...baseConfig,
+      encryptionKey: false,
+      tokenStorage: storage,
+    });
   });
 
   describe("authorize() rejects unregistered redirect_uri", () => {
@@ -173,11 +219,7 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
       ).rejects.toBeInstanceOf(OAuthProxyError);
 
       // And no transaction should have been persisted.
-      const transactionsField = (proxy as any).transactions as Map<
-        string,
-        unknown
-      >;
-      expect(transactionsField.size).toBe(0);
+      expect(storage.keys(TRANSACTION_PREFIX)).toHaveLength(0);
     });
 
     it("an attacker cannot self-register a non-localhost URI with the default config", async () => {
@@ -226,10 +268,12 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
 
       // Simulate revocation / tampering: drop the URI from the registry and
       // hand-craft an attacker replacement inside the transaction record.
-      const transactions = (proxy as any).transactions as Map<string, any>;
-      const txn = transactions.get(transactionId);
+      const transactionKey = `${TRANSACTION_PREFIX}${transactionId}`;
+      const txn = (await storage.get(transactionKey)) as {
+        clientCallbackUrl: string;
+      };
       txn.clientCallbackUrl = EVIL_REDIRECT;
-      transactions.set(transactionId, txn);
+      await storage.save(transactionKey, txn);
 
       const cbReq = new Request(
         `${baseConfig.baseUrl}${baseConfig.redirectPath}?code=UP_CODE&state=${encodeURIComponent(
@@ -242,15 +286,18 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
       });
 
       // Transaction should be purged so an attacker can't replay it.
-      expect(transactions.has(transactionId)).toBe(false);
+      expect(await storage.get(transactionKey)).toBeNull();
     });
   });
 
   describe("handleConsent() deny branch defense-in-depth", () => {
     it("refuses to 302 to a tampered clientCallbackUrl on deny", async () => {
+      const consentStorage = new InspectableTokenStorage();
       const consentProxy = new OAuthProxy({
         ...baseConfig,
         consentRequired: true,
+        encryptionKey: false,
+        tokenStorage: consentStorage,
       });
       const dcr = await consentProxy.registerClient({
         redirect_uris: [LEGIT_REDIRECT],
@@ -262,13 +309,13 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
       // Consent HTML response is a 200, not a 302.
       expect(authResp.status).toBe(200);
 
-      const transactions = (consentProxy as any).transactions as Map<
-        string,
-        any
-      >;
-      const [transactionId, txn] = [...transactions.entries()][0];
+      const [transactionKey] = consentStorage.keys(TRANSACTION_PREFIX);
+      const transactionId = transactionKey.slice(TRANSACTION_PREFIX.length);
+      const txn = (await consentStorage.get(transactionKey)) as {
+        clientCallbackUrl: string;
+      };
       txn.clientCallbackUrl = EVIL_REDIRECT;
-      transactions.set(transactionId, txn);
+      await consentStorage.save(transactionKey, txn);
 
       const formBody = new URLSearchParams({
         action: "deny",

--- a/src/auth/OAuthProxy.storage-persistence.test.ts
+++ b/src/auth/OAuthProxy.storage-persistence.test.ts
@@ -171,6 +171,71 @@ describe("OAuthProxy TokenStorage persistence", () => {
     });
   });
 
+  it("carries a consent-gated flow across instances", async () => {
+    // Consent is the one flow that reads a transaction without consuming it:
+    // the approving instance has to hand the same transaction to the upstream
+    // redirect, and a later instance still has to be able to use it.
+    const tokenStorage = createStorage();
+    mockUpstreamTokenEndpoint();
+
+    const consentConfig = { ...baseConfig, consentRequired: true };
+    const consentProxies = [0, 1, 2].map(() => {
+      const proxy = new OAuthProxy({ ...consentConfig, tokenStorage });
+      proxies.push(proxy);
+      return proxy;
+    });
+
+    const dcr = await consentProxies[0].registerClient({
+      redirect_uris: [CALLBACK_URL],
+    });
+
+    // Authorization renders the consent screen instead of redirecting.
+    const consentResponse = await consentProxies[0].authorize(
+      authParams(dcr.client_id),
+    );
+    expect(consentResponse.status).toBe(200);
+
+    const transactionId = /name="transaction_id" value="([^"]+)"/.exec(
+      await consentResponse.text(),
+    )?.[1];
+    expect(transactionId).toBeTruthy();
+
+    // A second instance handles the approval and redirects upstream.
+    const approvalResponse = await consentProxies[1].handleConsent(
+      new Request(`${baseConfig.baseUrl}/oauth/consent`, {
+        body: new URLSearchParams({
+          action: "approve",
+          transaction_id: transactionId!,
+        }).toString(),
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      }),
+    );
+
+    expect(approvalResponse.status).toBe(302);
+    const upstreamUrl = new URL(getRequiredLocation(approvalResponse));
+    expect(upstreamUrl.origin + upstreamUrl.pathname).toBe(
+      baseConfig.upstreamAuthorizationEndpoint,
+    );
+
+    // And a third instance can still complete the callback for it.
+    const callbackResponse = await consentProxies[2].handleCallback(
+      new Request(
+        `${baseConfig.baseUrl}/oauth/callback?code=upstream-code&state=${encodeURIComponent(
+          getRequiredSearchParam(upstreamUrl, "state"),
+        )}`,
+      ),
+    );
+
+    expect(callbackResponse.status).toBe(302);
+    expect(
+      getRequiredSearchParam(
+        new URL(getRequiredLocation(callbackResponse)),
+        "code",
+      ),
+    ).toBeTruthy();
+  });
+
   describe("single use is enforced across instances", () => {
     /**
      * Drives authorize -> callback and returns everything needed to redeem the

--- a/src/auth/OAuthProxy.storage-persistence.test.ts
+++ b/src/auth/OAuthProxy.storage-persistence.test.ts
@@ -170,4 +170,112 @@ describe("OAuthProxy TokenStorage persistence", () => {
       token_type: "Bearer",
     });
   });
+
+  describe("single use is enforced across instances", () => {
+    /**
+     * Drives authorize -> callback and returns everything needed to redeem the
+     * resulting authorization code.
+     */
+    const issueAuthorizationCode = async (tokenStorage: MemoryTokenStorage) => {
+      const registrationProxy = createProxy(tokenStorage);
+      const dcr = await registrationProxy.registerClient({
+        redirect_uris: [CALLBACK_URL],
+      });
+
+      const authResponse = await createProxy(tokenStorage).authorize(
+        authParams(dcr.client_id),
+      );
+      const transactionId = getRequiredSearchParam(
+        new URL(getRequiredLocation(authResponse)),
+        "state",
+      );
+
+      const callbackResponse = await createProxy(tokenStorage).handleCallback(
+        new Request(
+          `${baseConfig.baseUrl}/oauth/callback?code=upstream-code&state=${encodeURIComponent(
+            transactionId,
+          )}`,
+        ),
+      );
+
+      const code = getRequiredSearchParam(
+        new URL(getRequiredLocation(callbackResponse)),
+        "code",
+      );
+
+      return {
+        request: {
+          client_id: dcr.client_id,
+          code,
+          grant_type: "authorization_code" as const,
+          redirect_uri: CALLBACK_URL,
+        },
+        transactionId,
+      };
+    };
+
+    it("redeems an authorization code exactly once when two instances race", async () => {
+      // Given a code issued into shared storage.
+      const tokenStorage = createStorage();
+      mockUpstreamTokenEndpoint();
+      const { request } = await issueAuthorizationCode(tokenStorage);
+
+      // When two instances that have never seen the code redeem it at once,
+      // as a load balancer fanning out a retried request would produce.
+      const results = await Promise.allSettled([
+        createProxy(tokenStorage).exchangeAuthorizationCode(request),
+        createProxy(tokenStorage).exchangeAuthorizationCode(request),
+      ]);
+
+      // Then exactly one succeeds (RFC 6749 §4.1.2).
+      const fulfilled = results.filter((r) => r.status === "fulfilled");
+      expect(fulfilled).toHaveLength(1);
+    });
+
+    it("rejects a code that another instance already redeemed", async () => {
+      const tokenStorage = createStorage();
+      mockUpstreamTokenEndpoint();
+      const { request } = await issueAuthorizationCode(tokenStorage);
+
+      await createProxy(tokenStorage).exchangeAuthorizationCode(request);
+
+      await expect(
+        createProxy(tokenStorage).exchangeAuthorizationCode(request),
+      ).rejects.toMatchObject({ code: "invalid_grant" });
+    });
+
+    it("rejects a callback whose transaction another instance already consumed", async () => {
+      // Given an authorization started on one instance...
+      const tokenStorage = createStorage();
+      mockUpstreamTokenEndpoint();
+      const authorizationProxy = createProxy(tokenStorage);
+      const dcr = await createProxy(tokenStorage).registerClient({
+        redirect_uris: [CALLBACK_URL],
+      });
+
+      const authResponse = await authorizationProxy.authorize(
+        authParams(dcr.client_id),
+      );
+      const transactionId = getRequiredSearchParam(
+        new URL(getRequiredLocation(authResponse)),
+        "state",
+      );
+      const callbackRequest = () =>
+        new Request(
+          `${baseConfig.baseUrl}/oauth/callback?code=upstream-code&state=${encodeURIComponent(
+            transactionId,
+          )}`,
+        );
+
+      // ...and consumed by a *different* instance.
+      await createProxy(tokenStorage).handleCallback(callbackRequest());
+
+      // Then replaying it against the instance that started the flow — which
+      // is the one most likely to hold stale local state — must not mint a
+      // second authorization code.
+      await expect(
+        authorizationProxy.handleCallback(callbackRequest()),
+      ).rejects.toMatchObject({ code: "invalid_request" });
+    });
+  });
 });

--- a/src/auth/OAuthProxy.storage-persistence.test.ts
+++ b/src/auth/OAuthProxy.storage-persistence.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthorizationParams } from "./types.js";
+
+import { OAuthProxy } from "./OAuthProxy.js";
+import { MemoryTokenStorage } from "./utils/tokenStore.js";
+
+const CALLBACK_URL = "https://client.example.com/callback";
+
+const baseConfig = {
+  allowedRedirectUriPatterns: ["https://client.example.com/*"],
+  baseUrl: "https://proxy.example.com",
+  consentRequired: false,
+  enableTokenSwap: false,
+  encryptionKey: "shared-encryption-key",
+  upstreamAuthorizationEndpoint: "https://provider.com/oauth/authorize",
+  upstreamClientId: "upstream-client-id",
+  upstreamClientSecret: "upstream-client-secret",
+  upstreamTokenEndpoint: "https://provider.com/oauth/token",
+};
+
+const authParams = (clientId: string): AuthorizationParams => ({
+  client_id: clientId,
+  redirect_uri: CALLBACK_URL,
+  response_type: "code",
+  state: "client-state",
+});
+
+const getRequiredLocation = (response: Response): string => {
+  const location = response.headers.get("Location");
+  expect(location).toBeTruthy();
+
+  if (!location) {
+    throw new Error("Expected response to include a Location header");
+  }
+
+  return location;
+};
+
+const getRequiredSearchParam = (url: URL, name: string): string => {
+  const value = url.searchParams.get(name);
+  expect(value).toBeTruthy();
+
+  if (!value) {
+    throw new Error(`Expected URL to include ${name}`);
+  }
+
+  return value;
+};
+
+const mockUpstreamTokenEndpoint = (): void => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "upstream-access-token",
+            expires_in: 3600,
+            refresh_token: "upstream-refresh-token",
+            scope: "read write",
+            token_type: "Bearer",
+          }),
+          {
+            headers: { "Content-Type": "application/json" },
+            status: 200,
+          },
+        ),
+    ),
+  );
+};
+
+describe("OAuthProxy TokenStorage persistence", () => {
+  const proxies: OAuthProxy[] = [];
+  const storages: MemoryTokenStorage[] = [];
+
+  afterEach(() => {
+    for (const proxy of proxies) {
+      proxy.destroy();
+    }
+    proxies.length = 0;
+
+    for (const storage of storages) {
+      storage.destroy();
+    }
+    storages.length = 0;
+
+    vi.unstubAllGlobals();
+  });
+
+  const createStorage = (): MemoryTokenStorage => {
+    const storage = new MemoryTokenStorage();
+    storages.push(storage);
+    return storage;
+  };
+
+  const createProxy = (tokenStorage: MemoryTokenStorage): OAuthProxy => {
+    const proxy = new OAuthProxy({
+      ...baseConfig,
+      tokenStorage,
+    });
+    proxies.push(proxy);
+    return proxy;
+  };
+
+  it("loads registered DCR clients from shared TokenStorage", async () => {
+    // Given a client registered by one proxy instance.
+    const tokenStorage = createStorage();
+    const registrationProxy = createProxy(tokenStorage);
+    const authorizationProxy = createProxy(tokenStorage);
+
+    const dcr = await registrationProxy.registerClient({
+      redirect_uris: [CALLBACK_URL],
+    });
+
+    // When a different proxy instance handles the authorization request.
+    const response = await authorizationProxy.authorize(
+      authParams(dcr.client_id),
+    );
+
+    // Then it recognizes the persisted client registration.
+    expect(response.status).toBe(302);
+    const upstreamUrl = new URL(getRequiredLocation(response));
+    expect(upstreamUrl.searchParams.get("client_id")).toBe(
+      baseConfig.upstreamClientId,
+    );
+  });
+
+  it("completes authorize to callback to token exchange across shared-storage instances", async () => {
+    // Given separate instances that share one TokenStorage backend.
+    const tokenStorage = createStorage();
+    const registrationProxy = createProxy(tokenStorage);
+    const authorizationProxy = createProxy(tokenStorage);
+    const callbackProxy = createProxy(tokenStorage);
+    const tokenProxy = createProxy(tokenStorage);
+    mockUpstreamTokenEndpoint();
+
+    const dcr = await registrationProxy.registerClient({
+      redirect_uris: [CALLBACK_URL],
+    });
+
+    // When authorization starts on one instance and callback lands on another.
+    const authResponse = await authorizationProxy.authorize(
+      authParams(dcr.client_id),
+    );
+    const upstreamUrl = new URL(getRequiredLocation(authResponse));
+    const transactionId = getRequiredSearchParam(upstreamUrl, "state");
+    const callbackResponse = await callbackProxy.handleCallback(
+      new Request(
+        `${baseConfig.baseUrl}/oauth/callback?code=upstream-code&state=${encodeURIComponent(
+          transactionId,
+        )}`,
+      ),
+    );
+
+    // Then a third instance can exchange the client authorization code.
+    const clientRedirectUrl = new URL(getRequiredLocation(callbackResponse));
+    const authorizationCode = getRequiredSearchParam(clientRedirectUrl, "code");
+    const tokenResponse = await tokenProxy.exchangeAuthorizationCode({
+      client_id: dcr.client_id,
+      code: authorizationCode,
+      grant_type: "authorization_code",
+      redirect_uri: CALLBACK_URL,
+    });
+
+    expect(tokenResponse).toMatchObject({
+      access_token: "upstream-access-token",
+      refresh_token: "upstream-refresh-token",
+      scope: "read write",
+      token_type: "Bearer",
+    });
+  });
+});

--- a/src/auth/OAuthProxy.storage-persistence.test.ts
+++ b/src/auth/OAuthProxy.storage-persistence.test.ts
@@ -309,6 +309,78 @@ describe("OAuthProxy TokenStorage persistence", () => {
       ).rejects.toMatchObject({ code: "invalid_grant" });
     });
 
+    it("keeps reporting a spent code as used rather than as unknown", async () => {
+      const tokenStorage = createStorage();
+      mockUpstreamTokenEndpoint();
+      const { request } = await issueAuthorizationCode(tokenStorage);
+
+      await createProxy(tokenStorage).exchangeAuthorizationCode(request);
+
+      const replay = () =>
+        expect(
+          createProxy(tokenStorage).exchangeAuthorizationCode(request),
+        ).rejects.toMatchObject({
+          code: "invalid_grant",
+          description: "Authorization code already used",
+        });
+
+      // Each attempt takes the tombstone out of storage, so it has to be put
+      // back every time; otherwise the second replay would report an unknown
+      // code and hide the fact that this one was issued and spent.
+      await replay();
+      await replay();
+    });
+
+    it("drops the upstream tokens from the record once the code is redeemed", async () => {
+      // encryptionKey: false so the test can read back what was actually
+      // written rather than ciphertext.
+      const tokenStorage = createStorage();
+      mockUpstreamTokenEndpoint();
+
+      const proxy = new OAuthProxy({
+        ...baseConfig,
+        encryptionKey: false,
+        tokenStorage,
+      });
+      proxies.push(proxy);
+
+      const dcr = await proxy.registerClient({ redirect_uris: [CALLBACK_URL] });
+      const authResponse = await proxy.authorize(authParams(dcr.client_id));
+      const callbackResponse = await proxy.handleCallback(
+        new Request(
+          `${baseConfig.baseUrl}/oauth/callback?code=upstream-code&state=${encodeURIComponent(
+            getRequiredSearchParam(
+              new URL(getRequiredLocation(authResponse)),
+              "state",
+            ),
+          )}`,
+        ),
+      );
+      const code = getRequiredSearchParam(
+        new URL(getRequiredLocation(callbackResponse)),
+        "code",
+      );
+
+      // While the code is redeemable the record holds the upstream tokens.
+      await expect(tokenStorage.get(`code:${code}`)).resolves.toMatchObject({
+        upstreamTokens: { refreshToken: "upstream-refresh-token" },
+      });
+
+      await proxy.exchangeAuthorizationCode({
+        client_id: dcr.client_id,
+        code,
+        grant_type: "authorization_code",
+        redirect_uri: CALLBACK_URL,
+      });
+
+      // Afterwards only the tombstone is left, so a long-lived upstream
+      // refresh token does not sit in storage for the rest of the code's TTL.
+      await expect(tokenStorage.get(`code:${code}`)).resolves.toEqual({
+        expiresAt: expect.any(Date),
+        used: true,
+      });
+    });
+
     it("rejects a callback whose transaction another instance already consumed", async () => {
       // Given an authorization started on one instance...
       const tokenStorage = createStorage();

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -64,9 +64,12 @@ export class OAuthProxy {
   private config: OAuthProxyConfig;
   private consentManager: ConsentManager;
   private jwtIssuer?: JWTIssuer;
-  /** Keyed by redirect_uri for defence-in-depth checks in handleCallback/handleConsent */
-  private registeredClients: Map<string, ProxyDCRClient> = new Map();
-  /** Keyed by proxy-issued client_id for authorize/token-exchange lookups */
+  /**
+   * Keyed by proxy-issued client_id for authorize/token-exchange lookups and
+   * for the defence-in-depth callback checks. A registration never changes
+   * after it is written, so caching it locally cannot go stale; it is also
+   * persisted, so another instance can hydrate it.
+   */
   private registeredClientsByClientId: Map<string, ProxyDCRClient> = new Map();
   private stateStore: OAuthProxyStateStore;
   private tokenStorage: TokenStorage;
@@ -102,7 +105,6 @@ export class OAuthProxy {
 
     this.tokenStorage = storage;
     this.stateStore = new OAuthProxyStateStore({
-      registeredClients: this.registeredClients,
       registeredClientsByClientId: this.registeredClientsByClientId,
       tokenStorage: this.tokenStorage,
     });
@@ -207,7 +209,6 @@ export class OAuthProxy {
       this.cleanupInterval = null;
     }
 
-    this.registeredClients.clear();
     this.registeredClientsByClientId.clear();
   }
 
@@ -631,7 +632,7 @@ export class OAuthProxy {
   }
 
   /**
-   * Clean up expired transactions and codes
+   * Periodic maintenance hook. Expiry is enforced by the token storage.
    */
   private cleanup(): void {
     // Transactions and codes live in the token storage with a TTL derived from

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -22,6 +22,7 @@ import type {
   UpstreamTokenSet,
 } from "./types.js";
 
+import { OAuthProxyStateStore } from "./OAuthProxyStateStore.js";
 import {
   DEFAULT_ACCESS_TOKEN_TTL,
   DEFAULT_ACCESS_TOKEN_TTL_NO_REFRESH,
@@ -68,6 +69,7 @@ export class OAuthProxy {
   private registeredClients: Map<string, ProxyDCRClient> = new Map();
   /** Keyed by proxy-issued client_id for authorize/token-exchange lookups */
   private registeredClientsByClientId: Map<string, ProxyDCRClient> = new Map();
+  private stateStore: OAuthProxyStateStore;
   private tokenStorage: TokenStorage;
   private transactions: Map<string, OAuthTransaction> = new Map();
 
@@ -101,6 +103,13 @@ export class OAuthProxy {
     }
 
     this.tokenStorage = storage;
+    this.stateStore = new OAuthProxyStateStore({
+      clientCodes: this.clientCodes,
+      registeredClients: this.registeredClients,
+      registeredClientsByClientId: this.registeredClientsByClientId,
+      tokenStorage: this.tokenStorage,
+      transactions: this.transactions,
+    });
     this.consentManager = new ConsentManager(
       config.consentSigningKey || this.generateSigningKey(),
     );
@@ -153,9 +162,8 @@ export class OAuthProxy {
     // RFC 6749 §5.2 - reject unknown clients with invalid_client.
     // MCP clients receive a proxy-issued client_id during DCR (not the upstream
     // provider's credentials), so we look up by that proxy client_id.
-    const registeredClient = this.registeredClientsByClientId.get(
-      params.client_id,
-    );
+    const registeredClient =
+      await this.stateStore.getRegisteredClientByClientId(params.client_id);
     if (!registeredClient) {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
     }
@@ -225,11 +233,13 @@ export class OAuthProxy {
     // RFC 6749 §5.2 - reject unknown clients. Only proxy-issued client_ids
     // (obtained via DCR) are accepted, so stolen codes cannot be exchanged by
     // arbitrary callers.
-    if (!this.registeredClientsByClientId.has(request.client_id)) {
+    const registeredClient =
+      await this.stateStore.getRegisteredClientByClientId(request.client_id);
+    if (!registeredClient) {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
     }
 
-    const clientCode = this.clientCodes.get(request.code);
+    const clientCode = await this.stateStore.getClientCode(request.code);
     if (!clientCode) {
       throw new OAuthProxyError(
         "invalid_grant",
@@ -272,7 +282,7 @@ export class OAuthProxy {
 
     // Mark code as used
     clientCode.used = true;
-    this.clientCodes.set(request.code, clientCode);
+    await this.stateStore.saveClientCode(clientCode);
 
     // Return tokens based on token swap setting
     if (this.config.enableTokenSwap && this.jwtIssuer) {
@@ -388,7 +398,7 @@ export class OAuthProxy {
     }
 
     // Retrieve transaction
-    const transaction = this.transactions.get(state);
+    const transaction = await this.stateStore.getTransaction(state);
     if (!transaction) {
       throw new OAuthProxyError("invalid_request", "Invalid or expired state");
     }
@@ -396,8 +406,8 @@ export class OAuthProxy {
     // Defense-in-depth: the transaction's stored callback URL must still be
     // registered. Guards against any code path that could persist an
     // unvalidated URI, and against registration being revoked mid-flow.
-    if (!this.registeredClients.has(transaction.clientCallbackUrl)) {
-      this.transactions.delete(state);
+    if (!(await this.stateStore.isTransactionCallbackRegistered(transaction))) {
+      await this.stateStore.deleteTransaction(state);
       throw new OAuthProxyError(
         "invalid_request",
         "Transaction callback URL is not registered",
@@ -408,13 +418,13 @@ export class OAuthProxy {
     const upstreamTokens = await this.exchangeUpstreamCode(code, transaction);
 
     // Generate authorization code for client
-    const clientCode = this.generateAuthorizationCode(
+    const clientCode = await this.generateAuthorizationCode(
       transaction,
       upstreamTokens,
     );
 
     // Clean up transaction
-    this.transactions.delete(state);
+    await this.stateStore.deleteTransaction(state);
 
     // Redirect to client callback with code
     const redirectUrl = new URL(transaction.clientCallbackUrl);
@@ -434,14 +444,14 @@ export class OAuthProxy {
    */
   async handleConsent(request: Request): Promise<Response> {
     const formData = await request.formData();
-    const transactionId = formData.get("transaction_id") as string;
-    const action = formData.get("action") as string;
+    const transactionId = formData.get("transaction_id");
+    const action = formData.get("action");
 
-    if (!transactionId) {
+    if (typeof transactionId !== "string" || !transactionId) {
       throw new OAuthProxyError("invalid_request", "Missing transaction_id");
     }
 
-    const transaction = this.transactions.get(transactionId);
+    const transaction = await this.stateStore.getTransaction(transactionId);
     if (!transaction) {
       throw new OAuthProxyError(
         "invalid_request",
@@ -451,9 +461,11 @@ export class OAuthProxy {
 
     if (action === "deny") {
       // User denied consent
-      this.transactions.delete(transactionId);
+      await this.stateStore.deleteTransaction(transactionId);
       // Defense-in-depth: never redirect to an unregistered URI.
-      if (!this.registeredClients.has(transaction.clientCallbackUrl)) {
+      if (
+        !(await this.stateStore.isTransactionCallbackRegistered(transaction))
+      ) {
         throw new OAuthProxyError(
           "invalid_request",
           "Transaction callback URL is not registered",
@@ -476,10 +488,13 @@ export class OAuthProxy {
     }
 
     // User approved, mark consent and redirect to upstream
-    transaction.consentGiven = true;
-    this.transactions.set(transactionId, transaction);
+    const approvedTransaction = {
+      ...transaction,
+      consentGiven: true,
+    };
+    await this.stateStore.saveTransaction(approvedTransaction);
 
-    return this.redirectToUpstream(transaction);
+    return this.redirectToUpstream(approvedTransaction);
   }
 
   /**
@@ -567,14 +582,8 @@ export class OAuthProxy {
       registeredAt: new Date(),
     };
 
-    // Index by proxy client_id for authorize/token-exchange lookups.
-    this.registeredClientsByClientId.set(proxyClientId, client);
-
-    // Also index by every redirect_uri for defence-in-depth checks in
-    // handleCallback/handleConsent (RFC 6749 §3.1.2.3).
-    for (const uri of request.redirect_uris) {
-      this.registeredClients.set(uri, client);
-    }
+    this.stateStore.cacheRegisteredClient(client);
+    await this.stateStore.saveRegisteredClient(client);
 
     // Return RFC 7591 compliant response with proxy-issued credentials.
     const response: DCRResponse = {
@@ -631,14 +640,14 @@ export class OAuthProxy {
     // Clean up expired transactions
     for (const [id, transaction] of this.transactions.entries()) {
       if (transaction.expiresAt.getTime() < now) {
-        this.transactions.delete(id);
+        void this.stateStore.deleteTransaction(id);
       }
     }
 
     // Clean up expired codes
     for (const [code, clientCode] of this.clientCodes.entries()) {
       if (clientCode.expiresAt.getTime() < now) {
-        this.clientCodes.delete(code);
+        void this.stateStore.deleteClientCode(code);
       }
     }
 
@@ -671,7 +680,7 @@ export class OAuthProxy {
       state: params.state || this.generateId(),
     };
 
-    this.transactions.set(transactionId, transaction);
+    await this.stateStore.saveTransaction(transaction);
 
     return transaction;
   }
@@ -804,10 +813,10 @@ export class OAuthProxy {
   /**
    * Generate authorization code for client
    */
-  private generateAuthorizationCode(
+  private async generateAuthorizationCode(
     transaction: OAuthTransaction,
     upstreamTokens: UpstreamTokenSet,
-  ): string {
+  ): Promise<string> {
     const code = this.generateId();
 
     const clientCode: ClientCode = {
@@ -823,7 +832,7 @@ export class OAuthProxy {
       upstreamTokens,
     };
 
-    this.clientCodes.set(code, clientCode);
+    await this.stateStore.saveClientCode(clientCode);
 
     return code;
   }

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -61,7 +61,6 @@ const RESERVED_AUTHORIZATION_PARAMS: ReadonlySet<string> = new Set([
 export class OAuthProxy {
   private claimsExtractor: ClaimsExtractor | null = null;
   private cleanupInterval: NodeJS.Timeout | null = null;
-  private clientCodes: Map<string, ClientCode> = new Map();
   private config: OAuthProxyConfig;
   private consentManager: ConsentManager;
   private jwtIssuer?: JWTIssuer;
@@ -71,7 +70,6 @@ export class OAuthProxy {
   private registeredClientsByClientId: Map<string, ProxyDCRClient> = new Map();
   private stateStore: OAuthProxyStateStore;
   private tokenStorage: TokenStorage;
-  private transactions: Map<string, OAuthTransaction> = new Map();
 
   constructor(config: OAuthProxyConfig) {
     this.config = {
@@ -104,11 +102,9 @@ export class OAuthProxy {
 
     this.tokenStorage = storage;
     this.stateStore = new OAuthProxyStateStore({
-      clientCodes: this.clientCodes,
       registeredClients: this.registeredClients,
       registeredClientsByClientId: this.registeredClientsByClientId,
       tokenStorage: this.tokenStorage,
-      transactions: this.transactions,
     });
     this.consentManager = new ConsentManager(
       config.consentSigningKey || this.generateSigningKey(),
@@ -211,8 +207,6 @@ export class OAuthProxy {
       this.cleanupInterval = null;
     }
 
-    this.transactions.clear();
-    this.clientCodes.clear();
     this.registeredClients.clear();
     this.registeredClientsByClientId.clear();
   }
@@ -239,11 +233,30 @@ export class OAuthProxy {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
     }
 
-    const clientCode = await this.stateStore.getClientCode(request.code);
+    // Consume the code atomically: whoever takes it owns this exchange, so two
+    // concurrent requests — on this instance or another one sharing the
+    // storage — cannot both redeem it (RFC 6749 §4.1.2).
+    const clientCode = await this.stateStore.consumeClientCode(request.code);
     if (!clientCode) {
       throw new OAuthProxyError(
         "invalid_grant",
         "Invalid or expired authorization code",
+      );
+    }
+
+    const alreadyUsed = clientCode.used === true;
+
+    // Put the record back marked used, so later attempts get the precise
+    // "already used" error rather than looking like an unknown code. This is a
+    // tombstone: `used` only ever goes false -> true, so it cannot resurrect a
+    // spent code.
+    clientCode.used = true;
+    await this.stateStore.saveClientCode(clientCode);
+
+    if (alreadyUsed) {
+      throw new OAuthProxyError(
+        "invalid_grant",
+        "Authorization code already used",
       );
     }
 
@@ -271,18 +284,6 @@ export class OAuthProxy {
         throw new OAuthProxyError("invalid_grant", "Invalid PKCE verifier");
       }
     }
-
-    // Check if code was already used
-    if (clientCode.used) {
-      throw new OAuthProxyError(
-        "invalid_grant",
-        "Authorization code already used",
-      );
-    }
-
-    // Mark code as used
-    clientCode.used = true;
-    await this.stateStore.saveClientCode(clientCode);
 
     // Return tokens based on token swap setting
     if (this.config.enableTokenSwap && this.jwtIssuer) {
@@ -397,8 +398,10 @@ export class OAuthProxy {
       );
     }
 
-    // Retrieve transaction
-    const transaction = await this.stateStore.getTransaction(state);
+    // Consume the transaction: a callback is single-use, so taking it here
+    // prevents the same state from being replayed against this or any other
+    // instance sharing the storage.
+    const transaction = await this.stateStore.consumeTransaction(state);
     if (!transaction) {
       throw new OAuthProxyError("invalid_request", "Invalid or expired state");
     }
@@ -407,7 +410,6 @@ export class OAuthProxy {
     // registered. Guards against any code path that could persist an
     // unvalidated URI, and against registration being revoked mid-flow.
     if (!(await this.stateStore.isTransactionCallbackRegistered(transaction))) {
-      await this.stateStore.deleteTransaction(state);
       throw new OAuthProxyError(
         "invalid_request",
         "Transaction callback URL is not registered",
@@ -422,9 +424,6 @@ export class OAuthProxy {
       transaction,
       upstreamTokens,
     );
-
-    // Clean up transaction
-    await this.stateStore.deleteTransaction(state);
 
     // Redirect to client callback with code
     const redirectUrl = new URL(transaction.clientCallbackUrl);
@@ -635,24 +634,16 @@ export class OAuthProxy {
    * Clean up expired transactions and codes
    */
   private cleanup(): void {
-    const now = Date.now();
-
-    // Clean up expired transactions
-    for (const [id, transaction] of this.transactions.entries()) {
-      if (transaction.expiresAt.getTime() < now) {
-        void this.stateStore.deleteTransaction(id);
-      }
-    }
-
-    // Clean up expired codes
-    for (const [code, clientCode] of this.clientCodes.entries()) {
-      if (clientCode.expiresAt.getTime() < now) {
-        void this.stateStore.deleteClientCode(code);
-      }
-    }
-
-    // Clean up token storage
-    void this.tokenStorage.cleanup();
+    // Transactions and codes live in the token storage with a TTL derived from
+    // their expiry, so sweeping them is the storage's job. Failures here must
+    // not become unhandled rejections: this runs on a timer, and a transient
+    // backend error would otherwise take the process down.
+    void this.tokenStorage.cleanup().catch((error: unknown) => {
+      console.error(
+        "[FastMCP] OAuth proxy token storage cleanup failed:",
+        error instanceof Error ? error.message : String(error),
+      );
+    });
   }
 
   /**

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -237,29 +237,29 @@ export class OAuthProxy {
     // Consume the code atomically: whoever takes it owns this exchange, so two
     // concurrent requests — on this instance or another one sharing the
     // storage — cannot both redeem it (RFC 6749 §4.1.2).
-    const clientCode = await this.stateStore.consumeClientCode(request.code);
-    if (!clientCode) {
+    const consumed = await this.stateStore.consumeClientCode(request.code);
+    if (!consumed) {
       throw new OAuthProxyError(
         "invalid_grant",
         "Invalid or expired authorization code",
       );
     }
 
-    const alreadyUsed = clientCode.used === true;
+    // Put a tombstone back — whether the code was live or already spent — so
+    // later attempts get the precise "already used" error rather than looking
+    // like an unknown code. It replaces the record instead of amending it, so
+    // the upstream tokens stop being stored the moment they are handed over,
+    // and a spent code can never be resurrected.
+    await this.stateStore.markClientCodeSpent(request.code, consumed.expiresAt);
 
-    // Put the record back marked used, so later attempts get the precise
-    // "already used" error rather than looking like an unknown code. This is a
-    // tombstone: `used` only ever goes false -> true, so it cannot resurrect a
-    // spent code.
-    clientCode.used = true;
-    await this.stateStore.saveClientCode(clientCode);
-
-    if (alreadyUsed) {
+    if (consumed.status === "spent") {
       throw new OAuthProxyError(
         "invalid_grant",
         "Authorization code already used",
       );
     }
+
+    const clientCode = consumed.clientCode;
 
     // Validate client
     if (clientCode.clientId !== request.client_id) {
@@ -449,6 +449,16 @@ export class OAuthProxy {
 
     if (typeof transactionId !== "string" || !transactionId) {
       throw new OAuthProxyError("invalid_request", "Missing transaction_id");
+    }
+
+    // Require the choice to be explicit. Anything else used to fall through to
+    // the approve branch, so a submission that lost the field — or never sent
+    // one — granted access the user never clicked for.
+    if (action !== "approve" && action !== "deny") {
+      throw new OAuthProxyError(
+        "invalid_request",
+        "action must be 'approve' or 'deny'",
+      );
     }
 
     const transaction = await this.stateStore.getTransaction(transactionId);

--- a/src/auth/OAuthProxyStateStore.ts
+++ b/src/auth/OAuthProxyStateStore.ts
@@ -1,0 +1,265 @@
+import { z } from "zod";
+
+import type {
+  ClientCode,
+  OAuthTransaction,
+  ProxyDCRClient,
+  TokenStorage,
+  UpstreamTokenSet,
+} from "./types.js";
+
+const STORAGE_KEY_PREFIX = {
+  client: "client:",
+  code: "code:",
+  transaction: "transaction:",
+} as const;
+
+const storedDateSchema = z
+  .union([z.date(), z.string()])
+  .transform((value, context) => {
+    const date = value instanceof Date ? value : new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+      context.addIssue({
+        code: "custom",
+        message: "Invalid stored date",
+      });
+      return z.NEVER;
+    }
+
+    return date;
+  });
+
+const dcrClientMetadataSchema = z.object({
+  client_name: z.string().optional(),
+  client_uri: z.string().optional(),
+  contacts: z.array(z.string()).optional(),
+  jwks: z.record(z.string(), z.unknown()).optional(),
+  jwks_uri: z.string().optional(),
+  logo_uri: z.string().optional(),
+  policy_uri: z.string().optional(),
+  scope: z.string().optional(),
+  software_id: z.string().optional(),
+  software_version: z.string().optional(),
+  tos_uri: z.string().optional(),
+});
+
+const proxyDcrClientStorageSchema: z.ZodType<ProxyDCRClient> = z.object({
+  callbackUrl: z.string(),
+  clientId: z.string(),
+  clientSecret: z.string().optional(),
+  metadata: dcrClientMetadataSchema.optional(),
+  redirectUris: z.array(z.string()),
+  registeredAt: storedDateSchema,
+});
+
+const upstreamTokenSetStorageSchema: z.ZodType<UpstreamTokenSet> = z.object({
+  accessToken: z.string(),
+  expiresIn: z.number(),
+  idToken: z.string().optional(),
+  issuedAt: storedDateSchema,
+  refreshExpiresIn: z.number().optional(),
+  refreshToken: z.string().optional(),
+  scope: z.array(z.string()),
+  tokenType: z.string(),
+});
+
+const clientCodeStorageSchema: z.ZodType<ClientCode> = z.object({
+  clientId: z.string(),
+  code: z.string(),
+  codeChallenge: z.string(),
+  codeChallengeMethod: z.string(),
+  createdAt: storedDateSchema,
+  expiresAt: storedDateSchema,
+  transactionId: z.string(),
+  upstreamTokens: upstreamTokenSetStorageSchema,
+  used: z.boolean().optional(),
+});
+
+const oauthTransactionStorageSchema: z.ZodType<OAuthTransaction> = z.object({
+  clientCallbackUrl: z.string(),
+  clientCodeChallenge: z.string(),
+  clientCodeChallengeMethod: z.string(),
+  clientId: z.string(),
+  consentGiven: z.boolean().optional(),
+  createdAt: storedDateSchema,
+  expiresAt: storedDateSchema,
+  id: z.string(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  proxyCodeChallenge: z.string(),
+  proxyCodeVerifier: z.string(),
+  scope: z.array(z.string()),
+  state: z.string(),
+});
+
+interface OAuthProxyStateStoreConfig {
+  readonly clientCodes: Map<string, ClientCode>;
+  readonly registeredClients: Map<string, ProxyDCRClient>;
+  readonly registeredClientsByClientId: Map<string, ProxyDCRClient>;
+  readonly tokenStorage: TokenStorage;
+  readonly transactions: Map<string, OAuthTransaction>;
+}
+
+export class OAuthProxyStateStore {
+  private readonly clientCodes: Map<string, ClientCode>;
+  private readonly registeredClients: Map<string, ProxyDCRClient>;
+  private readonly registeredClientsByClientId: Map<string, ProxyDCRClient>;
+  private readonly tokenStorage: TokenStorage;
+  private readonly transactions: Map<string, OAuthTransaction>;
+
+  constructor(config: OAuthProxyStateStoreConfig) {
+    this.clientCodes = config.clientCodes;
+    this.registeredClients = config.registeredClients;
+    this.registeredClientsByClientId = config.registeredClientsByClientId;
+    this.tokenStorage = config.tokenStorage;
+    this.transactions = config.transactions;
+  }
+
+  cacheRegisteredClient(client: ProxyDCRClient): void {
+    this.registeredClientsByClientId.set(client.clientId, client);
+
+    for (const uri of client.redirectUris) {
+      this.registeredClients.set(uri, client);
+    }
+  }
+
+  async deleteClientCode(code: string): Promise<void> {
+    this.clientCodes.delete(code);
+    await this.tokenStorage.delete(`${STORAGE_KEY_PREFIX.code}${code}`);
+  }
+
+  async deleteTransaction(transactionId: string): Promise<void> {
+    this.transactions.delete(transactionId);
+    await this.tokenStorage.delete(
+      `${STORAGE_KEY_PREFIX.transaction}${transactionId}`,
+    );
+  }
+
+  async getClientCode(code: string): Promise<ClientCode | null> {
+    const cached = this.clientCodes.get(code);
+    if (cached) {
+      if (this.isExpired(cached.expiresAt)) {
+        await this.deleteClientCode(code);
+        return null;
+      }
+
+      return cached;
+    }
+
+    const stored = await this.tokenStorage.get(
+      `${STORAGE_KEY_PREFIX.code}${code}`,
+    );
+    const parsed = clientCodeStorageSchema.safeParse(stored);
+
+    if (!parsed.success) {
+      return null;
+    }
+
+    if (this.isExpired(parsed.data.expiresAt)) {
+      await this.deleteClientCode(code);
+      return null;
+    }
+
+    this.clientCodes.set(parsed.data.code, parsed.data);
+    return parsed.data;
+  }
+
+  async getRegisteredClientByClientId(
+    clientId: string,
+  ): Promise<null | ProxyDCRClient> {
+    const cached = this.registeredClientsByClientId.get(clientId);
+    if (cached) {
+      return cached;
+    }
+
+    const stored = await this.tokenStorage.get(
+      `${STORAGE_KEY_PREFIX.client}${clientId}`,
+    );
+    const parsed = proxyDcrClientStorageSchema.safeParse(stored);
+
+    if (!parsed.success) {
+      return null;
+    }
+
+    this.cacheRegisteredClient(parsed.data);
+    return parsed.data;
+  }
+
+  async getTransaction(
+    transactionId: string,
+  ): Promise<null | OAuthTransaction> {
+    const cached = this.transactions.get(transactionId);
+    if (cached) {
+      if (this.isExpired(cached.expiresAt)) {
+        await this.deleteTransaction(transactionId);
+        return null;
+      }
+
+      return cached;
+    }
+
+    const stored = await this.tokenStorage.get(
+      `${STORAGE_KEY_PREFIX.transaction}${transactionId}`,
+    );
+    const parsed = oauthTransactionStorageSchema.safeParse(stored);
+
+    if (!parsed.success) {
+      return null;
+    }
+
+    if (this.isExpired(parsed.data.expiresAt)) {
+      await this.deleteTransaction(transactionId);
+      return null;
+    }
+
+    this.transactions.set(parsed.data.id, parsed.data);
+    return parsed.data;
+  }
+
+  async isTransactionCallbackRegistered(
+    transaction: OAuthTransaction,
+  ): Promise<boolean> {
+    const registeredClient = await this.getRegisteredClientByClientId(
+      transaction.clientId,
+    );
+
+    return (
+      registeredClient?.redirectUris.includes(transaction.clientCallbackUrl) ??
+      false
+    );
+  }
+
+  async saveClientCode(clientCode: ClientCode): Promise<void> {
+    this.clientCodes.set(clientCode.code, clientCode);
+    await this.tokenStorage.save(
+      `${STORAGE_KEY_PREFIX.code}${clientCode.code}`,
+      clientCode,
+      this.getTtlSeconds(clientCode.expiresAt),
+    );
+  }
+
+  async saveRegisteredClient(client: ProxyDCRClient): Promise<void> {
+    await this.tokenStorage.save(
+      `${STORAGE_KEY_PREFIX.client}${client.clientId}`,
+      client,
+    );
+  }
+
+  async saveTransaction(transaction: OAuthTransaction): Promise<void> {
+    this.transactions.set(transaction.id, transaction);
+    await this.tokenStorage.save(
+      `${STORAGE_KEY_PREFIX.transaction}${transaction.id}`,
+      transaction,
+      this.getTtlSeconds(transaction.expiresAt),
+    );
+  }
+
+  private getTtlSeconds(expiresAt: Date): number {
+    const millisecondsUntilExpiry = expiresAt.getTime() - Date.now();
+    return Math.max(Math.ceil(millisecondsUntilExpiry / 1000), 1);
+  }
+
+  private isExpired(expiresAt: Date): boolean {
+    return expiresAt.getTime() < Date.now();
+  }
+}

--- a/src/auth/OAuthProxyStateStore.ts
+++ b/src/auth/OAuthProxyStateStore.ts
@@ -93,26 +93,30 @@ const oauthTransactionStorageSchema: z.ZodType<OAuthTransaction> = z.object({
 });
 
 interface OAuthProxyStateStoreConfig {
-  readonly clientCodes: Map<string, ClientCode>;
   readonly registeredClients: Map<string, ProxyDCRClient>;
   readonly registeredClientsByClientId: Map<string, ProxyDCRClient>;
   readonly tokenStorage: TokenStorage;
-  readonly transactions: Map<string, OAuthTransaction>;
 }
 
+/**
+ * Backs OAuth proxy state with the configured TokenStorage so that several
+ * proxy instances can serve one flow.
+ *
+ * Client registrations are immutable once written, so they are cached locally.
+ * Transactions and authorization codes are *not* cached: they are single-use
+ * and mutated by whichever instance handles the next leg of the flow, so a
+ * local copy would go stale and let a consumed code or transaction be redeemed
+ * a second time.
+ */
 export class OAuthProxyStateStore {
-  private readonly clientCodes: Map<string, ClientCode>;
   private readonly registeredClients: Map<string, ProxyDCRClient>;
   private readonly registeredClientsByClientId: Map<string, ProxyDCRClient>;
   private readonly tokenStorage: TokenStorage;
-  private readonly transactions: Map<string, OAuthTransaction>;
 
   constructor(config: OAuthProxyStateStoreConfig) {
-    this.clientCodes = config.clientCodes;
     this.registeredClients = config.registeredClients;
     this.registeredClientsByClientId = config.registeredClientsByClientId;
     this.tokenStorage = config.tokenStorage;
-    this.transactions = config.transactions;
   }
 
   cacheRegisteredClient(client: ProxyDCRClient): void {
@@ -123,45 +127,51 @@ export class OAuthProxyStateStore {
     }
   }
 
-  async deleteClientCode(code: string): Promise<void> {
-    this.clientCodes.delete(code);
-    await this.tokenStorage.delete(`${STORAGE_KEY_PREFIX.code}${code}`);
-  }
-
-  async deleteTransaction(transactionId: string): Promise<void> {
-    this.transactions.delete(transactionId);
-    await this.tokenStorage.delete(
-      `${STORAGE_KEY_PREFIX.transaction}${transactionId}`,
-    );
-  }
-
-  async getClientCode(code: string): Promise<ClientCode | null> {
-    const cached = this.clientCodes.get(code);
-    if (cached) {
-      if (this.isExpired(cached.expiresAt)) {
-        await this.deleteClientCode(code);
-        return null;
-      }
-
-      return cached;
-    }
-
-    const stored = await this.tokenStorage.get(
+  /**
+   * Atomically consume an authorization code. At most one caller — across all
+   * processes sharing the storage — can receive a given code, which is what
+   * makes single use enforceable (RFC 6749 §4.1.2).
+   */
+  async consumeClientCode(code: string): Promise<ClientCode | null> {
+    const stored = await this.takeFromStorage(
       `${STORAGE_KEY_PREFIX.code}${code}`,
     );
     const parsed = clientCodeStorageSchema.safeParse(stored);
 
-    if (!parsed.success) {
+    if (!parsed.success || this.isExpired(parsed.data.expiresAt)) {
       return null;
     }
 
-    if (this.isExpired(parsed.data.expiresAt)) {
-      await this.deleteClientCode(code);
-      return null;
-    }
-
-    this.clientCodes.set(parsed.data.code, parsed.data);
     return parsed.data;
+  }
+
+  /**
+   * Atomically consume a transaction, so a callback can only be redeemed once
+   * no matter which instance it lands on.
+   */
+  async consumeTransaction(
+    transactionId: string,
+  ): Promise<null | OAuthTransaction> {
+    const stored = await this.takeFromStorage(
+      `${STORAGE_KEY_PREFIX.transaction}${transactionId}`,
+    );
+    const parsed = oauthTransactionStorageSchema.safeParse(stored);
+
+    if (!parsed.success || this.isExpired(parsed.data.expiresAt)) {
+      return null;
+    }
+
+    return parsed.data;
+  }
+
+  async deleteClientCode(code: string): Promise<void> {
+    await this.tokenStorage.delete(`${STORAGE_KEY_PREFIX.code}${code}`);
+  }
+
+  async deleteTransaction(transactionId: string): Promise<void> {
+    await this.tokenStorage.delete(
+      `${STORAGE_KEY_PREFIX.transaction}${transactionId}`,
+    );
   }
 
   async getRegisteredClientByClientId(
@@ -185,19 +195,13 @@ export class OAuthProxyStateStore {
     return parsed.data;
   }
 
+  /**
+   * Read a transaction without consuming it. Used by the consent screen, which
+   * has to hand the same transaction back to the upstream redirect.
+   */
   async getTransaction(
     transactionId: string,
   ): Promise<null | OAuthTransaction> {
-    const cached = this.transactions.get(transactionId);
-    if (cached) {
-      if (this.isExpired(cached.expiresAt)) {
-        await this.deleteTransaction(transactionId);
-        return null;
-      }
-
-      return cached;
-    }
-
     const stored = await this.tokenStorage.get(
       `${STORAGE_KEY_PREFIX.transaction}${transactionId}`,
     );
@@ -212,7 +216,6 @@ export class OAuthProxyStateStore {
       return null;
     }
 
-    this.transactions.set(parsed.data.id, parsed.data);
     return parsed.data;
   }
 
@@ -230,7 +233,6 @@ export class OAuthProxyStateStore {
   }
 
   async saveClientCode(clientCode: ClientCode): Promise<void> {
-    this.clientCodes.set(clientCode.code, clientCode);
     await this.tokenStorage.save(
       `${STORAGE_KEY_PREFIX.code}${clientCode.code}`,
       clientCode,
@@ -246,7 +248,6 @@ export class OAuthProxyStateStore {
   }
 
   async saveTransaction(transaction: OAuthTransaction): Promise<void> {
-    this.transactions.set(transaction.id, transaction);
     await this.tokenStorage.save(
       `${STORAGE_KEY_PREFIX.transaction}${transaction.id}`,
       transaction,
@@ -261,5 +262,26 @@ export class OAuthProxyStateStore {
 
   private isExpired(expiresAt: Date): boolean {
     return expiresAt.getTime() < Date.now();
+  }
+
+  /**
+   * Prefer the storage's atomic take. Falling back to get + delete leaves a
+   * window in which two processes can both observe the same value, so
+   * multi-process deployments should implement `TokenStorage.take`.
+   */
+  private async takeFromStorage(key: string): Promise<null | unknown> {
+    if (this.tokenStorage.take) {
+      return this.tokenStorage.take(key);
+    }
+
+    const stored = await this.tokenStorage.get(key);
+
+    if (stored === null) {
+      return null;
+    }
+
+    await this.tokenStorage.delete(key);
+
+    return stored;
   }
 }

--- a/src/auth/OAuthProxyStateStore.ts
+++ b/src/auth/OAuthProxyStateStore.ts
@@ -93,7 +93,6 @@ const oauthTransactionStorageSchema: z.ZodType<OAuthTransaction> = z.object({
 });
 
 interface OAuthProxyStateStoreConfig {
-  readonly registeredClients: Map<string, ProxyDCRClient>;
   readonly registeredClientsByClientId: Map<string, ProxyDCRClient>;
   readonly tokenStorage: TokenStorage;
 }
@@ -109,22 +108,16 @@ interface OAuthProxyStateStoreConfig {
  * a second time.
  */
 export class OAuthProxyStateStore {
-  private readonly registeredClients: Map<string, ProxyDCRClient>;
   private readonly registeredClientsByClientId: Map<string, ProxyDCRClient>;
   private readonly tokenStorage: TokenStorage;
 
   constructor(config: OAuthProxyStateStoreConfig) {
-    this.registeredClients = config.registeredClients;
     this.registeredClientsByClientId = config.registeredClientsByClientId;
     this.tokenStorage = config.tokenStorage;
   }
 
   cacheRegisteredClient(client: ProxyDCRClient): void {
     this.registeredClientsByClientId.set(client.clientId, client);
-
-    for (const uri of client.redirectUris) {
-      this.registeredClients.set(uri, client);
-    }
   }
 
   /**
@@ -162,10 +155,6 @@ export class OAuthProxyStateStore {
     }
 
     return parsed.data;
-  }
-
-  async deleteClientCode(code: string): Promise<void> {
-    await this.tokenStorage.delete(`${STORAGE_KEY_PREFIX.code}${code}`);
   }
 
   async deleteTransaction(transactionId: string): Promise<void> {

--- a/src/auth/OAuthProxyStateStore.ts
+++ b/src/auth/OAuthProxyStateStore.ts
@@ -76,6 +76,19 @@ const clientCodeStorageSchema: z.ZodType<ClientCode> = z.object({
   used: z.boolean().optional(),
 });
 
+/**
+ * What is left behind once a code has been redeemed. Deliberately not a
+ * `ClientCode`: the tombstone carries only what a later attempt needs, so the
+ * upstream tokens do not linger in storage after they have been handed over.
+ *
+ * A full record written by an older version had `used: true` set on it, and
+ * still matches this shape, so those are read back as spent too.
+ */
+const spentClientCodeStorageSchema = z.object({
+  expiresAt: storedDateSchema,
+  used: z.literal(true),
+});
+
 const oauthTransactionStorageSchema: z.ZodType<OAuthTransaction> = z.object({
   clientCallbackUrl: z.string(),
   clientCodeChallenge: z.string(),
@@ -91,6 +104,16 @@ const oauthTransactionStorageSchema: z.ZodType<OAuthTransaction> = z.object({
   scope: z.array(z.string()),
   state: z.string(),
 });
+
+/**
+ * The result of taking an authorization code out of storage. Distinct from the
+ * `null` that `consumeClientCode` returns for a code that was never issued or
+ * has expired: `"spent"` means the code existed and a previous exchange
+ * already redeemed it, which the caller reports differently.
+ */
+export type ConsumedClientCode =
+  | { clientCode: ClientCode; expiresAt: Date; status: "active" }
+  | { expiresAt: Date; status: "spent" };
 
 interface OAuthProxyStateStoreConfig {
   readonly registeredClientsByClientId: Map<string, ProxyDCRClient>;
@@ -124,18 +147,35 @@ export class OAuthProxyStateStore {
    * Atomically consume an authorization code. At most one caller — across all
    * processes sharing the storage — can receive a given code, which is what
    * makes single use enforceable (RFC 6749 §4.1.2).
+   *
+   * Spent codes are taken too, so the caller must write the tombstone back
+   * with `markClientCodeSpent` to keep reporting the precise error on the
+   * attempt after this one.
    */
-  async consumeClientCode(code: string): Promise<ClientCode | null> {
+  async consumeClientCode(code: string): Promise<ConsumedClientCode | null> {
     const stored = await this.takeFromStorage(
       `${STORAGE_KEY_PREFIX.code}${code}`,
     );
+
+    const spent = spentClientCodeStorageSchema.safeParse(stored);
+
+    if (spent.success) {
+      return this.isExpired(spent.data.expiresAt)
+        ? null
+        : { expiresAt: spent.data.expiresAt, status: "spent" };
+    }
+
     const parsed = clientCodeStorageSchema.safeParse(stored);
 
     if (!parsed.success || this.isExpired(parsed.data.expiresAt)) {
       return null;
     }
 
-    return parsed.data;
+    return {
+      clientCode: parsed.data,
+      expiresAt: parsed.data.expiresAt,
+      status: "active",
+    };
   }
 
   /**
@@ -218,6 +258,19 @@ export class OAuthProxyStateStore {
     return (
       registeredClient?.redirectUris.includes(transaction.clientCallbackUrl) ??
       false
+    );
+  }
+
+  /**
+   * Record that an authorization code has been redeemed, so a later attempt
+   * gets "already used" rather than looking like an unknown code. Keyed and
+   * expiring exactly like the code it replaces, so it cannot outlive it.
+   */
+  async markClientCodeSpent(code: string, expiresAt: Date): Promise<void> {
+    await this.tokenStorage.save(
+      `${STORAGE_KEY_PREFIX.code}${code}`,
+      { expiresAt, used: true },
+      this.getTtlSeconds(expiresAt),
     );
   }
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -407,6 +407,21 @@ export interface TokenStorage {
   get(key: string): Promise<null | unknown>;
   /** Save a value with optional TTL */
   save(key: string, value: unknown, ttl?: number): Promise<void>;
+  /**
+   * Atomically retrieve a value and delete it, returning `null` if the key was
+   * absent. At most one caller may observe a given value.
+   *
+   * Optional, but **required for correctness when more than one process shares
+   * this storage**: the OAuth proxy consumes authorization codes and
+   * transactions through it, and single-use enforcement depends on the
+   * atomicity. Without it the proxy falls back to a non-atomic get + delete,
+   * where two concurrent requests can both redeem the same authorization code.
+   *
+   * Most backends expose a suitable primitive: Redis `GETDEL`, DynamoDB
+   * `DeleteItem` with `ReturnValues: "ALL_OLD"`, or SQL
+   * `DELETE ... RETURNING *`.
+   */
+  take?(key: string): Promise<null | unknown>;
 }
 
 /**

--- a/src/auth/utils/diskStore.test.ts
+++ b/src/auth/utils/diskStore.test.ts
@@ -201,4 +201,52 @@ describe("DiskStore", () => {
 
     store.destroy();
   });
+
+  describe("take", () => {
+    it("should return the value and remove it", async () => {
+      const store = new DiskStore({ directory: TEST_DIR });
+      await store.save("take-key", { token: "secret" });
+
+      expect(await store.take("take-key")).toEqual({ token: "secret" });
+      expect(await store.get("take-key")).toBeNull();
+
+      store.destroy();
+    });
+
+    it("should return null for a missing key", async () => {
+      const store = new DiskStore({ directory: TEST_DIR });
+
+      expect(await store.take("no-such-key")).toBeNull();
+
+      store.destroy();
+    });
+
+    it("should hand the value to exactly one of several concurrent callers", async () => {
+      // The rename() claim is what makes single-use safe when several
+      // processes share the directory.
+      const store = new DiskStore({ directory: TEST_DIR });
+      await store.save("contended-key", "value");
+
+      const results = await Promise.all([
+        store.take("contended-key"),
+        store.take("contended-key"),
+        store.take("contended-key"),
+      ]);
+
+      expect(results.filter((result) => result !== null)).toEqual(["value"]);
+
+      store.destroy();
+    });
+
+    it("should not leave claim files behind", async () => {
+      const store = new DiskStore({ directory: TEST_DIR });
+      await store.save("claim-key", "value");
+      await store.take("claim-key");
+
+      const files = await readdir(TEST_DIR);
+      expect(files.filter((file) => file.endsWith(".claim"))).toHaveLength(0);
+
+      store.destroy();
+    });
+  });
 });

--- a/src/auth/utils/diskStore.test.ts
+++ b/src/auth/utils/diskStore.test.ts
@@ -244,7 +244,7 @@ describe("DiskStore", () => {
       await store.take("claim-key");
 
       const files = await readdir(TEST_DIR);
-      expect(files.filter((file) => file.endsWith(".claim"))).toHaveLength(0);
+      expect(files.filter((file) => file.includes(".claim"))).toHaveLength(0);
 
       store.destroy();
     });

--- a/src/auth/utils/diskStore.ts
+++ b/src/auth/utils/diskStore.ts
@@ -3,7 +3,16 @@
  * Provides persistent file-based storage for OAuth tokens and transaction state
  */
 
-import { mkdir, readdir, readFile, rm, stat, writeFile } from "fs/promises";
+import { randomUUID } from "crypto";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "fs/promises";
 import { join } from "path";
 
 import type { TokenStorage } from "../types.js";
@@ -176,6 +185,40 @@ export class DiskStore implements TokenStorage {
       return files.filter((f) => f.endsWith(this.fileExtension)).length;
     } catch {
       return 0;
+    }
+  }
+
+  /**
+   * Atomically retrieve a value and delete it.
+   *
+   * rename() is atomic on POSIX filesystems, so when several processes race
+   * for the same key exactly one rename succeeds and the losers see ENOENT.
+   * That is what makes single-use authorization codes safe when more than one
+   * process shares the directory.
+   */
+  async take(key: string): Promise<null | unknown> {
+    const filePath = this.getFilePath(key);
+    const claimPath = `${filePath}.${randomUUID()}.claim`;
+
+    try {
+      await rename(filePath, claimPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.error(`Failed to take key ${key}:`, error);
+      }
+      return null;
+    }
+
+    try {
+      const content = await readFile(claimPath, "utf-8");
+      const entry: StorageEntry = JSON.parse(content);
+
+      return entry.expiresAt < Date.now() ? null : entry.value;
+    } catch (error) {
+      console.error(`Failed to read key ${key}:`, error);
+      return null;
+    } finally {
+      await rm(claimPath, { force: true });
     }
   }
 

--- a/src/auth/utils/diskStore.ts
+++ b/src/auth/utils/diskStore.ts
@@ -198,7 +198,10 @@ export class DiskStore implements TokenStorage {
    */
   async take(key: string): Promise<null | unknown> {
     const filePath = this.getFilePath(key);
-    const claimPath = `${filePath}.${randomUUID()}.claim`;
+    // Keep the configured extension on the claim file so that if the process
+    // dies between the rename and the unlink, cleanup() still reaps it once
+    // the entry expires rather than leaving it on disk forever.
+    const claimPath = `${filePath}.${randomUUID()}.claim${this.fileExtension}`;
 
     try {
       await rename(filePath, claimPath);

--- a/src/auth/utils/tokenStore.test.ts
+++ b/src/auth/utils/tokenStore.test.ts
@@ -5,6 +5,8 @@
 import { setTimeout as delay } from "timers/promises";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import type { TokenStorage } from "../types.js";
+
 import { EncryptedTokenStorage, MemoryTokenStorage } from "./tokenStore.js";
 
 describe("MemoryTokenStorage", () => {
@@ -78,6 +80,38 @@ describe("MemoryTokenStorage", () => {
 
       expect(storage.size()).toBe(1);
       expect(await storage.get("key7")).toBe("value7");
+    });
+  });
+
+  describe("take", () => {
+    it("should return the value and remove it", async () => {
+      await storage.save("take-key", "value");
+
+      expect(await storage.take("take-key")).toBe("value");
+      expect(await storage.get("take-key")).toBeNull();
+    });
+
+    it("should return null for a missing key", async () => {
+      expect(await storage.take("no-such-key")).toBeNull();
+    });
+
+    it("should return null for an expired entry", async () => {
+      await storage.save("expired-key", "value", 0.1);
+      await delay(150);
+
+      expect(await storage.take("expired-key")).toBeNull();
+    });
+
+    it("should hand the value to exactly one of several concurrent callers", async () => {
+      await storage.save("contended-key", "value");
+
+      const results = await Promise.all([
+        storage.take("contended-key"),
+        storage.take("contended-key"),
+        storage.take("contended-key"),
+      ]);
+
+      expect(results.filter((result) => result !== null)).toEqual(["value"]);
     });
   });
 });
@@ -183,6 +217,47 @@ describe("EncryptedTokenStorage", () => {
       await storage.delete("delete-key");
       const value = await storage.get("delete-key");
       expect(value).toBeNull();
+    });
+  });
+
+  describe("take", () => {
+    it("should decrypt the value and remove it", async () => {
+      const value = { nested: { token: "secret" } };
+      await storage.save("take-key", value);
+
+      expect(await storage.take("take-key")).toEqual(value);
+      expect(await storage.get("take-key")).toBeNull();
+      expect(await backend.get("take-key")).toBeNull();
+    });
+
+    it("should return null for a missing key", async () => {
+      expect(await storage.take("no-such-key")).toBeNull();
+    });
+
+    it("should delegate to a backend that cannot take atomically", async () => {
+      const calls: string[] = [];
+      const backendWithoutTake: TokenStorage = {
+        cleanup: async () => {},
+        delete: async (key) => {
+          calls.push(`delete:${key}`);
+          await backend.delete(key);
+        },
+        get: async (key) => {
+          calls.push(`get:${key}`);
+          return backend.get(key);
+        },
+        save: async (key, value, ttl) => backend.save(key, value, ttl),
+      };
+      const wrapper = new EncryptedTokenStorage(
+        backendWithoutTake,
+        "test-encryption-key",
+      );
+
+      await wrapper.save("fallback-key", "value");
+
+      expect(await wrapper.take("fallback-key")).toBe("value");
+      expect(calls).toEqual(["get:fallback-key", "delete:fallback-key"]);
+      expect(await wrapper.get("fallback-key")).toBeNull();
     });
   });
 });

--- a/src/auth/utils/tokenStore.ts
+++ b/src/auth/utils/tokenStore.ts
@@ -42,22 +42,7 @@ export class EncryptedTokenStorage implements TokenStorage {
   }
 
   async get(key: string): Promise<null | unknown> {
-    const encrypted = await this.backend.get(key);
-
-    if (!encrypted) {
-      return null;
-    }
-
-    try {
-      const decrypted = await this.decrypt(
-        encrypted as string,
-        this.encryptionKey,
-      );
-      return JSON.parse(decrypted);
-    } catch (error) {
-      console.error("Failed to decrypt value:", error);
-      return null;
-    }
+    return this.decryptStored(await this.backend.get(key));
   }
 
   async save(key: string, value: unknown, ttl?: number): Promise<void> {
@@ -66,6 +51,26 @@ export class EncryptedTokenStorage implements TokenStorage {
       this.encryptionKey,
     );
     await this.backend.save(key, encrypted, ttl);
+  }
+
+  /**
+   * Delegates to the backend so that the atomicity of the underlying store is
+   * preserved; falls back to get + delete when the backend cannot do better.
+   */
+  async take(key: string): Promise<null | unknown> {
+    if (this.backend.take) {
+      return this.decryptStored(await this.backend.take(key));
+    }
+
+    const value = await this.get(key);
+
+    if (value === null) {
+      return null;
+    }
+
+    await this.backend.delete(key);
+
+    return value;
   }
 
   private async decrypt(ciphertext: string, key: Buffer): Promise<string> {
@@ -90,6 +95,23 @@ export class EncryptedTokenStorage implements TokenStorage {
     decrypted += decipher.final("utf8");
 
     return decrypted;
+  }
+
+  private async decryptStored(encrypted: unknown): Promise<null | unknown> {
+    if (!encrypted) {
+      return null;
+    }
+
+    try {
+      const decrypted = await this.decrypt(
+        encrypted as string,
+        this.encryptionKey,
+      );
+      return JSON.parse(decrypted);
+    } catch (error) {
+      console.error("Failed to decrypt value:", error);
+      return null;
+    }
   }
 
   private async encrypt(plaintext: string, key: Buffer): Promise<string> {
@@ -185,5 +207,20 @@ export class MemoryTokenStorage implements TokenStorage {
    */
   size(): number {
     return this.store.size;
+  }
+
+  /**
+   * Atomic by construction: the read and the delete happen in a single
+   * synchronous block, so no other task can observe the value in between.
+   */
+  async take(key: string): Promise<null | unknown> {
+    const entry = this.store.get(key);
+    this.store.delete(key);
+
+    if (!entry || entry.expiresAt < Date.now()) {
+      return null;
+    }
+
+    return entry.value;
   }
 }


### PR DESCRIPTION
## Summary

- Persist OAuthProxy DCR clients, in-flight transactions, and generated authorization codes through the configured TokenStorage
- Keep the existing in-memory maps as local caches while allowing another proxy instance to hydrate the state from storage
- Add regression coverage for DCR authorization and authorize -> callback -> token exchange across separate instances sharing encrypted TokenStorage

Fixes #277.

## Validation

- pnpm vitest run src/auth/OAuthProxy.storage-persistence.test.ts
- pnpm vitest run src/auth/OAuthProxy.open-redirect.test.ts
- pnpm vitest run src/auth/OAuthProxy.token-swap.test.ts
- pnpm vitest run src/auth/OAuthProxy.extra-authorization-params.test.ts src/auth/OAuthProxy.token-parsing.test.ts
- pnpm exec prettier --check .
- pnpm exec eslint .
- pnpm exec tsc --noEmit
- pnpm exec jsr publish --dry-run --allow-dirty
- pnpm lint

Note: the first full `pnpm test` run passed all 369 tests but failed on unrelated unhandled HTTP transport errors. A second full run reproduced unrelated `FastMCP.completions.test.ts` timeouts under the parallel suite; that file passed when run in isolation.
