### PR TITLE
fix: preserve _meta in tool execute() results

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4930,6 +4930,46 @@ test("validates explicit structuredContent against outputSchema", async () => {
   });
 });
 
+test("passes through result _meta from tool execute", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          name: "get-weather",
+        }),
+      ).toEqual({
+        _meta: {
+          requestId: "req_123",
+          retryable: true,
+        },
+        content: [{ text: "Weather: 72F", type: "text" }],
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Get weather for a city",
+        execute: async () => {
+          return {
+            _meta: {
+              requestId: "req_123",
+              retryable: true,
+            },
+            content: [{ text: "Weather: 72F", type: "text" }],
+          };
+        },
+        name: "get-weather",
+      });
+
+      return server;
+    },
+  });
+});
+
 test("returns an error when structuredContent fails outputSchema validation", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -381,6 +381,7 @@ const ContentZodSchema = z.discriminatedUnion("type", [
 ]) satisfies z.ZodType<Content>;
 
 type ContentResult = {
+  _meta?: Record<string, unknown>;
   content: Content[];
   isError?: boolean;
   structuredContent?: Record<string, unknown>;
@@ -388,6 +389,7 @@ type ContentResult = {
 
 const ContentResultZodSchema = z
   .object({
+    _meta: z.record(z.string(), z.unknown()).optional(),
     content: ContentZodSchema.array(),
     isError: z.boolean().optional(),
     structuredContent: z.record(z.string(), z.unknown()).optional(),


### PR DESCRIPTION
## Summary

Fixes #289.

- allow tool `execute()` results to include `_meta`
- preserve existing strict result validation for other fields
- add regression coverage for `_meta` passthrough on tool calls

## Testing

- `pnpm vitest run src/FastMCP.test.ts -t 'passes through result _meta from tool execute|returns structuredContent for tool output that matches outputSchema|validates explicit structuredContent against outputSchema'`
- `pnpm vitest run src/FastMCP.test.ts -t 'passes through result _meta from tool execute'`
- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check src/FastMCP.ts src/FastMCP.test.ts`
- `pnpm exec eslint src/FastMCP.ts src/FastMCP.test.ts`
- `pnpm build`
