### PR TITLE
Pass load context (client info, log, session) to resource and prompt load()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1329,6 +1329,23 @@ async load() {
 }
 ```
 
+`load` also receives `auth` (the value returned by your `authenticate` function, if any) and a `context` object as its second and third arguments. `context` mirrors the `client`, `log`, `session`, and `sessionId` fields available to `tool.execute` (see [Session ID and Request ID Tracking](#session-id-and-request-id-tracking)); `reportProgress` and `streamContent` are not included since they are tied to a tool call's progress token:
+
+```ts
+server.addResource({
+  uri: "file:///logs/app.log",
+  name: "Application Logs",
+  mimeType: "text/plain",
+  async load(auth, context) {
+    context.log.info("loading application logs", { requestedBy: auth?.userId });
+
+    return {
+      text: await readLogFile(),
+    };
+  },
+});
+```
+
 ### Resource templates
 
 You can also define resource templates:
@@ -1352,6 +1369,8 @@ server.addResourceTemplate({
   },
 });
 ```
+
+Like plain resources, `load` also receives `auth` and `context` as its second and third arguments (see [Resources](#resources)).
 
 #### Resource template argument auto-completion
 
@@ -1512,6 +1531,27 @@ server.addPrompt({
     },
   ],
   load: async (args) => {
+    return `Generate a concise but descriptive commit message for these changes:\n\n${args.changes}`;
+  },
+});
+```
+
+Like resources, `load` also receives `auth` and `context` as its second and third arguments (see [Resources](#resources)):
+
+```ts
+server.addPrompt({
+  name: "git-commit",
+  description: "Generate a Git commit message",
+  arguments: [
+    {
+      name: "changes",
+      description: "Git diff or description of changes",
+      required: true,
+    },
+  ],
+  load: async (args, auth, context) => {
+    context.log.debug("generating git commit prompt", { user: auth?.userId });
+
     return `Generate a concise but descriptive commit message for these changes:\n\n${args.changes}`;
   },
 });

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -2747,10 +2747,13 @@ test("provides auth to resources", async () => {
   });
 
   expect(resourceLoad).toHaveBeenCalledTimes(1);
-  expect(resourceLoad).toHaveBeenCalledWith({
-    role: "admin",
-    userId: 42,
-  });
+  expect(resourceLoad).toHaveBeenCalledWith(
+    {
+      role: "admin",
+      userId: 42,
+    },
+    expect.anything(),
+  );
 
   expect(result).toEqual({
     contents: [
@@ -2842,6 +2845,7 @@ test("provides auth to resource templates", async () => {
   expect(templateLoad).toHaveBeenCalledWith(
     { resourceId: "resource-123" },
     { permissions: ["read", "write"], userId: 99 },
+    expect.anything(),
   );
 
   expect(result).toEqual({
@@ -2939,6 +2943,7 @@ test("provides auth to resource templates returning arrays", async () => {
   expect(templateLoad).toHaveBeenCalledWith(
     { category: "reports" },
     { accessLevel: 3, teamId: "team-alpha" },
+    expect.anything(),
   );
 
   expect(result).toEqual({
@@ -3134,6 +3139,7 @@ test("provides auth to prompt load function", async () => {
   expect(promptLoad).toHaveBeenCalledWith(
     { option: "dashboard" },
     { level: "admin", username: "testuser" },
+    expect.anything(),
   );
 
   expect(result).toEqual({
@@ -4624,6 +4630,151 @@ test("tools can access client info", async () => {
           return `Client name: ${clientInfo?.name || "unknown"}\nClient version: ${clientInfo?.version || "unknown"}`;
         },
         name: "get-client-info",
+      });
+
+      return server;
+    },
+  });
+});
+
+test("resources can access client info via load context", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const result = await client.readResource({
+        uri: "file:///logs/app.log",
+      });
+
+      expect(result.contents).toHaveLength(1);
+      const text = (result.contents[0] as { text: string } | undefined)
+        ?.text as string;
+      expect(text).toContain("Client name:");
+      expect(text).toContain("Client version:");
+      expect(text).toMatch(/Client name:\s+\w+/);
+      expect(text).toMatch(/Client version:\s+[\d.]+/);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addResource({
+        async load(_auth, context) {
+          expect(context).toBeDefined();
+          expect(context?.log.debug).toBeInstanceOf(Function);
+          expect(context?.log.info).toBeInstanceOf(Function);
+          expect(context?.log.warn).toBeInstanceOf(Function);
+          expect(context?.log.error).toBeInstanceOf(Function);
+          expect(context).not.toHaveProperty("reportProgress");
+          expect(context).not.toHaveProperty("streamContent");
+
+          const clientInfo = context?.client.version;
+          return {
+            text: `Client name: ${clientInfo?.name || "unknown"}\nClient version: ${clientInfo?.version || "unknown"}`,
+          };
+        },
+        mimeType: "text/plain",
+        name: "Application Logs",
+        uri: "file:///logs/app.log",
+      });
+
+      return server;
+    },
+  });
+});
+
+test("resource templates can access client info via load context", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const result = await client.readResource({
+        uri: "user://profile/123",
+      });
+
+      expect(result.contents).toHaveLength(1);
+      const text = (result.contents[0] as { text: string } | undefined)
+        ?.text as string;
+      expect(text).toContain("Client name:");
+      expect(text).toContain("Client version:");
+      expect(text).toMatch(/Client name:\s+\w+/);
+      expect(text).toMatch(/Client version:\s+[\d.]+/);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addResourceTemplate({
+        arguments: [
+          {
+            name: "userId",
+            required: true,
+          },
+        ],
+        async load(_args, _auth, context) {
+          expect(context).toBeDefined();
+          expect(context?.log.info).toBeInstanceOf(Function);
+          expect(context).not.toHaveProperty("reportProgress");
+          expect(context).not.toHaveProperty("streamContent");
+
+          const clientInfo = context?.client.version;
+          return {
+            text: `Client name: ${clientInfo?.name || "unknown"}\nClient version: ${clientInfo?.version || "unknown"}`,
+          };
+        },
+        mimeType: "text/plain",
+        name: "User Profile",
+        uriTemplate: "user://profile/{userId}",
+      });
+
+      return server;
+    },
+  });
+});
+
+test("prompts can access client info via load context", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const result = await client.getPrompt({
+        arguments: {
+          changes: "foo",
+        },
+        name: "git-commit",
+      });
+
+      const message = result.messages[0]?.content;
+      expect(message).toHaveProperty("type", "text");
+      const text = (message as { text: string }).text;
+      expect(text).toContain("Client name:");
+      expect(text).toContain("Client version:");
+      expect(text).toMatch(/Client name:\s+\w+/);
+      expect(text).toMatch(/Client version:\s+[\d.]+/);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addPrompt({
+        arguments: [
+          {
+            description: "Git diff or description of changes",
+            name: "changes",
+            required: true,
+          },
+        ],
+        description: "Generate a Git commit message",
+        async load(_args, _auth, context) {
+          expect(context).toBeDefined();
+          expect(context?.log.info).toBeInstanceOf(Function);
+          expect(context).not.toHaveProperty("reportProgress");
+          expect(context).not.toHaveProperty("streamContent");
+
+          const clientInfo = context?.client.version;
+          return `Client name: ${clientInfo?.name || "unknown"}\nClient version: ${clientInfo?.version || "unknown"}`;
+        },
+        name: "git-commit",
       });
 
       return server;

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -242,6 +242,18 @@ type Extras = Record<string, Extra>;
 
 type Literal = boolean | null | number | string | undefined;
 
+/**
+ * Context passed to `load` for resources, resource templates, and prompts.
+ *
+ * This is a subset of the tool execution {@link Context}. `reportProgress`
+ * and `streamContent` are tied to a tool call's progress token / streaming
+ * notification and are not available outside of `tool.execute`.
+ */
+type LoadContext<T extends FastMCPSessionAuth> = Omit<
+  Context<T>,
+  "reportProgress" | "streamContent"
+>;
+
 type Progress = {
   /**
    * The progress thus far. This should increase every time progress is made, even if the total is unknown.
@@ -429,7 +441,11 @@ type InputPrompt<
   arguments?: InputPromptArgument<T>[];
   complete?: (name: string, value: string, auth?: T) => Promise<Completion>;
   description?: string;
-  load: (args: Args, auth?: T) => Promise<PromptResult>;
+  load: (
+    args: Args,
+    auth?: T,
+    context?: LoadContext<T>,
+  ) => Promise<PromptResult>;
   name: string;
 };
 
@@ -453,6 +469,7 @@ type InputResourceTemplate<
   load: (
     args: ResourceTemplateArgumentsToObject<Arguments>,
     auth?: T,
+    context?: LoadContext<T>,
   ) => Promise<ResourceResult | ResourceResult[]>;
   mimeType?: string;
   name: string;
@@ -486,7 +503,11 @@ type Prompt<
   arguments?: PromptArgument<T>[];
   complete?: (name: string, value: string, auth?: T) => Promise<Completion>;
   description?: string;
-  load: (args: Args, auth?: T) => Promise<PromptResult>;
+  load: (
+    args: Args,
+    auth?: T,
+    context?: LoadContext<T>,
+  ) => Promise<PromptResult>;
   name: string;
 };
 
@@ -514,7 +535,10 @@ type PromptResult = Pick<GetPromptResult, "messages"> | string;
 type Resource<T extends FastMCPSessionAuth> = {
   complete?: (name: string, value: string, auth?: T) => Promise<Completion>;
   description?: string;
-  load: (auth?: T) => Promise<ResourceResult | ResourceResult[]>;
+  load: (
+    auth?: T,
+    context?: LoadContext<T>,
+  ) => Promise<ResourceResult | ResourceResult[]>;
   mimeType?: string;
   name: string;
   uri: string;
@@ -543,6 +567,7 @@ type ResourceTemplate<
   load: (
     args: ResourceTemplateArgumentsToObject<Arguments>,
     auth?: T,
+    context?: LoadContext<T>,
   ) => Promise<ResourceResult | ResourceResult[]>;
   mimeType?: string;
   name: string;
@@ -1446,6 +1471,70 @@ export class FastMCPSession<
     });
   }
 
+  /**
+   * Builds the context object passed as the third argument to
+   * `resource.load` / `resourceTemplate.load` / `prompt.load`.
+   *
+   * This mirrors the `client`, `log`, `requestId`, `session`, and
+   * `sessionId` fields available to `tool.execute` via {@link Context}.
+   * `reportProgress` and `streamContent` are intentionally omitted: they
+   * are tied to a tool call's progress token / streaming notification,
+   * which resource and prompt reads do not have.
+   */
+  #createLoadContext(meta?: Record<string, unknown>): LoadContext<T> {
+    return {
+      client: {
+        version: this.#server.getClientVersion(),
+      },
+      log: this.#createLog(),
+      requestId:
+        typeof meta?.requestId === "string" ? meta.requestId : undefined,
+      session: this.#auth,
+      sessionId: this.#sessionId,
+    };
+  }
+
+  #createLog(): Context<T>["log"] {
+    return {
+      debug: (message: string, context?: SerializableValue) => {
+        this.#server.sendLoggingMessage({
+          data: {
+            context,
+            message,
+          },
+          level: "debug",
+        });
+      },
+      error: (message: string, context?: SerializableValue) => {
+        this.#server.sendLoggingMessage({
+          data: {
+            context,
+            message,
+          },
+          level: "error",
+        });
+      },
+      info: (message: string, context?: SerializableValue) => {
+        this.#server.sendLoggingMessage({
+          data: {
+            context,
+            message,
+          },
+          level: "info",
+        });
+      },
+      warn: (message: string, context?: SerializableValue) => {
+        this.#server.sendLoggingMessage({
+          data: {
+            context,
+            message,
+          },
+          level: "warning",
+        });
+      },
+    };
+  }
+
   #formatSchemaIssues(issues: readonly StandardSchemaV1.Issue[]): string {
     return this.#utils?.formatInvalidParamsErrorMessage
       ? this.#utils.formatInvalidParamsErrorMessage(issues)
@@ -1725,6 +1814,7 @@ export class FastMCPSession<
         result = await prompt.load(
           args as Record<string, string | undefined>,
           this.#auth,
+          this.#createLoadContext(request.params?._meta),
         );
       } catch (error) {
         const errorMessage =
@@ -1798,7 +1888,11 @@ export class FastMCPSession<
 
               const uri = uriTemplate.fill(match);
 
-              const result = await resourceTemplate.load(match, this.#auth);
+              const result = await resourceTemplate.load(
+                match,
+                this.#auth,
+                this.#createLoadContext(request.params?._meta),
+              );
 
               const resources = Array.isArray(result) ? result : [result];
               return {
@@ -1829,7 +1923,10 @@ export class FastMCPSession<
           let maybeArrayResult: Awaited<ReturnType<Resource<T>["load"]>>;
 
           try {
-            maybeArrayResult = await resource.load(this.#auth);
+            maybeArrayResult = await resource.load(
+              this.#auth,
+              this.#createLoadContext(request.params?._meta),
+            );
           } catch (error) {
             const errorMessage =
               error instanceof Error ? error.message : String(error);
@@ -2044,44 +2141,7 @@ export class FastMCPSession<
           }
         };
 
-        const log = {
-          debug: (message: string, context?: SerializableValue) => {
-            this.#server.sendLoggingMessage({
-              data: {
-                context,
-                message,
-              },
-              level: "debug",
-            });
-          },
-          error: (message: string, context?: SerializableValue) => {
-            this.#server.sendLoggingMessage({
-              data: {
-                context,
-                message,
-              },
-              level: "error",
-            });
-          },
-          info: (message: string, context?: SerializableValue) => {
-            this.#server.sendLoggingMessage({
-              data: {
-                context,
-                message,
-              },
-              level: "info",
-            });
-          },
-          warn: (message: string, context?: SerializableValue) => {
-            this.#server.sendLoggingMessage({
-              data: {
-                context,
-                message,
-              },
-              level: "warning",
-            });
-          },
-        };
+        const log = this.#createLog();
 
         // Create a promise for tool execution
         // Streams partial results while a tool is still executing
@@ -3609,6 +3669,7 @@ export type {
   ImageContent,
   InputPrompt,
   InputPromptArgument,
+  LoadContext,
   LoggingLevel,
   Progress,
   Prompt,


### PR DESCRIPTION
## Summary

Issue #171 was resolved for **tools** by #173, which added `client.version` / `getClientVersion()` to the `Context<T>` object passed to `tool.execute`. The issue was left open because a follow-up comment (attiks, 2025-09-12) pointed out that `Resource.load`, `ResourceTemplate.load`, and `Prompt.load` never receive a `Context`, so resources and prompts have no way to read client name/version, log through the MCP logging channel, or access session / session ID / request ID.

I re-checked `src/FastMCP.ts` on current `main` (b170e78) before starting: `InputPrompt.load` / `Prompt.load` were `(args, auth?) => ...`, `InputResourceTemplate.load` / `ResourceTemplate.load` were `(args, auth?) => ...`, and `Resource.load` was `(auth?) => ...` — none received anything like `Context`. This PR closes that gap.

## What changed

- Added `LoadContext<T>`, defined as `Omit<Context<T>, "reportProgress" | "streamContent">`, and exported it alongside `Context`.
  - `reportProgress` and `streamContent` are intentionally excluded: both are tied to a tool call's progress token / streaming notification, which resource and prompt reads do not have.
- `Resource.load`, `ResourceTemplate.load`, and `Prompt.load` (and their `Input*` counterparts) now accept an additional, optional trailing `context?: LoadContext<T>` parameter:
  - `Resource.load: (auth?: T, context?: LoadContext<T>) => ...`
  - `ResourceTemplate.load` / `Prompt.load`: `(args, auth?: T, context?: LoadContext<T>) => ...`
- `FastMCPSession` gained two private helpers, `#createLoadContext()` and `#createLog()`, so the `client`/`log`/`session`/`sessionId`/`requestId` construction is shared between the tool, resource, and prompt handlers instead of being duplicated (the tool handler's inline `log` object was refactored to call `#createLog()`).
- Updated the three call sites (`GetPromptRequestSchema`, and the two `resource.load` / `resourceTemplate.load` calls inside `ReadResourceRequestSchema`) to pass the new context through.
- README: added `auth`/`context` notes and short examples for Resources, Resource templates, and Prompts.

## Backward compatibility

The new parameter is additive and appended **after** the existing `auth` parameter, so:
- Existing `load` implementations with fewer parameters (`load()`, `load(auth)`, `load(args)`, `load(args, auth)`) keep compiling and behaving exactly as before — JS/TS callers are free to ignore extra arguments.
- No existing public API, type export, or runtime behavior for tools was touched (the tool `Context` shape is unchanged; only the `log` object construction was extracted into a shared private method).
- `FastMCP.embedded()` (the top-level convenience method, not a request handler) still calls `.load()` with no context, since it has no active request/session to source one from — this is unchanged.

## Testing

- Added 3 new tests: resources / resource templates / prompts reading `context.client.version`, plus assertions that `reportProgress` and `streamContent` are *not* present on the load context (locking in the intentional subset).
- Updated 4 pre-existing "provides auth to ..." tests whose `vi.fn()` mocks assert `toHaveBeenCalledWith(...)` — added `expect.anything()` for the new third argument.
- `npm run build` (tsup): passes.
- `npx vitest run`: 370/370 tests pass.
- `npx eslint .` and `npx prettier --check` on the touched files: clean.
- `npx tsc --noEmit`: clean.

(Note: I used `npm` instead of `pnpm` to install dependencies locally — `pnpm install` crashed with a native `STATUS_STACK_BUFFER_OVERRUN` on this machine, unrelated to this change. `pnpm-lock.yaml` was not touched.)

Closes #171.
