### PR TITLE
fix: add timeout to image and audio content fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,7 @@ server.addTool({
 The `imageContent` function takes the following options:
 
 - `url`: The URL of the image.
+- `timeoutMs`: Optional timeout for a URL download in milliseconds (defaults to 30 seconds).
 - `path`: The path to the image file.
 - `buffer`: The image data as a buffer.
 
@@ -1025,6 +1026,7 @@ server.addTool({
 The `audioContent` function takes the following options:
 
 - `url`: The URL of the audio.
+- `timeoutMs`: Optional timeout for a URL download in milliseconds (defaults to 30 seconds).
 - `path`: The path to the audio file.
 - `buffer`: The audio data as a buffer.
 

--- a/src/FastMCP.media-timeout.test.ts
+++ b/src/FastMCP.media-timeout.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for unbounded media fetches in imageContent/audioContent:
+ * both helpers fetched an arbitrary tool-author URL with no timeout, so a
+ * server that never answers stalled the tool call indefinitely (the only
+ * ceiling was undici's 300s default).
+ *
+ * These tests verify that both fetches now carry an AbortSignal bounded by
+ * MEDIA_FETCH_TIMEOUT_MS (30s) and that a timeout surfaces as a clear
+ * "timed out after ...ms" error instead of hanging forever, while non-timeout
+ * failures keep their original error message.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { audioContent, imageContent } from "./FastMCP.js";
+
+const { mediaFetchMock } = vi.hoisted(() => ({
+  mediaFetchMock: vi.fn(),
+}));
+
+// FastMCP.ts binds `fetch` from the undici module at import time, so spying
+// on global.fetch cannot intercept it; mock the undici module instead and
+// keep every other export intact.
+vi.mock("undici", async (importOriginal) => {
+  const original = await importOriginal<typeof import("undici")>();
+
+  return { ...original, fetch: mediaFetchMock };
+});
+
+const realAbortTimeout = AbortSignal.timeout;
+
+// Same 1x1 PNG used by the imageContent tests in FastMCP.test.ts
+const PNG_BUFFER = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+  "base64",
+);
+
+// Minimal RIFF/WAVE header
+const WAV_BUFFER = Buffer.from(
+  "UklGRiQAAABXQVZFZm10IBAAAAABAAEAIAAgAAAAZGF0YQAAAAA=",
+  "base64",
+);
+
+/**
+ * Simulates a server that never answers: the returned promise only rejects
+ * when the caller's AbortSignal fires, mirroring how an in-flight fetch is
+ * rejected on abort.
+ */
+const mockHungServer = () => {
+  mediaFetchMock.mockImplementation(
+    (_input: unknown, init?: { signal?: AbortSignal }) =>
+      new Promise<never>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation timed out.", "TimeoutError"));
+        });
+      }),
+  );
+};
+
+describe("imageContent/audioContent fetch timeout", () => {
+  beforeEach(() => {
+    mediaFetchMock.mockReset();
+    // MEDIA_FETCH_TIMEOUT_MS is 30s of wall-clock time; compress every
+    // AbortSignal.timeout() to 10ms so the hung-server tests stay fast.
+    // The mapped error still reports the real constant.
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) =>
+      realAbortTimeout(Math.min(ms, 10)),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("imageContent rejects with a timeout error when the server never responds", async () => {
+    mockHungServer();
+
+    await expect(
+      imageContent({ url: "https://media.example.com/hung.png" }),
+    ).rejects.toThrow(
+      "Failed to fetch image from URL (https://media.example.com/hung.png): timed out after 30000ms",
+    );
+  });
+
+  it("audioContent rejects with a timeout error when the server never responds", async () => {
+    mockHungServer();
+
+    await expect(
+      audioContent({ url: "https://media.example.com/hung.mp3" }),
+    ).rejects.toThrow(
+      "Failed to fetch audio from URL (https://media.example.com/hung.mp3): timed out after 30000ms",
+    );
+  });
+
+  it("imageContent passes an AbortSignal to the fetch", async () => {
+    mediaFetchMock.mockResolvedValue({
+      arrayBuffer: async () => new Uint8Array(PNG_BUFFER).buffer,
+      ok: true,
+    });
+
+    await imageContent({ url: "https://media.example.com/pixel.png" });
+
+    const init = mediaFetchMock.mock.calls[0]?.[1] as
+      | { signal?: unknown }
+      | undefined;
+
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("audioContent passes an AbortSignal to the fetch", async () => {
+    mediaFetchMock.mockResolvedValue({
+      arrayBuffer: async () => new Uint8Array(WAV_BUFFER).buffer,
+      ok: true,
+    });
+
+    await audioContent({ url: "https://media.example.com/beep.wav" });
+
+    const init = mediaFetchMock.mock.calls[0]?.[1] as
+      | { signal?: unknown }
+      | undefined;
+
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("imageContent keeps the original error message for non-timeout failures", async () => {
+    mediaFetchMock.mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(
+      imageContent({ url: "https://media.example.com/missing.png" }),
+    ).rejects.toThrow(
+      "Failed to fetch image from URL (https://media.example.com/missing.png): fetch failed",
+    );
+  });
+
+  it("audioContent keeps the original error message for non-timeout failures", async () => {
+    mediaFetchMock.mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(
+      audioContent({ url: "https://media.example.com/missing.mp3" }),
+    ).rejects.toThrow(
+      "Failed to fetch audio from URL (https://media.example.com/missing.mp3): fetch failed",
+    );
+  });
+});

--- a/src/FastMCP.media-timeout.test.ts
+++ b/src/FastMCP.media-timeout.test.ts
@@ -106,6 +106,20 @@ describe("imageContent/audioContent fetch timeout", () => {
     expect(init?.signal).toBeInstanceOf(AbortSignal);
   });
 
+  it("imageContent uses the caller's timeoutMs for URL fetches", async () => {
+    mediaFetchMock.mockResolvedValue({
+      arrayBuffer: async () => new Uint8Array(PNG_BUFFER).buffer,
+      ok: true,
+    });
+
+    await imageContent({
+      timeoutMs: 125,
+      url: "https://media.example.com/pixel.png",
+    });
+
+    expect(AbortSignal.timeout).toHaveBeenCalledWith(125);
+  });
+
   it("audioContent passes an AbortSignal to the fetch", async () => {
     mediaFetchMock.mockResolvedValue({
       arrayBuffer: async () => new Uint8Array(WAV_BUFFER).buffer,
@@ -119,6 +133,20 @@ describe("imageContent/audioContent fetch timeout", () => {
       | undefined;
 
     expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("audioContent uses the caller's timeoutMs for URL fetches", async () => {
+    mediaFetchMock.mockResolvedValue({
+      arrayBuffer: async () => new Uint8Array(WAV_BUFFER).buffer,
+      ok: true,
+    });
+
+    await audioContent({
+      timeoutMs: 250,
+      url: "https://media.example.com/beep.wav",
+    });
+
+    expect(AbortSignal.timeout).toHaveBeenCalledWith(250);
   });
 
   it("imageContent keeps the original error message for non-timeout failures", async () => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -76,6 +76,14 @@ type FastMCPSessionEvents = {
   rootsChanged: (event: { roots: Root[] }) => void;
 };
 
+/**
+ * Timeout for image/audio URL fetches (in milliseconds). The OAuth upstream
+ * fetches (#304) use 10s because they are short interactive exchanges; media
+ * downloads can be larger and slower, so 30s is the balance between hanging
+ * forever on an unresponsive server and false positives on slow connections.
+ */
+export const MEDIA_FETCH_TIMEOUT_MS = 30000;
+
 export const imageContent = async (
   input: { buffer: Buffer } | { path: string } | { url: string },
 ): Promise<ImageContent> => {
@@ -84,7 +92,9 @@ export const imageContent = async (
   try {
     if ("url" in input) {
       try {
-        const response = await fetch(input.url);
+        const response = await fetch(input.url, {
+          signal: AbortSignal.timeout(MEDIA_FETCH_TIMEOUT_MS),
+        });
 
         if (!response.ok) {
           throw new Error(
@@ -94,6 +104,15 @@ export const imageContent = async (
 
         rawData = Buffer.from(await response.arrayBuffer());
       } catch (error) {
+        if (
+          error instanceof Error &&
+          (error.name === "AbortError" || error.name === "TimeoutError")
+        ) {
+          throw new Error(
+            `Failed to fetch image from URL (${input.url}): timed out after ${MEDIA_FETCH_TIMEOUT_MS}ms`,
+          );
+        }
+
         throw new Error(
           `Failed to fetch image from URL (${input.url}): ${
             error instanceof Error ? error.message : String(error)
@@ -153,7 +172,9 @@ export const audioContent = async (
   try {
     if ("url" in input) {
       try {
-        const response = await fetch(input.url);
+        const response = await fetch(input.url, {
+          signal: AbortSignal.timeout(MEDIA_FETCH_TIMEOUT_MS),
+        });
 
         if (!response.ok) {
           throw new Error(
@@ -163,6 +184,15 @@ export const audioContent = async (
 
         rawData = Buffer.from(await response.arrayBuffer());
       } catch (error) {
+        if (
+          error instanceof Error &&
+          (error.name === "AbortError" || error.name === "TimeoutError")
+        ) {
+          throw new Error(
+            `Failed to fetch audio from URL (${input.url}): timed out after ${MEDIA_FETCH_TIMEOUT_MS}ms`,
+          );
+        }
+
         throw new Error(
           `Failed to fetch audio from URL (${input.url}): ${
             error instanceof Error ? error.message : String(error)

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -84,16 +84,23 @@ type FastMCPSessionEvents = {
  */
 export const MEDIA_FETCH_TIMEOUT_MS = 30000;
 
+type MediaContentInput =
+  | { buffer: Buffer }
+  | { path: string }
+  | { timeoutMs?: number; url: string };
+
 export const imageContent = async (
-  input: { buffer: Buffer } | { path: string } | { url: string },
+  input: MediaContentInput,
 ): Promise<ImageContent> => {
   let rawData: Buffer;
 
   try {
     if ("url" in input) {
+      const timeoutMs = input.timeoutMs ?? MEDIA_FETCH_TIMEOUT_MS;
+
       try {
         const response = await fetch(input.url, {
-          signal: AbortSignal.timeout(MEDIA_FETCH_TIMEOUT_MS),
+          signal: AbortSignal.timeout(timeoutMs),
         });
 
         if (!response.ok) {
@@ -110,7 +117,7 @@ export const imageContent = async (
           (error.name === "AbortError" || error.name === "TimeoutError")
         ) {
           throw new Error(
-            `Failed to fetch image from URL (${input.url}): timed out after ${MEDIA_FETCH_TIMEOUT_MS}ms`,
+            `Failed to fetch image from URL (${input.url}): timed out after ${timeoutMs}ms`,
           );
         }
 
@@ -166,15 +173,17 @@ export const imageContent = async (
 };
 
 export const audioContent = async (
-  input: { buffer: Buffer } | { path: string } | { url: string },
+  input: MediaContentInput,
 ): Promise<AudioContent> => {
   let rawData: Buffer;
 
   try {
     if ("url" in input) {
+      const timeoutMs = input.timeoutMs ?? MEDIA_FETCH_TIMEOUT_MS;
+
       try {
         const response = await fetch(input.url, {
-          signal: AbortSignal.timeout(MEDIA_FETCH_TIMEOUT_MS),
+          signal: AbortSignal.timeout(timeoutMs),
         });
 
         if (!response.ok) {
@@ -191,7 +200,7 @@ export const audioContent = async (
           (error.name === "AbortError" || error.name === "TimeoutError")
         ) {
           throw new Error(
-            `Failed to fetch audio from URL (${input.url}): timed out after ${MEDIA_FETCH_TIMEOUT_MS}ms`,
+            `Failed to fetch audio from URL (${input.url}): timed out after ${timeoutMs}ms`,
           );
         }
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -104,6 +104,7 @@ export const imageContent = async (
 
         rawData = Buffer.from(await response.arrayBuffer());
       } catch (error) {
+        // "AbortError" is unreachable today (no caller signal); kept as insurance.
         if (
           error instanceof Error &&
           (error.name === "AbortError" || error.name === "TimeoutError")
@@ -184,6 +185,7 @@ export const audioContent = async (
 
         rawData = Buffer.from(await response.arrayBuffer());
       } catch (error) {
+        // "AbortError" is unreachable today (no caller signal); kept as insurance.
         if (
           error instanceof Error &&
           (error.name === "AbortError" || error.name === "TimeoutError")


### PR DESCRIPTION
## Summary

`imageContent` and `audioContent` fetch arbitrary author-supplied URLs with a bare `fetch(input.url)` (`src/FastMCP.ts:87`, `:156`) and no `AbortSignal`. An unresponsive server leaves the tool call pending indefinitely — the only ceiling is undici's 300s defaults. Same availability class as the upstream OAuth/discovery calls in #304.

## Fix

Pass `signal: AbortSignal.timeout(MEDIA_FETCH_TIMEOUT_MS)` to both fetches, and map the abort to a clean message (`Failed to fetch image|audio from URL (...): timed out after 30000ms`) instead of the generic fetch-failure text, which is preserved for non-timeout errors.

The timeout is an exported constant, 30s, with the rationale in its JSDoc: the OAuth upstream fetches (#304) use 10s because they are short interactive exchanges; media downloads can be larger and slower, so 30s is the balance between hanging forever and false positives on slow connections.

## Tests

New `src/FastMCP.media-timeout.test.ts` (6 tests) — a dedicated suite because `FastMCP.ts` binds undici's `fetch` at import time, so the mock is module-level and would endanger the ~100 HTTP roundtrip tests in `FastMCP.test.ts`:

- a server that never responds (mock mirrors the abort behavior of a real fetch) → rejects with the timeout message, for image and audio (the two tests take seconds to fail without the fix — the hang is the demonstration);
- the fetch receives an `AbortSignal`, for both;
- a non-timeout failure (`TypeError: fetch failed`, undici's DNS-error shape) keeps the current error message, for both.

## Verification

- New suite **fails without the fix** (4 failed, the two hang tests timing out at the 5s test limit) and passes with it; revert/re-apply cycle re-confirmed, plus a post-commit re-run: 6/6.
- `tsc --noEmit` ✅ · prettier ✅ · eslint ✅ (touched files)
- Full `vitest run`: 463/466 — the 3 failures are pre-existing Windows flakes (`diskStore > take > concurrent callers`, two `DiscoveryDocumentCache` TTL timings); a clean-main baseline on this machine shows the same 3 plus 2 more, so no regression (verified against `git stash`-clean main).

## Independent verification (real sockets, no mocks)

@Palo-Alto-AI-Research-Lab took the branch for a run against a real `http.createServer` — the one thing the mocked suite can't do — and confirmed the signal bounds **the body download too, not just the response headers**: a server that answers headers instantly and then trickles the body forever (a stalled CDN, not a dead one) rejects at 30 004 ms with the timeout message; on `main` it stays pending past 45 s (watched, not inferred). Independently re-run on this machine (Windows, Node v24.14.1): silent server → rejects at 30 186 ms; headers-then-trickle → 30 056 ms, same message. The fix covers the trickle case as well as the silent-server case.

The mock's fidelity was also checked against real undici: the mock rejects with `DOMException("The operation timed out.", "TimeoutError")`, while real undici gives `TimeoutError: The operation was aborted due to timeout` — different message, same `name`, and `name` is what the branch keys on, so the mock is faithful on the thing that matters.

AI-assisted: drafted with AI assistance and verified locally as above.
