### PR TITLE
feat: support elicitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,7 +1247,7 @@ server.addTool({
 
 #### Elicitation
 
-Tools can request additional information from the user mid-execution via [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation), using the `elicit` method in the context object. The client must declare the `elicitation` capability.
+Tools can request additional information from the user mid-execution via [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation), using the `elicit` method in the context object. The client must advertise the matching `elicitation` capability mode — `elicitation: { form: {} }` for form requests (the default) and/or `elicitation: { url: {} }` for url requests.
 
 ```js
 server.addTool({
@@ -2244,7 +2244,7 @@ Refer to [Sessions](#sessions) for examples of how to obtain a `FastMCPSession` 
 
 ### `requestElicitation`
 
-`requestElicitation` creates an [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) request to collect additional information from the user via the client and returns the response. The client must declare the `elicitation` capability.
+`requestElicitation` creates an [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) request to collect additional information from the user via the client and returns the response. The client must advertise the matching `elicitation` capability mode — `elicitation: { form: {} }` for form requests (the default) and/or `elicitation: { url: {} }` for url requests.
 
 ```ts
 await session.requestElicitation({

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A TypeScript framework for building [MCP](https://glama.ai/mcp) servers capable 
 - [Typed server events](#typed-server-events)
 - [Prompt argument auto-completion](#prompt-argument-auto-completion)
 - [Sampling](#requestsampling)
+- [Elicitation](#elicitation)
 - [Configurable ping behavior](#configurable-ping-behavior)
 - [Health-check endpoint](#health-check-endpoint)
 - [Roots](#roots-management)
@@ -1244,6 +1245,44 @@ server.addTool({
 });
 ```
 
+#### Elicitation
+
+Tools can request additional information from the user mid-execution via [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation), using the `elicit` method in the context object. The client must declare the `elicitation` capability.
+
+```js
+server.addTool({
+  name: "delete-file",
+  description: "Delete a file",
+  parameters: z.object({
+    path: z.string(),
+  }),
+  execute: async (args, { elicit }) => {
+    const response = await elicit({
+      message: `Are you sure you want to delete ${args.path}?`,
+      requestedSchema: {
+        type: "object",
+        properties: {
+          confirmed: {
+            type: "boolean",
+          },
+        },
+        required: ["confirmed"],
+      },
+    });
+
+    if (response.action !== "accept" || !response.content?.confirmed) {
+      return "Deletion cancelled.";
+    }
+
+    // ...
+
+    return `Deleted ${args.path}`;
+  },
+});
+```
+
+The response `action` is `"accept"`, `"decline"`, or `"cancel"`; on accept, `content` holds the user's answers matching `requestedSchema`. Elicitation is also available outside of tools via [`session.requestElicitation`](#requestelicitation).
+
 #### Tool Annotations
 
 As of the MCP Specification (2025-03-26), tools can include annotations that provide richer context and control by adding metadata about a tool's behavior:
@@ -2202,6 +2241,25 @@ server.on("disconnect", (event) => {
 `FastMCPSession` represents a client session and provides methods to interact with the client.
 
 Refer to [Sessions](#sessions) for examples of how to obtain a `FastMCPSession` instance.
+
+### `requestElicitation`
+
+`requestElicitation` creates an [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) request to collect additional information from the user via the client and returns the response. The client must declare the `elicitation` capability.
+
+```ts
+await session.requestElicitation({
+  message: "What is your name?",
+  requestedSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+    },
+    required: ["name"],
+  },
+});
+```
+
+Inside a tool, prefer the `elicit` method from the [context object](#elicitation).
 
 ### `requestSampling`
 

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -3,6 +3,7 @@ import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import {
   CreateMessageRequestSchema,
+  ElicitRequestSchema,
   ErrorCode,
   ListRootsRequestSchema,
   LoggingMessageNotificationSchema,
@@ -2303,6 +2304,169 @@ test("makes a sampling request", async () => {
   });
 });
 
+const elicitationTestClient = async () => {
+  const client = new Client(
+    {
+      name: "example-client",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        elicitation: { form: {} },
+      },
+    },
+  );
+  return client;
+};
+
+const elicitationTestServer = async () => {
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  server.addTool({
+    description: "Greets the user by the name collected via elicitation",
+    async execute(_args, { elicit }) {
+      const response = await elicit({
+        message: "What is your name?",
+        requestedSchema: {
+          properties: {
+            name: { type: "string" },
+          },
+          required: ["name"],
+          type: "object",
+        },
+      });
+
+      if (response.action !== "accept") {
+        return `No name provided (${response.action})`;
+      }
+
+      return `Hello, ${response.content?.name}!`;
+    },
+    name: "greet-user",
+  });
+
+  return server;
+};
+
+test("makes an elicitation request from a tool", async () => {
+  const onElicitRequest = vi.fn(
+    (request: z.infer<typeof ElicitRequestSchema>) => {
+      expect(request.params.message).toBe("What is your name?");
+
+      return {
+        action: "accept" as const,
+        content: {
+          name: "Alice",
+        },
+      };
+    },
+  );
+
+  await runWithTestServer({
+    client: elicitationTestClient,
+    run: async ({ client }) => {
+      client.setRequestHandler(ElicitRequestSchema, onElicitRequest);
+
+      const result = await client.callTool({
+        arguments: {},
+        name: "greet-user",
+      });
+
+      expect(result.content).toEqual([
+        {
+          text: "Hello, Alice!",
+          type: "text",
+        },
+      ]);
+
+      expect(onElicitRequest).toHaveBeenCalledTimes(1);
+    },
+    server: elicitationTestServer,
+  });
+});
+
+test("handles a declined elicitation request", async () => {
+  await runWithTestServer({
+    client: elicitationTestClient,
+    run: async ({ client }) => {
+      client.setRequestHandler(ElicitRequestSchema, () => {
+        return {
+          action: "decline" as const,
+        };
+      });
+
+      const result = await client.callTool({
+        arguments: {},
+        name: "greet-user",
+      });
+
+      expect(result.content).toEqual([
+        {
+          text: "No name provided (decline)",
+          type: "text",
+        },
+      ]);
+    },
+    server: elicitationTestServer,
+  });
+});
+
+test("makes an elicitation request via session.requestElicitation", async () => {
+  await runWithTestServer({
+    client: elicitationTestClient,
+    run: async ({ client, session }) => {
+      client.setRequestHandler(ElicitRequestSchema, () => {
+        return {
+          action: "accept" as const,
+          content: {
+            name: "Alice",
+          },
+        };
+      });
+
+      const response = await session.requestElicitation({
+        message: "What is your name?",
+        requestedSchema: {
+          properties: {
+            name: { type: "string" },
+          },
+          required: ["name"],
+          type: "object",
+        },
+      });
+
+      expect(response).toEqual({
+        action: "accept",
+        content: {
+          name: "Alice",
+        },
+      });
+    },
+  });
+});
+
+test("rejects elicitation when the client does not declare the capability", async () => {
+  await runWithTestServer({
+    run: async ({ session }) => {
+      await expect(
+        session.requestElicitation({
+          message: "What is your name?",
+          requestedSchema: {
+            properties: {
+              name: { type: "string" },
+            },
+            required: ["name"],
+            type: "object",
+          },
+        }),
+      ).rejects.toThrow("Client does not support form elicitation");
+    },
+  });
+});
+
 test("throws ErrorCode.InvalidParams if tool parameters do not match zod schema", async () => {
   await runWithTestServer({
     run: async ({ client }) => {
@@ -2662,6 +2826,7 @@ test("provides auth to tools", async () => {
     },
     {
       client: expect.any(Object),
+      elicit: expect.any(Function),
       log: {
         debug: expect.any(Function),
         error: expect.any(Function),

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1496,8 +1496,8 @@ export class FastMCPSession<
    * Builds the context object passed as the third argument to
    * `resource.load` / `resourceTemplate.load` / `prompt.load`.
    *
-   * This mirrors the `client`, `log`, `requestId`, `session`, and
-   * `sessionId` fields available to `tool.execute` via {@link Context}.
+   * This mirrors the `client`, `elicit`, `log`, `requestId`, `session`,
+   * and `sessionId` fields available to `tool.execute` via {@link Context}.
    * `reportProgress` and `streamContent` are intentionally omitted: they
    * are tied to a tool call's progress token / streaming notification,
    * which resource and prompt reads do not have.
@@ -1507,6 +1507,10 @@ export class FastMCPSession<
       client: {
         version: this.#server.getClientVersion(),
       },
+      elicit: (
+        params: ElicitRequestFormParams | ElicitRequestURLParams,
+        options?: RequestOptions,
+      ) => this.#server.elicitInput(params, options),
       log: this.#createLog(),
       requestId:
         typeof meta?.requestId === "string" ? meta.requestId : undefined,

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -219,7 +219,9 @@ type Context<T extends FastMCPSessionAuth> = {
   /**
    * Requests additional information from the user via the client
    * (see https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation).
-   * The client must declare the `elicitation` capability.
+   * The client must advertise the matching `elicitation` capability mode —
+   * `elicitation: { form: {} }` for form requests (the default) and/or
+   * `elicitation: { url: {} }` for url requests.
    */
   elicit: (
     params: ElicitRequestFormParams | ElicitRequestURLParams,

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -8,6 +8,9 @@ import {
   ClientCapabilities,
   CompleteRequestSchema,
   CreateMessageRequestSchema,
+  ElicitRequestFormParams,
+  ElicitRequestURLParams,
+  ElicitResult,
   ErrorCode,
   GetPromptRequestSchema,
   GetPromptResult,
@@ -213,6 +216,15 @@ type Context<T extends FastMCPSessionAuth> = {
   client: {
     version: ReturnType<Server["getClientVersion"]>;
   };
+  /**
+   * Requests additional information from the user via the client
+   * (see https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation).
+   * The client must declare the `elicitation` capability.
+   */
+  elicit: (
+    params: ElicitRequestFormParams | ElicitRequestURLParams,
+    options?: RequestOptions,
+  ) => Promise<ElicitResult>;
   log: {
     debug: (message: string, data?: SerializableValue) => void;
     error: (message: string, data?: SerializableValue) => void;
@@ -1356,6 +1368,13 @@ export class FastMCPSession<
     this.triggerListChangedNotification("notifications/prompts/list_changed");
   }
 
+  public async requestElicitation(
+    params: ElicitRequestFormParams | ElicitRequestURLParams,
+    options?: RequestOptions,
+  ): Promise<ElicitResult> {
+    return this.#server.elicitInput(params, options);
+  }
+
   public async requestSampling(
     message: z.infer<typeof CreateMessageRequestSchema>["params"],
     options?: RequestOptions,
@@ -2122,6 +2141,10 @@ export class FastMCPSession<
           client: {
             version: this.#server.getClientVersion(),
           },
+          elicit: (
+            params: ElicitRequestFormParams | ElicitRequestURLParams,
+            options?: RequestOptions,
+          ) => this.#server.elicitInput(params, options),
           log,
           reportProgress,
           requestId:


### PR DESCRIPTION
## Summary

Closes #162.

Adds MCP [elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) support, letting a server request additional information from the user mid-interaction via the client — the TypeScript counterpart of Python FastMCP's `ctx.elicit`, as suggested in the issue.

Two entry points, following the existing `requestSampling` pattern:

- **`elicit` in the tool execute context** — the primary ergonomic API:

  ```ts
  execute: async (args, { elicit }) => {
    const response = await elicit({
      message: `Are you sure you want to delete ${args.path}?`,
      requestedSchema: {
        type: "object",
        properties: { confirmed: { type: "boolean" } },
        required: ["confirmed"],
      },
    });
    if (response.action !== "accept" || !response.content?.confirmed) {
      return "Deletion cancelled.";
    }
    // ...
  ```

- **`FastMCPSession.requestElicitation(params, options?)`** — session-level sibling of `requestSampling`, for use outside tool execution.

Both are thin passthroughs to the SDK's `Server.elicitInput` (available since the pinned `@modelcontextprotocol/sdk` version), which already enforces the client's `elicitation` capability, validates accepted content against `requestedSchema`, and supports both `form` and `url` modes — so fastmcp inherits spec behavior instead of re-implementing it, exactly like `requestSampling` does with `createMessage`.

## Tests

Four new tests mirroring the existing sampling test setup (real client/server over the test transport):

- tool-context `elicit` round-trip (accept path, asserts the message reaches the client handler and the tool sees the content)
- decline path handled by the tool
- session-level `requestElicitation` round-trip
- rejection when the client does not declare the `elicitation` capability (pins the SDK's capability check)

One existing test ("provides auth to tools") asserts the exact context shape, so it gained the new `elicit` member.

Full validation: `prettier --check` ✅, `eslint` ✅, `tsc --noEmit` ✅, `vitest run` **371/371 passed** ✅

## Docs

README: feature-list entry, an `#### Elicitation` section under Tools (delete-confirmation example), and a `### requestElicitation` section under `FastMCPSession`.

One note for reviewers: the capability check is the SDK server's, which currently requires the client to declare `elicitation.form` / `elicitation.url` explicitly (an empty `elicitation: {}` object is only granted form-mode by the SDK's *client*-side check, not the server-side one). Since this wrapper stays thin, fastmcp will automatically inherit any future SDK change there.

Used AI assistance; reviewed and tested by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)