### PR TITLE
fix(auth): use timing-safe comparison for JWT and consent signatures

### DIFF
--- a/src/auth/utils/consent.test.ts
+++ b/src/auth/utils/consent.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { ConsentData } from "../types.js";
+
+import { ConsentManager } from "./consent.js";
+
+describe("ConsentManager.validateConsentCookie", () => {
+  const manager = new ConsentManager("test-secret-key");
+  const data: ConsentData = {
+    clientName: "MCP Client",
+    provider: "github",
+    scope: ["read"],
+    timestamp: Date.now(),
+    transactionId: "txn-1",
+  };
+
+  it("round-trips a validly signed cookie", () => {
+    const cookie = manager.signConsentCookie(data);
+    const result = manager.validateConsentCookie(cookie);
+
+    expect(result?.transactionId).toBe("txn-1");
+    expect(result?.provider).toBe("github");
+  });
+
+  // Regression test for CWE-208: the cookie's HMAC signature is compared with
+  // crypto.timingSafeEqual behind a length guard.
+  it("rejects a same-length forged signature", () => {
+    const cookie = manager.signConsentCookie(data);
+    const [payloadB64, signature] = cookie.split(".");
+    // Flip one hex char while preserving length → exercises timingSafeEqual.
+    const forged = (signature[0] === "a" ? "b" : "a") + signature.slice(1);
+    expect(forged).toHaveLength(signature.length);
+    expect(forged).not.toBe(signature);
+
+    expect(manager.validateConsentCookie(`${payloadB64}.${forged}`)).toBeNull();
+  });
+
+  it("rejects a different-length signature", () => {
+    const cookie = manager.signConsentCookie(data);
+    const [payloadB64, signature] = cookie.split(".");
+
+    expect(
+      manager.validateConsentCookie(`${payloadB64}.${signature}extra`),
+    ).toBeNull();
+  });
+});

--- a/src/auth/utils/consent.ts
+++ b/src/auth/utils/consent.ts
@@ -3,7 +3,7 @@
  * Handles user consent flow for OAuth authorization
  */
 
-import { createHmac } from "crypto";
+import { createHmac, timingSafeEqual } from "crypto";
 
 import type { ConsentData, OAuthTransaction } from "../types.js";
 
@@ -277,7 +277,14 @@ export class ConsentManager {
       const payload = Buffer.from(payloadB64, "base64").toString("utf8");
       const expectedSignature = this.sign(payload);
 
-      if (signature !== expectedSignature) {
+      // Constant-time HMAC comparison (CWE-208): a plain `!==` leaks, via
+      // timing, how many leading bytes of the cookie signature are correct.
+      const actualBuf = Buffer.from(signature);
+      const expectedBuf = Buffer.from(expectedSignature);
+      if (
+        actualBuf.length !== expectedBuf.length ||
+        !timingSafeEqual(actualBuf, expectedBuf)
+      ) {
         return null;
       }
 

--- a/src/auth/utils/jwtIssuer.test.ts
+++ b/src/auth/utils/jwtIssuer.test.ts
@@ -120,6 +120,37 @@ describe("JWTIssuer", () => {
       expect(result.error).toBe("Invalid signature");
     });
 
+    // Regression tests for CWE-208 (observable timing discrepancy). The
+    // signature is compared with crypto.timingSafeEqual behind a length guard;
+    // these lock that behaviour in.
+    it("should reject a same-length forged signature", async () => {
+      const token = issuer.issueAccessToken("client-123", ["read"]);
+      const [header, payload, signature] = token.split(".");
+      // Flip one character while preserving length so the comparison reaches
+      // timingSafeEqual, not just the length pre-check.
+      const forged = (signature[0] === "A" ? "B" : "A") + signature.slice(1);
+      expect(forged).toHaveLength(signature.length);
+      expect(forged).not.toBe(signature);
+
+      const result = await issuer.verify(`${header}.${payload}.${forged}`);
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("Invalid signature");
+    });
+
+    it("should reject a longer signature without throwing", async () => {
+      const token = issuer.issueAccessToken("client-123", ["read"]);
+      const [header, payload, signature] = token.split(".");
+      // The length guard must reject this as "Invalid signature" rather than
+      // letting timingSafeEqual throw (which would surface the generic catch).
+      const result = await issuer.verify(
+        `${header}.${payload}.${signature}extra`,
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("Invalid signature");
+    });
+
     it("should reject expired tokens", async () => {
       const shortLivedIssuer = new JWTIssuer({
         accessTokenTtl: 1, // 1 second

--- a/src/auth/utils/jwtIssuer.ts
+++ b/src/auth/utils/jwtIssuer.ts
@@ -3,7 +3,7 @@
  * Issues and validates short-lived JWTs that reference upstream provider tokens
  */
 
-import { createHmac, pbkdf2, randomBytes } from "crypto";
+import { createHmac, pbkdf2, randomBytes, timingSafeEqual } from "crypto";
 import { promisify } from "util";
 
 import {
@@ -172,9 +172,18 @@ export class JWTIssuer {
 
       const [headerB64, payloadB64, signatureB64] = parts;
 
-      // Verify signature
+      // Verify signature in constant time. A plain `!==` on the base64url HMAC
+      // short-circuits on the first differing byte, leaking via response timing
+      // how many leading bytes are correct — an oracle for forging a valid MAC
+      // (CWE-208). timingSafeEqual requires equal-length buffers, so a length
+      // mismatch (the signature length is not secret) is rejected up front.
       const expectedSignature = this.sign(`${headerB64}.${payloadB64}`);
-      if (signatureB64 !== expectedSignature) {
+      const actualBuf = Buffer.from(signatureB64);
+      const expectedBuf = Buffer.from(expectedSignature);
+      if (
+        actualBuf.length !== expectedBuf.length ||
+        !timingSafeEqual(actualBuf, expectedBuf)
+      ) {
         return {
           error: "Invalid signature",
           valid: false,


### PR DESCRIPTION
## What & why

`JWTIssuer.verify()` and `ConsentManager.validateConsentCookie()` compared the presented HMAC signature against the expected one with a plain `!==`:

```ts
// src/auth/utils/jwtIssuer.ts
const expectedSignature = this.sign(`${headerB64}.${payloadB64}`);
if (signatureB64 !== expectedSignature) { ... }   // non-constant-time
```

`===`/`!==` on strings short-circuits at the first differing byte, so response time scales with the length of the correct prefix of the signature — an observable timing discrepancy (CWE-208) that acts as an oracle for forging a valid MAC one byte at a time. `signatureB64` is fully attacker-controlled (it's the third segment of the bearer token the caller submits).

This matters because the JWT path is the default token-swap gate — `enableTokenSwap` is on by default — and `verify()` guards `loadUpstreamTokens`, `extractJti`, and **refresh-token exchange** (a forged refresh token would mint new access tokens). `ConsentManager.validateConsentCookie()` has the identical pattern on the consent cookie's HMAC. `timingSafeEqual` appeared nowhere in the codebase.

## Change

Compare with `crypto.timingSafeEqual`, guarding the equal-length precondition it requires (the signature length is not secret, so a length mismatch is rejected up front):

```ts
const expectedSignature = this.sign(`${headerB64}.${payloadB64}`);
const actualBuf = Buffer.from(signatureB64);
const expectedBuf = Buffer.from(expectedSignature);
if (actualBuf.length !== expectedBuf.length || !timingSafeEqual(actualBuf, expectedBuf)) {
  return { error: "Invalid signature", valid: false };
}
```

Same pattern applied to `validateConsentCookie`. `pkce.ts` also uses `===`, but it compares a client-supplied verifier against a public challenge (not a server secret), so it is intentionally left out of scope to keep this PR tight.

## Tests

- `jwtIssuer.test.ts`: a same-length forged signature is rejected via the constant-time path; a longer signature is rejected by the length guard **without throwing** (preserving the specific `"Invalid signature"` result rather than the generic catch — the existing `invalid-signature` and tampered-payload tests already cover the shorter/same-length cases and still pass).
- New `consent.test.ts`: round-trips a valid cookie, and rejects same-length-forged and different-length signatures.

Verified locally: `tsc --noEmit` clean, `prettier`/`eslint` clean, `vitest run` — 22/22 pass.

---
_AI-assisted; reviewed and verified by the author._
