### PR TITLE
feat: support resource subscriptions and list-changed capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1406,6 +1406,26 @@ server.addResource({
 });
 ```
 
+#### Subscribing to resource updates
+
+Clients can subscribe to a resource with the MCP [`resources/subscribe`](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#subscriptions) method to be notified whenever its contents change. FastMCP advertises the `subscribe` capability automatically for any server that exposes resources, tracks each client's subscriptions, and lets you emit an update with `sendResourceUpdated`:
+
+```ts
+server.addResource({
+  uri: "file:///logs/app.log",
+  name: "Application Logs",
+  mimeType: "text/plain",
+  async load() {
+    return { text: await readLogFile() };
+  },
+});
+
+// Whenever the underlying data changes, notify subscribed clients:
+await server.sendResourceUpdated("file:///logs/app.log");
+```
+
+`sendResourceUpdated` only notifies clients that have subscribed to the given URI, so it is safe to call whenever your data changes. FastMCP also advertises the `listChanged` capability for resources and prompts and emits `notifications/resources/list_changed` / `notifications/prompts/list_changed` automatically when you add or remove resources, resource templates, or prompts at runtime.
+
 ### Resource templates
 
 You can also define resource templates:

--- a/src/FastMCP.resource-subscriptions.test.ts
+++ b/src/FastMCP.resource-subscriptions.test.ts
@@ -1,0 +1,188 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ResourceUpdatedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import { getRandomPort } from "get-port-please";
+import { setTimeout as delay } from "timers/promises";
+import { describe, expect, it } from "vitest";
+
+import { FastMCP, FastMCPSession } from "./FastMCP.js";
+
+const runWithTestServer = async ({
+  run,
+  server: providedServer,
+}: {
+  run: ({
+    client,
+    server,
+    session,
+  }: {
+    client: Client;
+    server: FastMCP;
+    session: FastMCPSession;
+  }) => Promise<void>;
+  server?: FastMCP;
+}) => {
+  const port = await getRandomPort();
+
+  const server =
+    providedServer ??
+    new FastMCP({
+      name: "Test",
+      version: "1.0.0",
+    });
+
+  await server.start({
+    httpStream: {
+      host: "127.0.0.1",
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const client = new Client(
+      {
+        name: "example-client",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`),
+    );
+
+    const session = await new Promise<FastMCPSession>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Connection timeout")),
+        10000,
+      );
+      server.on("connect", async (event) => {
+        clearTimeout(timeout);
+        await event.session.waitForReady();
+        resolve(event.session);
+      });
+
+      client.connect(transport).catch(reject);
+    });
+
+    await delay(100); // Small grace period
+    await run({ client, server, session });
+  } finally {
+    await server.stop();
+  }
+};
+
+const createServerWithResource = () => {
+  const server = new FastMCP({ name: "Test", version: "1.0.0" });
+
+  server.addResource({
+    load: async () => ({ text: "content" }),
+    name: "example",
+    uri: "test://example",
+  });
+
+  return server;
+};
+
+describe("FastMCP resource subscriptions", () => {
+  it("advertises resource subscribe and listChanged capabilities", async () => {
+    await runWithTestServer({
+      run: async ({ client }) => {
+        expect(client.getServerCapabilities()?.resources).toEqual({
+          listChanged: true,
+          subscribe: true,
+        });
+      },
+      server: createServerWithResource(),
+    });
+  });
+
+  it("advertises prompt listChanged capability", async () => {
+    const server = new FastMCP({ name: "Test", version: "1.0.0" });
+
+    server.addPrompt({
+      load: async () => "hello",
+      name: "example",
+    });
+
+    await runWithTestServer({
+      run: async ({ client }) => {
+        expect(client.getServerCapabilities()?.prompts).toEqual({
+          listChanged: true,
+        });
+      },
+      server,
+    });
+  });
+
+  it("notifies a subscribed client when a resource is updated", async () => {
+    await runWithTestServer({
+      run: async ({ client, server }) => {
+        const updates: string[] = [];
+
+        client.setNotificationHandler(
+          ResourceUpdatedNotificationSchema,
+          (notification) => {
+            updates.push(notification.params.uri);
+          },
+        );
+
+        await client.subscribeResource({ uri: "test://example" });
+
+        await server.sendResourceUpdated("test://example");
+        await delay(200);
+
+        expect(updates).toEqual(["test://example"]);
+      },
+      server: createServerWithResource(),
+    });
+  });
+
+  it("does not notify a client that has not subscribed", async () => {
+    await runWithTestServer({
+      run: async ({ client, server }) => {
+        const updates: string[] = [];
+
+        client.setNotificationHandler(
+          ResourceUpdatedNotificationSchema,
+          (notification) => {
+            updates.push(notification.params.uri);
+          },
+        );
+
+        await server.sendResourceUpdated("test://example");
+        await delay(200);
+
+        expect(updates).toEqual([]);
+      },
+      server: createServerWithResource(),
+    });
+  });
+
+  it("stops notifying after the client unsubscribes", async () => {
+    await runWithTestServer({
+      run: async ({ client, server }) => {
+        const updates: string[] = [];
+
+        client.setNotificationHandler(
+          ResourceUpdatedNotificationSchema,
+          (notification) => {
+            updates.push(notification.params.uri);
+          },
+        );
+
+        await client.subscribeResource({ uri: "test://example" });
+        await client.unsubscribeResource({ uri: "test://example" });
+
+        await server.sendResourceUpdated("test://example");
+        await delay(200);
+
+        expect(updates).toEqual([]);
+      },
+      server: createServerWithResource(),
+    });
+  });
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -30,6 +30,8 @@ import {
   Tool as SDKTool,
   ServerCapabilities,
   SetLevelRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { StandardSchemaV1 } from "@standard-schema/spec";
 import { EventEmitter } from "events";
@@ -1164,6 +1166,13 @@ export class FastMCPSession<
    */
   #sessionId?: string;
 
+  /**
+   * Resource URIs the connected client has subscribed to via
+   * `resources/subscribe`. Used to scope `notifications/resources/updated`
+   * to interested clients only.
+   */
+  #subscriptions: Set<string> = new Set();
+
   #utils?: ServerOptions<T>["utils"];
 
   constructor({
@@ -1214,7 +1223,7 @@ export class FastMCPSession<
     }
 
     if (resources.length || resourcesTemplates.length) {
-      this.#capabilities.resources = {};
+      this.#capabilities.resources = { listChanged: true, subscribe: true };
     }
 
     if (prompts.length) {
@@ -1222,7 +1231,7 @@ export class FastMCPSession<
         this.addPrompt(prompt);
       }
 
-      this.#capabilities.prompts = {};
+      this.#capabilities.prompts = { listChanged: true };
     }
 
     this.#capabilities.logging = {};
@@ -1251,6 +1260,7 @@ export class FastMCPSession<
       }
 
       this.setupResourceHandlers();
+      this.setupResourceSubscriptionHandlers();
 
       if (resourcesTemplates.length) {
         for (const resourceTemplate of resourcesTemplates) {
@@ -1427,6 +1437,29 @@ export class FastMCPSession<
     }
     this.setupResourceTemplateHandlers();
     this.triggerListChangedNotification("notifications/resources/list_changed");
+  }
+
+  /**
+   * Notifies the connected client that the contents of a resource have changed.
+   *
+   * The `notifications/resources/updated` notification is only sent when the
+   * client has subscribed to the URI via `resources/subscribe`; otherwise this
+   * is a no-op.
+   */
+  async sendResourceUpdated(uri: string) {
+    if (!this.#subscriptions.has(uri)) {
+      return;
+    }
+
+    try {
+      await this.#server.sendResourceUpdated({ uri });
+    } catch (error) {
+      this.#logger.error(
+        `[FastMCP error] failed to send resources/updated notification for '${uri}'.\n\n${
+          error instanceof Error ? error.stack : JSON.stringify(error)
+        }`,
+      );
+    }
   }
 
   toolsListChanged(tools: Tool<T>[]) {
@@ -1985,6 +2018,20 @@ export class FastMCPSession<
         });
       },
     );
+  }
+
+  private setupResourceSubscriptionHandlers() {
+    this.#server.setRequestHandler(SubscribeRequestSchema, (request) => {
+      this.#subscriptions.add(request.params.uri);
+
+      return {};
+    });
+
+    this.#server.setRequestHandler(UnsubscribeRequestSchema, (request) => {
+      this.#subscriptions.delete(request.params.uri);
+
+      return {};
+    });
   }
 
   private setupResourceTemplateHandlers() {
@@ -2748,6 +2795,22 @@ export class FastMCP<
     if (this.#serverState === ServerState.Running) {
       this.#toolsListChanged(this.#tools);
     }
+  }
+
+  /**
+   * Notifies subscribed clients that a resource's contents have changed.
+   *
+   * Sends a `notifications/resources/updated` notification to every connected
+   * session that has subscribed to `uri` via `resources/subscribe`. Sessions
+   * that have not subscribed to the URI are skipped, so it is safe to call this
+   * whenever the underlying data changes.
+   *
+   * @param uri - The URI of the resource whose contents changed.
+   */
+  public async sendResourceUpdated(uri: string): Promise<void> {
+    await Promise.all(
+      this.#sessions.map((session) => session.sendResourceUpdated(uri)),
+    );
   }
 
   /**


### PR DESCRIPTION
Closes #185.

Adds support for MCP resource subscriptions and makes the server's list-changed capabilities discoverable.

### What's added

- **Capabilities**: advertise `resources: { listChanged: true, subscribe: true }` and `prompts: { listChanged: true }` when those features are enabled. The server already emitted `notifications/resources/list_changed` and `notifications/prompts/list_changed`, but never advertised the capability, so spec-compliant clients didn't know to expect them.
- **Subscribe/unsubscribe**: handlers for `resources/subscribe` and `resources/unsubscribe`, tracked per session.
- **Update notifications**: `server.sendResourceUpdated(uri)` emits `notifications/resources/updated` only to clients that subscribed to that URI ([spec](https://modelcontextprotocol.io/specification/2025-06-18/server/resources#subscriptions)).

### Example

```ts
server.addResource({
  uri: "file:///logs/app.log",
  name: "Application Logs",
  mimeType: "text/plain",
  async load() {
    return { text: await readLogFile() };
  },
});

// When the underlying data changes, notify subscribed clients:
await server.sendResourceUpdated("file:///logs/app.log");
```

`sendResourceUpdated` is a no-op for URIs no client has subscribed to, so it's safe to call whenever data changes.

### Design note

`subscribe: true` is advertised for every server that exposes resources rather than being gated behind an opt-in flag, since the subscribe/update plumbing is generic and `sendResourceUpdated` is a no-op for URIs nobody subscribed to. If you'd rather make it opt-in, happy to gate it behind a flag.

### Spec references

- `resources/subscribe`, `resources/unsubscribe`, `notifications/resources/updated`: https://modelcontextprotocol.io/specification/2025-06-18/server/resources#subscriptions
- `listChanged` notifications for resources and prompts.

### Tests

New `src/FastMCP.resource-subscriptions.test.ts` covers capability advertisement (resources + prompts), notification delivery to a subscribed client, no delivery without a subscription, and unsubscribe stopping delivery. Full suite green: **388 tests passing**, plus `prettier`, `eslint`, and `tsc --noEmit` all clean.
