### PR TITLE
fix(auth): add timeout to upstream OAuth and discovery fetch calls

### DIFF
--- a/src/DiscoveryDocumentCache.test.ts
+++ b/src/DiscoveryDocumentCache.test.ts
@@ -340,3 +340,41 @@ test("handles concurrent requests with slow fetch correctly", async () => {
 
   fetchSpy.mockRestore();
 });
+
+test("times out when the upstream discovery endpoint hangs", async () => {
+  const cache = new DiscoveryDocumentCache({ timeoutMs: 50 });
+  const testUrl = "https://auth.example.com/.well-known/openid-configuration";
+  // simulate an upstream that never answers: the promise only rejects when
+  // the caller's AbortSignal fires, mirroring an in-flight fetch abort
+  const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(
+    (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation timed out.", "TimeoutError"));
+        });
+      }),
+  );
+
+  await expect(cache.get(testUrl)).rejects.toThrow(
+    `Failed to fetch discovery document from ${testUrl}: timed out after 50ms`,
+  );
+
+  fetchSpy.mockRestore();
+});
+
+test("passes an AbortSignal to the discovery fetch", async () => {
+  const cache = new DiscoveryDocumentCache();
+  const testUrl = "https://auth.example.com/.well-known/openid-configuration";
+  const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+    json: async () => ({}),
+    ok: true,
+  } as Response);
+
+  await cache.get(testUrl);
+
+  const init = fetchSpy.mock.calls[0]?.[1];
+
+  expect(init?.signal).toBeInstanceOf(AbortSignal);
+
+  fetchSpy.mockRestore();
+});

--- a/src/DiscoveryDocumentCache.ts
+++ b/src/DiscoveryDocumentCache.ts
@@ -13,13 +13,17 @@ export class DiscoveryDocumentCache {
 
   #inFlight: Map<string, Promise<unknown>> = new Map();
 
+  #timeoutMs: number;
+
   #ttl: number;
 
   /**
    * @param options - configuration options
+   * @param options.timeoutMs - timeout in miliseconds for the upstream fetch
    * @param options.ttl - time-to-live in miliseconds
    */
-  public constructor(options: { ttl?: number } = {}) {
+  public constructor(options: { timeoutMs?: number; ttl?: number } = {}) {
+    this.#timeoutMs = options.timeoutMs ?? 10000; // default 10 seconds
     this.#ttl = options.ttl ?? 3600000; // default 1 hour
   }
 
@@ -97,8 +101,23 @@ export class DiscoveryDocumentCache {
   }
 
   async #fetchAndCache(url: string): Promise<unknown> {
-    // fetch fresh document
-    const res = await fetch(url);
+    // fetch fresh document, bounded by the configured timeout
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        signal: AbortSignal.timeout(this.#timeoutMs),
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === "AbortError" || error.name === "TimeoutError")
+      ) {
+        throw new Error(
+          `Failed to fetch discovery document from ${url}: timed out after ${this.#timeoutMs}ms`,
+        );
+      }
+      throw error;
+    }
 
     if (!res.ok) {
       throw new Error(

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_AUTHORIZATION_CODE_TTL,
   DEFAULT_REFRESH_TOKEN_TTL,
   DEFAULT_TRANSACTION_TTL,
+  DEFAULT_UPSTREAM_REQUEST_TIMEOUT_MS,
 } from "./types.js";
 import { ClaimsExtractor } from "./utils/claimsExtractor.js";
 import { ConsentManager } from "./utils/consent.js";
@@ -81,6 +82,7 @@ export class OAuthProxy {
       enableTokenSwap: true, // Enabled by default for security
       redirectPath: "/oauth/callback",
       transactionTtl: DEFAULT_TRANSACTION_TTL,
+      upstreamRequestTimeoutMs: DEFAULT_UPSTREAM_REQUEST_TIMEOUT_MS,
       upstreamTokenEndpointAuthMethod: "client_secret_basic",
       ...config,
     };
@@ -719,11 +721,7 @@ export class OAuthProxy {
       headers["Authorization"] = this.getBasicAuthHeader();
     }
 
-    const tokenResponse = await fetch(this.config.upstreamTokenEndpoint, {
-      body: new URLSearchParams(bodyParams),
-      headers,
-      method: "POST",
-    });
+    const tokenResponse = await this.fetchUpstream(bodyParams, headers);
 
     if (!tokenResponse.ok) {
       let errorCode = "server_error";
@@ -810,6 +808,39 @@ export class OAuthProxy {
     }
 
     return Object.keys(allClaims).length > 0 ? allClaims : null;
+  }
+
+  /**
+   * POST to the upstream token endpoint with a bounded wait.
+   *
+   * Maps an abort of the configured timeout signal to a clean OAuth error
+   * instead of letting the raw `TimeoutError`/`AbortError` propagate.
+   */
+  private async fetchUpstream(
+    bodyParams: Record<string, string>,
+    headers: Record<string, string>,
+  ): Promise<Response> {
+    let tokenResponse: Response;
+    try {
+      tokenResponse = await fetch(this.config.upstreamTokenEndpoint, {
+        body: new URLSearchParams(bodyParams),
+        headers,
+        method: "POST",
+        signal: AbortSignal.timeout(
+          this.config.upstreamRequestTimeoutMs ??
+            DEFAULT_UPSTREAM_REQUEST_TIMEOUT_MS,
+        ),
+      });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === "AbortError" || error.name === "TimeoutError")
+      ) {
+        throw new OAuthProxyError("server_error", "Upstream request timed out");
+      }
+      throw error;
+    }
+    return tokenResponse;
   }
 
   /**
@@ -904,11 +935,7 @@ export class OAuthProxy {
     }
 
     // Exchange refresh token with upstream provider
-    const tokenResponse = await fetch(this.config.upstreamTokenEndpoint, {
-      body: new URLSearchParams(bodyParams),
-      headers,
-      method: "POST",
-    });
+    const tokenResponse = await this.fetchUpstream(bodyParams, headers);
 
     if (!tokenResponse.ok) {
       let errorCode = "invalid_grant";
@@ -1354,11 +1381,7 @@ export class OAuthProxy {
     }
 
     // Exchange refresh token with upstream provider
-    const tokenResponse = await fetch(this.config.upstreamTokenEndpoint, {
-      body: new URLSearchParams(bodyParams),
-      headers,
-      method: "POST",
-    });
+    const tokenResponse = await this.fetchUpstream(bodyParams, headers);
 
     if (!tokenResponse.ok) {
       let errorCode = "invalid_grant";

--- a/src/auth/OAuthProxy.upstream-timeout.test.ts
+++ b/src/auth/OAuthProxy.upstream-timeout.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression tests for CWE-400 uncontrolled resource consumption in
+ * OAuthProxy: the upstream token/refresh fetch calls were bare `fetch(...)`
+ * with no timeout, so a hung or trickling identity provider stalled the
+ * corresponding authorize/token/refresh request indefinitely.
+ *
+ * These tests verify that every upstream call now carries an AbortSignal
+ * bounded by `upstreamRequestTimeoutMs` and that a timeout surfaces as a
+ * clean `OAuthProxyError("server_error", "Upstream request timed out")`
+ * instead of a raw `TimeoutError`/`AbortError`.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, vi } from "vitest";
+
+import { OAuthProxy } from "./OAuthProxy.js";
+
+/**
+ * Simulates an upstream that never answers: the returned promise only
+ * rejects when the caller's AbortSignal fires, mirroring how an in-flight
+ * fetch is rejected on abort.
+ */
+const mockHungUpstream = () =>
+  vi.spyOn(global, "fetch").mockImplementation(
+    (_input, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation timed out.", "TimeoutError"));
+        });
+      }),
+  );
+
+describe("OAuthProxy - Upstream Request Timeout", () => {
+  const baseConfig = {
+    baseUrl: "https://proxy.example.com",
+    consentRequired: false,
+    upstreamAuthorizationEndpoint: "https://provider.com/oauth/authorize",
+    upstreamClientId: "upstream-client-id",
+    upstreamClientSecret: "upstream-client-secret",
+    upstreamRequestTimeoutMs: 50,
+    upstreamTokenEndpoint: "https://provider.com/oauth/token",
+  };
+
+  const transaction = {
+    clientCallbackUrl: "https://client.example.com/callback",
+    clientCodeChallenge: "client-challenge",
+    clientCodeChallengeMethod: "S256",
+    clientId: "client-id",
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() + 600000),
+    id: "transaction-id",
+    proxyCodeChallenge: "proxy-challenge",
+    proxyCodeVerifier: "proxy-verifier",
+    scope: ["read"],
+    state: "state",
+  };
+
+  it("bounds the authorization-code exchange and maps the timeout to server_error", async () => {
+    const proxy = new OAuthProxy(baseConfig);
+    const fetchSpy = mockHungUpstream();
+
+    await expect(
+      (proxy as any).exchangeUpstreamCode("auth-code", transaction),
+    ).rejects.toMatchObject({
+      code: "server_error",
+      description: "Upstream request timed out",
+      name: "OAuthProxyError",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    proxy.destroy();
+    fetchSpy.mockRestore();
+  });
+
+  it("bounds the passthrough refresh exchange and maps the timeout to server_error", async () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableTokenSwap: false });
+    const fetchSpy = mockHungUpstream();
+
+    await expect(
+      (proxy as any).handlePassthroughRefresh({
+        client_id: "client-id",
+        grant_type: "refresh_token",
+        refresh_token: "upstream-refresh-token",
+      }),
+    ).rejects.toMatchObject({
+      code: "server_error",
+      description: "Upstream request timed out",
+      name: "OAuthProxyError",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    proxy.destroy();
+    fetchSpy.mockRestore();
+  });
+
+  it("bounds the swap-mode upstream refresh and maps the timeout to server_error", async () => {
+    const proxy = new OAuthProxy(baseConfig);
+    const fetchSpy = mockHungUpstream();
+
+    await expect(
+      (proxy as any).refreshUpstreamTokens("upstream-refresh-token"),
+    ).rejects.toMatchObject({
+      code: "server_error",
+      description: "Upstream request timed out",
+      name: "OAuthProxyError",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    proxy.destroy();
+    fetchSpy.mockRestore();
+  });
+
+  it("passes an AbortSignal to every upstream fetch", async () => {
+    const proxy = new OAuthProxy(baseConfig);
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ access_token: "t", token_type: "Bearer" }),
+        {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+        },
+      ),
+    );
+
+    await (proxy as any).refreshUpstreamTokens("upstream-refresh-token");
+
+    const init = fetchSpy.mock.calls[0]?.[1];
+
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+
+    proxy.destroy();
+    fetchSpy.mockRestore();
+  });
+
+  it("does not remap non-timeout fetch failures", async () => {
+    const proxy = new OAuthProxy(baseConfig);
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(
+      (proxy as any).refreshUpstreamTokens("upstream-refresh-token"),
+    ).rejects.toThrow(TypeError);
+
+    proxy.destroy();
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -13,6 +13,11 @@ export const DEFAULT_AUTHORIZATION_CODE_TTL = 300; // 5 minutes
 export const DEFAULT_TRANSACTION_TTL = 600; // 10 minutes
 
 /**
+ * Default timeout for upstream token/refresh HTTP requests (in milliseconds)
+ */
+export const DEFAULT_UPSTREAM_REQUEST_TIMEOUT_MS = 10000; // 10 seconds
+
+/**
  * OAuth authorization request parameters
  */
 export interface AuthorizationParams {
@@ -275,6 +280,8 @@ export interface OAuthProxyConfig {
   upstreamClientId: string;
   /** Pre-registered client secret with upstream provider */
   upstreamClientSecret: string;
+  /** Timeout in milliseconds for upstream token/refresh HTTP requests (default: 10000) */
+  upstreamRequestTimeoutMs?: number;
   /** Upstream provider's token endpoint URL */
   upstreamTokenEndpoint: string;
   /** Upstream token endpoint authentication method (default: "client_secret_basic") */


### PR DESCRIPTION
## Summary

The OAuth proxy's outbound calls to the upstream identity provider and the OIDC discovery document were bare `fetch(...)` with no timeout, so a hung or trickling upstream stalled the corresponding authorize/token/refresh request indefinitely — the only ceiling was undici's 300s `headersTimeout`/`bodyTimeout` defaults (fastmcp depends on `undici ^7.16.0`).

Implements the shape from #302: configurable, 10s default, all four sites in one pass. Closes #302.

## Root cause

No `AbortSignal`/timeout on any of the auth surface's outbound calls (verified by a sweep of `src/` for bare `fetch(` — the only other hits are the `imageContent`/`audioContent` user-content helpers, a different concern):

- `src/auth/OAuthProxy.ts` — the three token/refresh exchanges (`exchangeUpstreamCode`, `handlePassthroughRefresh`, `refreshUpstreamTokens`)
- `src/DiscoveryDocumentCache.ts:101` — the OIDC discovery fetch

These sit in interactive paths (code exchange during a browser redirect, refresh on a live request), where a healthy IdP answers in well under a second.

## Fix

- New `upstreamRequestTimeoutMs?: number` on `OAuthProxyConfig` (default `10000`, exported as `DEFAULT_UPSTREAM_REQUEST_TIMEOUT_MS`), matching the config's all-optional-with-documented-default convention — a required field would be a breaking change.
- The three token/refresh calls now go through a small `fetchUpstream` helper that passes `signal: AbortSignal.timeout(...)` and maps `TimeoutError`/`AbortError` to `OAuthProxyError("server_error", "Upstream request timed out")` instead of a raw throw. `server_error` matches the existing default in `exchangeUpstreamCode`; happy to switch to `temporarily_unavailable` if you prefer.
- `DiscoveryDocumentCache` gets its own `timeoutMs` option (default `10000`, independent of its TTL), keeping its plain-`Error` style.

No new dependencies (`AbortSignal.timeout` is built-in since Node 17.3). Behavior is unchanged when the upstream answers within the budget.

## Tests

- New `src/auth/OAuthProxy.upstream-timeout.test.ts` (CWE-400 header, per repo convention): a hung-upstream stub for each of the three sites asserts the clean `server_error` mapping; the signal is asserted present on every upstream fetch; non-timeout failures (`TypeError: fetch failed`) propagate un-mapped.
- `src/DiscoveryDocumentCache.test.ts`: hung-upstream timeout maps to the cache's plain-`Error` message; the discovery fetch carries a signal.

## Verification

- `tsc --noEmit` ✅ · `prettier --check` ✅ · `eslint` ✅
- `vitest run`: 459/460 — the single failure (`diskStore > take > should hand the value to exactly one of several concurrent callers`) also fails on clean `main` on this machine (Windows file-claim race, untouched by this diff; verified via `git stash`).

AI-assisted: drafted with AI assistance and verified locally as above.