### PR TITLE
Harden CI/CD supply chain (7 recommendations)

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -19,14 +19,14 @@ jobs:
           - 24
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 9
       - name: Setup NodeJS ${{ matrix.node }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node }}
           cache: "pnpm"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,20 +9,20 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       issues: write
       pull-requests: write
       id-token: write
     steps:
       - name: setup repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1
         with:
           version: 9
       - name: Setup NodeJS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
           cache: "pnpm"


### PR DESCRIPTION
This PR applies deterministic supply-chain hardening to the CI/CD workflows: immutable action refs and least-privilege permissions. No functional changes are intended.

Affected workflows:

- `.github/workflows/feature.yaml`
- `.github/workflows/main.yaml`

No behavioral changes expected. Only immutable SHA pinning and hardening fixes.

---

Prepared with Sentinel after manual review.