### PR TITLE
fix: return 401 for authentication failures instead of relying on error-message heuristics

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4569,6 +4569,69 @@ test("authentication failure handling: should not create session for authenticat
   }
 });
 
+// See https://github.com/punkpeye/fastmcp/issues/180
+test("authentication failure handling: returns 401 with WWW-Authenticate even when the error message has no auth-related keywords", async () => {
+  const port = await getRandomPort();
+  let callCount = 0;
+
+  // Regression test for a session-mode (non-stateless) request where
+  // `authenticate()` is invoked twice for the same request -- once by the
+  // transport layer and once internally by FastMCP when building the
+  // session. If the second call reports a failure whose message doesn't
+  // happen to contain a magic keyword (e.g. "Authentication", "Token",
+  // "Unauthorized"), the response must still be 401, not a generic 500.
+  const server = new FastMCP<{ authenticated: boolean; error?: string }>({
+    authenticate: async () => {
+      callCount += 1;
+
+      if (callCount === 1) {
+        return { authenticated: true };
+      }
+
+      return { authenticated: false, error: "Access denied" };
+    },
+    name: "Test server",
+    version: "1.0.0",
+  });
+
+  await server.start({
+    httpStream: {
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const response = await fetch(`http://localhost:${port}/mcp`, {
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          capabilities: {},
+          clientInfo: { name: "test", version: "1.0" },
+          protocolVersion: "2024-11-05",
+        },
+      }),
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("WWW-Authenticate")).toContain("Bearer");
+
+    const body = (await response.json()) as {
+      error?: { code?: number; message?: string };
+    };
+    expect(body.error?.message).toBe("Access denied");
+  } finally {
+    await server.stop();
+  }
+});
+
 test("host configuration works with 0.0.0.0", async () => {
   const port = await getRandomPort();
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2774,9 +2774,10 @@ export class FastMCP<
               auth = await this.#authenticate(request);
 
               // In stateless mode, authentication is REQUIRED
-              // mcp-proxy will catch this error and return 401
               if (auth === undefined || auth === null) {
-                throw new Error("Authentication required");
+                throw this.#createUnauthorizedResponse(
+                  "Authentication required",
+                );
               }
             }
 
@@ -2935,7 +2936,7 @@ export class FastMCP<
         typeof (auth as { error: unknown }).error === "string"
           ? (auth as { error: string }).error
           : "Authentication failed";
-      throw new Error(errorMessage);
+      throw this.#createUnauthorizedResponse(errorMessage);
     }
 
     const allowedTools = auth
@@ -2960,6 +2961,48 @@ export class FastMCP<
       utils: this.#options.utils,
       version: this.#options.version,
     });
+  }
+
+  /**
+   * Builds a 401 Unauthorized HTTP Response for authentication failures.
+   *
+   * Throwing a `Response` (rather than a plain `Error`) guarantees that the
+   * transport (e.g. mcp-proxy) surfaces the correct status code directly,
+   * instead of relying on heuristics that infer the status code from the
+   * error message's text (see https://github.com/punkpeye/fastmcp/issues/180).
+   *
+   * The response body matches the JSON-RPC error envelope FastMCP otherwise
+   * produces, and a `WWW-Authenticate` header is included per RFC 7235 (and
+   * RFC 9728 when protected-resource metadata is configured), so HTTP-aware
+   * clients can distinguish "unauthenticated" from a malformed request.
+   */
+  #createUnauthorizedResponse(message: string): Response {
+    const resource = this.#options.oauth?.protectedResource?.resource;
+    const wwwAuthenticateParts = [
+      'error="invalid_token"',
+      `error_description="${message.replace(/"/g, '\\"')}"`,
+    ];
+
+    if (resource) {
+      wwwAuthenticateParts.push(
+        `resource_metadata="${resource}/.well-known/oauth-protected-resource"`,
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        error: { code: -32000, message },
+        id: null,
+        jsonrpc: "2.0",
+      }),
+      {
+        headers: {
+          "Content-Type": "application/json",
+          "WWW-Authenticate": `Bearer ${wwwAuthenticateParts.join(", ")}`,
+        },
+        status: 401,
+      },
+    );
   }
 
   /**

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2977,7 +2977,15 @@ export class FastMCP<
    * clients can distinguish "unauthenticated" from a malformed request.
    */
   #createUnauthorizedResponse(message: string): Response {
-    const resource = this.#options.oauth?.protectedResource?.resource;
+    // Only advertise resource_metadata when OAuth is enabled: the
+    // `/.well-known/oauth-protected-resource` endpoint is served only under
+    // `oauth.enabled` (and this matches how the oauth config is forwarded to
+    // mcp-proxy at the httpStream call sites), so gating here avoids pointing
+    // clients at an endpoint that would 404.
+    const oauth = this.#options.oauth;
+    const resource = oauth?.enabled
+      ? oauth.protectedResource?.resource
+      : undefined;
     const wwwAuthenticateParts = [
       'error="invalid_token"',
       `error_description="${message.replace(/"/g, '\\"')}"`,


### PR DESCRIPTION
## Summary

Fixes #180.

`FastMCP`'s `#createSession` already rejects requests when `authenticate()` returns `{ authenticated: false }` (added in #188 for #186), but it does so by throwing a plain `Error`. Whether that becomes a 401 downstream depends on `mcp-proxy` matching specific substrings ("Authentication", "Invalid JWT", "Token", "Unauthorized") in the error message. A rejection message without one of those words, such as "Access denied", falls through to a generic `500 Error creating server` instead of a 401.

The trigger is that FastMCP calls `authenticate()` a second time inside its `createServer` callback, after mcp-proxy has already called it once at the transport layer. An auth function that rejects on token reuse, or rejects non-deterministically, hits this internal path and gets the 500. This PR fixes the status-code side of that: FastMCP now constructs the 401 response itself (status code, JSON-RPC error body, and a `WWW-Authenticate` header per RFC 7235/9728) wherever it already detects an authentication failure, instead of depending on the transport's string matching. Covered paths:

- the `{ authenticated: false }` convention in `#createSession` (stateless and session HTTP-stream modes)
- the stateless-mode "no auth result" check (`auth === undefined || auth === null`)

The `authenticate` option's documented pattern is `throw new Response(null, { status: 401, ... })`; FastMCP's internal failure path now follows the same convention, so any custom failure message reliably produces a 401. The `resource_metadata` parameter is included only when OAuth is enabled and protected-resource metadata is configured, matching where the `/.well-known/oauth-protected-resource` endpoint is actually served.

## Changes

- `src/FastMCP.ts`: adds a private `#createUnauthorizedResponse(message)` helper that builds a 401 `Response` with a JSON-RPC-shaped body (`{ error: { code: -32000, message } }`) and a `WWW-Authenticate` header. Both existing auth-failure throw sites use it instead of `new Error(...)`.
- `src/FastMCP.test.ts`: adds a regression test in which `authenticate()` reports failure with a message containing none of the substrings the transport's fallback heuristic looks for. Before this change the request received 500; after, it receives 401 with a `WWW-Authenticate` header.

## Test plan

- `pnpm exec tsc --noEmit`: clean
- `pnpm exec eslint src/FastMCP.ts src/FastMCP.test.ts`: clean
- `pnpm exec prettier --check src/FastMCP.ts src/FastMCP.test.ts`: clean
- `pnpm vitest run`: 368/368 passing
- Confirmed the new regression test fails (500) against current `main` and passes (401) with the fix applied.

## Notes for reviewers

- No behavior change for any currently-passing scenario: every existing auth-failure test message already contains one of the transport's substrings, so those paths returned 401 before and still do.
- `EdgeFastMCP` (`src/edge/*`) is untouched; it has no authentication support yet.
- A possible follow-up outside this PR's scope: the second internal `authenticate()` call is redundant with mcp-proxy's transport-level call and can be problematic for single-use credentials. Happy to look at that separately if wanted.
