### PR TITLE
fix(auth): handle aborted and oversized bodies in OAuth proxy endpoints

### DIFF
--- a/src/FastMCP.oauth-body-reader.test.ts
+++ b/src/FastMCP.oauth-body-reader.test.ts
@@ -151,6 +151,7 @@ describe("OAuth proxy body readers", () => {
         () => {
           expect(response).toContain("400");
           expect(response).toContain("invalid_request");
+          expect(response).toContain("Request body exceeds 1 MiB");
         },
         { interval: 50, timeout: 3000 },
       );
@@ -193,6 +194,7 @@ describe("OAuth proxy body readers", () => {
         () => {
           expect(response).toContain("400");
           expect(response).toContain("invalid_request");
+          expect(response).toContain("Request body exceeds 1 MiB");
           expect(serverClosedSocket).toBe(true);
         },
         { interval: 50, timeout: 3000 },
@@ -311,14 +313,14 @@ describe("OAuth proxy body readers", () => {
 
       // Send chunks until we exceed 1 MiB limit
       const chunkSize = 256 * 1024; // 256 KiB per chunk
-      const chunkData = Buffer.alloc(chunkSize, 'a');
+      const chunkData = Buffer.alloc(chunkSize, "a");
 
       for (let sent = 0; sent < 1.5 * 1024 * 1024; sent += chunkSize) {
         if (socket.destroyed) break;
         // Write chunk in HTTP chunked format: size-in-hex CRLF data CRLF
         socket.write(`${chunkSize.toString(16)}\r\n`);
         socket.write(chunkData);
-        socket.write('\r\n');
+        socket.write("\r\n");
         await sleep(10);
       }
 
@@ -326,6 +328,7 @@ describe("OAuth proxy body readers", () => {
         () => {
           expect(response).toContain("400");
           expect(response).toContain("invalid_request");
+          expect(response).toContain("Request body exceeds 1 MiB");
           expect(serverClosedSocket).toBe(true);
         },
         { interval: 50, timeout: 5000 },
@@ -359,22 +362,23 @@ describe("OAuth proxy body readers", () => {
 
       // Split "Café 日本語 клиент" across two chunks
       const part1 = '{"client_name":"Caf';
-      const part2 = 'é 日本語 клиент","redirect_uris":["https://client.example.com/callback"]}';
+      const part2 =
+        'é 日本語 клиент","redirect_uris":["https://client.example.com/callback"]}';
 
       // First chunk
       socket.write(`${Buffer.byteLength(part1).toString(16)}\r\n`);
       socket.write(part1);
-      socket.write('\r\n');
+      socket.write("\r\n");
 
       await sleep(50);
 
       // Second chunk
       socket.write(`${Buffer.byteLength(part2).toString(16)}\r\n`);
       socket.write(part2);
-      socket.write('\r\n');
+      socket.write("\r\n");
 
       // Terminating chunk
-      socket.write('0\r\n\r\n');
+      socket.write("0\r\n\r\n");
 
       await vi.waitFor(
         () => {
@@ -414,17 +418,17 @@ describe("OAuth proxy body readers", () => {
       const chunk1 = "grant_type=authorization_code&code=abc";
       socket.write(`${Buffer.byteLength(chunk1).toString(16)}\r\n`);
       socket.write(chunk1);
-      socket.write('\r\n');
+      socket.write("\r\n");
 
       await sleep(50);
 
       // Abort before sending terminating chunk
       socket.destroy();
 
-      await vi.waitFor(
-        () => expect(socketClosed).toBe(true),
-        { interval: 50, timeout: 2000 },
-      );
+      await vi.waitFor(() => expect(socketClosed).toBe(true), {
+        interval: 50,
+        timeout: 2000,
+      });
 
       // Verify server is still responsive after abort
       const healthSocket = await openSocket(port);
@@ -433,10 +437,10 @@ describe("OAuth proxy body readers", () => {
       healthSocket.on("data", (chunk) => (healthResponse += chunk));
       healthSocket.write(`GET / HTTP/1.1\r\nHost: localhost\r\n\r\n`);
 
-      await vi.waitFor(
-        () => expect(healthResponse.length).toBeGreaterThan(0),
-        { interval: 50, timeout: 2000 },
-      );
+      await vi.waitFor(() => expect(healthResponse.length).toBeGreaterThan(0), {
+        interval: 50,
+        timeout: 2000,
+      });
 
       healthSocket.end();
     } finally {

--- a/src/FastMCP.oauth-body-reader.test.ts
+++ b/src/FastMCP.oauth-body-reader.test.ts
@@ -1,0 +1,195 @@
+/**
+ * OAuth Proxy body-reader robustness tests
+ * Exercises the /oauth/* POST endpoints over raw sockets to cover request
+ * bodies that are aborted mid-stream or exceed the accepted size limit.
+ */
+
+import { getRandomPort } from "get-port-please";
+import { OutgoingMessage } from "node:http";
+import { connect, type Socket } from "node:net";
+import { describe, expect, it, vi } from "vitest";
+
+import { OAuthProxy } from "./auth/OAuthProxy.js";
+import { FastMCP } from "./FastMCP.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function openSocket(port: number): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = connect(port, "127.0.0.1");
+    socket.once("connect", () => resolve(socket));
+    socket.once("error", reject);
+  });
+}
+
+function requestHead(
+  contentLength: number,
+  contentType: string,
+  path: string,
+  port: number,
+): string {
+  return [
+    `POST ${path} HTTP/1.1`,
+    `Host: localhost:${port}`,
+    `Content-Type: ${contentType}`,
+    `Content-Length: ${contentLength}`,
+    "Connection: close",
+    "",
+    "",
+  ].join("\r\n");
+}
+
+async function startOAuthProxyServer(port: number) {
+  const authProxy = new OAuthProxy({
+    allowedRedirectUriPatterns: ["https://client.example.com/*"],
+    baseUrl: `http://localhost:${port}`,
+    scopes: ["openid", "profile"],
+    upstreamAuthorizationEndpoint: "https://example.com/oauth/authorize",
+    upstreamClientId: "test-client-id",
+    upstreamClientSecret: "test-client-secret",
+    upstreamTokenEndpoint: "https://example.com/oauth/token",
+  });
+
+  const server = new FastMCP({
+    name: "Test Server",
+    oauth: {
+      authorizationServer: authProxy.getAuthorizationServerMetadata(),
+      enabled: true,
+      proxy: authProxy,
+    },
+    version: "1.0.0",
+  });
+
+  await server.start({
+    // Raw-socket clients need a concrete address family
+    httpStream: { host: "127.0.0.1", port },
+    transportType: "httpStream",
+  });
+
+  return server;
+}
+
+describe("OAuth proxy body readers", () => {
+  it.each(["/oauth/register", "/oauth/consent", "/oauth/token"])(
+    "settles with 400 invalid_request when the client aborts mid-body (%s)",
+    async (path) => {
+      const port = await getRandomPort();
+      const server = await startOAuthProxyServer(port);
+      const endSpy = vi.spyOn(OutgoingMessage.prototype, "end");
+
+      try {
+        const body = JSON.stringify({
+          redirect_uris: ["https://client.example.com/callback"],
+        });
+        const socket = await openSocket(port);
+        socket.write(requestHead(body.length, "application/json", path, port));
+        socket.end(body.slice(0, 10)); // incomplete body, then FIN
+
+        // The aborted socket is torn down by Node's own parse-error handling,
+        // so the 400 is observed server-side: the body reader must settle and
+        // attempt a 400 invalid_request response instead of hanging forever.
+        await vi.waitFor(
+          () => {
+            expect(
+              endSpy.mock.calls.some((call) =>
+                String(call[0]).includes("invalid_request"),
+              ),
+            ).toBe(true);
+          },
+          { interval: 50, timeout: 3000 },
+        );
+
+        // The server stays responsive for subsequent requests.
+        const response = await fetch(
+          `http://localhost:${port}/oauth/register`,
+          {
+            body,
+            headers: { "Content-Type": "application/json" },
+            method: "POST",
+          },
+        );
+        expect(response.status).toBe(201);
+      } finally {
+        endSpy.mockRestore();
+        await server.stop();
+      }
+    },
+  );
+
+  it("rejects an over-limit body before it is fully received", async () => {
+    const port = await getRandomPort();
+    const server = await startOAuthProxyServer(port);
+
+    try {
+      const socket = await openSocket(port);
+      // The server may close the connection while we are still writing.
+      socket.on("error", () => {});
+
+      const declaredLength = 4 * 1024 * 1024;
+      socket.write(
+        requestHead(
+          declaredLength,
+          "application/x-www-form-urlencoded",
+          "/oauth/token",
+          port,
+        ),
+      );
+
+      let response = "";
+      socket.on("data", (chunk) => (response += chunk));
+
+      // Trickle 6 × 256 KiB = 1.5 MiB, crossing the 1 MiB limit.
+      const chunk = "x".repeat(256 * 1024);
+      for (let i = 0; i < 6 && response.length === 0; i++) {
+        if (!socket.writable) break;
+        socket.write(chunk);
+        await sleep(50);
+      }
+
+      await vi.waitFor(
+        () => {
+          expect(response).toContain("400");
+          expect(response).toContain("invalid_request");
+        },
+        { interval: 50, timeout: 3000 },
+      );
+
+      // The rejection happened before the declared body was fully sent.
+      expect(socket.bytesWritten).toBeLessThan(declaredLength);
+      socket.destroy();
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("still accepts a valid body delivered in slow chunks", async () => {
+    const port = await getRandomPort();
+    const server = await startOAuthProxyServer(port);
+
+    try {
+      const body = JSON.stringify({
+        redirect_uris: ["https://client.example.com/callback"],
+      });
+      const socket = await openSocket(port);
+      socket.write(
+        requestHead(body.length, "application/json", "/oauth/register", port),
+      );
+      socket.write(body.slice(0, 10));
+      await sleep(100);
+      socket.end(body.slice(10)); // final chunk completes the body
+
+      let response = "";
+      socket.on("data", (chunk) => (response += chunk));
+
+      await vi.waitFor(
+        () => {
+          expect(response).toContain("201");
+          expect(response).toContain("client_id");
+        },
+        { interval: 50, timeout: 3000 },
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/src/FastMCP.oauth-body-reader.test.ts
+++ b/src/FastMCP.oauth-body-reader.test.ts
@@ -27,13 +27,14 @@ function requestHead(
   contentType: string,
   path: string,
   port: number,
+  connection = "close",
 ): string {
   return [
     `POST ${path} HTTP/1.1`,
     `Host: localhost:${port}`,
     `Content-Type: ${contentType}`,
     `Content-Length: ${contentLength}`,
-    "Connection: close",
+    `Connection: ${connection}`,
     "",
     "",
   ].join("\r\n");
@@ -162,6 +163,45 @@ describe("OAuth proxy body readers", () => {
     }
   });
 
+  it("closes a keep-alive request after rejecting an over-limit body", async () => {
+    const port = await getRandomPort();
+    const server = await startOAuthProxyServer(port);
+
+    try {
+      const socket = await openSocket(port);
+      socket.on("error", () => {});
+
+      let response = "";
+      let serverClosedSocket = false;
+      socket.on("data", (chunk) => (response += chunk));
+      socket.once("end", () => {
+        serverClosedSocket = true;
+      });
+
+      socket.write(
+        requestHead(
+          4 * 1024 * 1024,
+          "application/x-www-form-urlencoded",
+          "/oauth/token",
+          port,
+          "keep-alive",
+        ),
+      );
+      socket.write("x".repeat(1280 * 1024));
+
+      await vi.waitFor(
+        () => {
+          expect(response).toContain("400");
+          expect(response).toContain("invalid_request");
+          expect(serverClosedSocket).toBe(true);
+        },
+        { interval: 50, timeout: 3000 },
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
   it("still accepts a valid body delivered in slow chunks", async () => {
     const port = await getRandomPort();
     const server = await startOAuthProxyServer(port);
@@ -185,6 +225,50 @@ describe("OAuth proxy body readers", () => {
         () => {
           expect(response).toContain("201");
           expect(response).toContain("client_id");
+        },
+        { interval: 50, timeout: 3000 },
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("preserves a UTF-8 character split across request chunks", async () => {
+    const port = await getRandomPort();
+    const server = await startOAuthProxyServer(port);
+
+    try {
+      const clientName = "Café 日本語 клиент";
+      const body = Buffer.from(
+        JSON.stringify({
+          client_name: clientName,
+          redirect_uris: ["https://client.example.com/callback"],
+        }),
+        "utf8",
+      );
+      const accentStart = body.indexOf(Buffer.from("é", "utf8"));
+      expect(accentStart).toBeGreaterThanOrEqual(0);
+
+      const socket = await openSocket(port);
+      socket.write(
+        requestHead(
+          body.byteLength,
+          "application/json",
+          "/oauth/register",
+          port,
+        ),
+      );
+      socket.write(body.subarray(0, accentStart + 1));
+      await sleep(100);
+      socket.end(body.subarray(accentStart + 1));
+
+      let response = "";
+      socket.on("data", (chunk) => (response += chunk));
+
+      await vi.waitFor(
+        () => {
+          expect(response).toContain("201");
+          expect(response).toContain(clientName);
         },
         { interval: 50, timeout: 3000 },
       );

--- a/src/FastMCP.oauth-body-reader.test.ts
+++ b/src/FastMCP.oauth-body-reader.test.ts
@@ -276,4 +276,171 @@ describe("OAuth proxy body readers", () => {
       await server.stop();
     }
   });
+
+  // ============================================================================
+  // CHUNKED ENCODING TESTS — validates the streaming counter design rationale
+  // ============================================================================
+  // These three tests lock in the guarantee that the streaming counter protects
+  // chunked and dishonest bodies. Without them, a future "optimization" that
+  // trusts only Content-Length would pass the existing suite and silently break
+  // the chunked path (Transfer-Encoding: chunked uses no Content-Length header).
+
+  it("rejects an oversize chunked body (no Content-Length)", async () => {
+    const port = await getRandomPort();
+    const server = await startOAuthProxyServer(port);
+
+    try {
+      const socket = await openSocket(port);
+      let response = "";
+      let serverClosedSocket = false;
+
+      socket.on("data", (chunk) => (response += chunk));
+      socket.on("close", () => (serverClosedSocket = true));
+
+      // Send chunked request (no Content-Length header)
+      const headers = [
+        `POST /oauth/register HTTP/1.1`,
+        `Host: localhost:${port}`,
+        `Transfer-Encoding: chunked`,
+        `Content-Type: application/json`,
+        ``,
+        ``,
+      ].join("\r\n");
+
+      socket.write(headers);
+
+      // Send chunks until we exceed 1 MiB limit
+      const chunkSize = 256 * 1024; // 256 KiB per chunk
+      const chunkData = Buffer.alloc(chunkSize, 'a');
+
+      for (let sent = 0; sent < 1.5 * 1024 * 1024; sent += chunkSize) {
+        if (socket.destroyed) break;
+        // Write chunk in HTTP chunked format: size-in-hex CRLF data CRLF
+        socket.write(`${chunkSize.toString(16)}\r\n`);
+        socket.write(chunkData);
+        socket.write('\r\n');
+        await sleep(10);
+      }
+
+      await vi.waitFor(
+        () => {
+          expect(response).toContain("400");
+          expect(response).toContain("invalid_request");
+          expect(serverClosedSocket).toBe(true);
+        },
+        { interval: 50, timeout: 5000 },
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("preserves UTF-8 characters split across chunked wire boundaries", async () => {
+    const port = await getRandomPort();
+    const server = await startOAuthProxyServer(port);
+
+    try {
+      const socket = await openSocket(port);
+      let response = "";
+
+      socket.on("data", (chunk) => (response += chunk));
+
+      // Send chunked request with UTF-8 character split across chunks
+      const headers = [
+        `POST /oauth/register HTTP/1.1`,
+        `Host: localhost:${port}`,
+        `Transfer-Encoding: chunked`,
+        `Content-Type: application/json`,
+        ``,
+        ``,
+      ].join("\r\n");
+
+      socket.write(headers);
+
+      // Split "Café 日本語 клиент" across two chunks
+      const part1 = '{"client_name":"Caf';
+      const part2 = 'é 日本語 клиент","redirect_uris":["https://client.example.com/callback"]}';
+
+      // First chunk
+      socket.write(`${Buffer.byteLength(part1).toString(16)}\r\n`);
+      socket.write(part1);
+      socket.write('\r\n');
+
+      await sleep(50);
+
+      // Second chunk
+      socket.write(`${Buffer.byteLength(part2).toString(16)}\r\n`);
+      socket.write(part2);
+      socket.write('\r\n');
+
+      // Terminating chunk
+      socket.write('0\r\n\r\n');
+
+      await vi.waitFor(
+        () => {
+          expect(response).toContain("201");
+          expect(response).toContain("Café 日本語 клиент");
+        },
+        { interval: 50, timeout: 3000 },
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("handles chunked request aborted before terminating chunk", async () => {
+    const port = await getRandomPort();
+    const server = await startOAuthProxyServer(port);
+
+    try {
+      const socket = await openSocket(port);
+      let socketClosed = false;
+
+      socket.on("close", () => (socketClosed = true));
+
+      // Send chunked request headers
+      const headers = [
+        `POST /oauth/token HTTP/1.1`,
+        `Host: localhost:${port}`,
+        `Transfer-Encoding: chunked`,
+        `Content-Type: application/x-www-form-urlencoded`,
+        ``,
+        ``,
+      ].join("\r\n");
+
+      socket.write(headers);
+
+      // Send one chunk
+      const chunk1 = "grant_type=authorization_code&code=abc";
+      socket.write(`${Buffer.byteLength(chunk1).toString(16)}\r\n`);
+      socket.write(chunk1);
+      socket.write('\r\n');
+
+      await sleep(50);
+
+      // Abort before sending terminating chunk
+      socket.destroy();
+
+      await vi.waitFor(
+        () => expect(socketClosed).toBe(true),
+        { interval: 50, timeout: 2000 },
+      );
+
+      // Verify server is still responsive after abort
+      const healthSocket = await openSocket(port);
+      let healthResponse = "";
+
+      healthSocket.on("data", (chunk) => (healthResponse += chunk));
+      healthSocket.write(`GET / HTTP/1.1\r\nHost: localhost\r\n\r\n`);
+
+      await vi.waitFor(
+        () => expect(healthResponse.length).toBeGreaterThan(0),
+        { interval: 50, timeout: 2000 },
+      );
+
+      healthSocket.end();
+    } finally {
+      await server.stop();
+    }
+  });
 });

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3611,7 +3611,12 @@ export class FastMCP<
                   Connection: "close",
                   "Content-Type": "application/json",
                 })
-                .end(JSON.stringify({ error: "invalid_request" }));
+                .end(
+                  JSON.stringify({
+                    error: "invalid_request",
+                    error_description: "Request body exceeds 1 MiB",
+                  }),
+                );
               resolve();
             };
             req.on("data", (chunk) => {
@@ -3738,7 +3743,12 @@ export class FastMCP<
                   Connection: "close",
                   "Content-Type": "application/json",
                 })
-                .end(JSON.stringify({ error: "invalid_request" }));
+                .end(
+                  JSON.stringify({
+                    error: "invalid_request",
+                    error_description: "Request body exceeds 1 MiB",
+                  }),
+                );
               resolve();
             };
             req.on("data", (chunk) => {
@@ -3812,7 +3822,12 @@ export class FastMCP<
                   Connection: "close",
                   "Content-Type": "application/json",
                 })
-                .end(JSON.stringify({ error: "invalid_request" }));
+                .end(
+                  JSON.stringify({
+                    error: "invalid_request",
+                    error_description: "Request body exceeds 1 MiB",
+                  }),
+                );
               resolve();
             };
             req.on("data", (chunk) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3597,7 +3597,7 @@ export class FastMCP<
         // DCR endpoint - POST /oauth/register
         if (req.method === "POST" && oauthPath === "/oauth/register") {
           await new Promise<void>((resolve) => {
-            let body = "";
+            const bodyChunks: Buffer[] = [];
             let bodySize = 0;
             let failed = false;
             const fail = () => {
@@ -3607,7 +3607,10 @@ export class FastMCP<
               }
               failed = true;
               res
-                .writeHead(400, { "Content-Type": "application/json" })
+                .writeHead(400, {
+                  Connection: "close",
+                  "Content-Type": "application/json",
+                })
                 .end(JSON.stringify({ error: "invalid_request" }));
               resolve();
             };
@@ -3615,11 +3618,12 @@ export class FastMCP<
               if (failed) {
                 return;
               }
-              body += chunk;
               bodySize += chunk.length;
               if (bodySize > OAUTH_PROXY_MAX_BODY_SIZE) {
                 fail();
+                return;
               }
+              bodyChunks.push(chunk);
             });
             // An aborted/errored request never emits "end"; settle the promise
             // instead of leaving the handler pending forever.
@@ -3630,7 +3634,9 @@ export class FastMCP<
                 return;
               }
               try {
-                const request = JSON.parse(body);
+                const request = JSON.parse(
+                  Buffer.concat(bodyChunks).toString("utf8"),
+                );
                 const response = await oauthProxy.registerClient(request);
                 res
                   .writeHead(201, { "Content-Type": "application/json" })
@@ -3718,7 +3724,7 @@ export class FastMCP<
         // Consent endpoint - POST /oauth/consent
         if (req.method === "POST" && oauthPath === "/oauth/consent") {
           await new Promise<void>((resolve) => {
-            let body = "";
+            const bodyChunks: Buffer[] = [];
             let bodySize = 0;
             let failed = false;
             const fail = () => {
@@ -3728,7 +3734,10 @@ export class FastMCP<
               }
               failed = true;
               res
-                .writeHead(400, { "Content-Type": "application/json" })
+                .writeHead(400, {
+                  Connection: "close",
+                  "Content-Type": "application/json",
+                })
                 .end(JSON.stringify({ error: "invalid_request" }));
               resolve();
             };
@@ -3736,11 +3745,12 @@ export class FastMCP<
               if (failed) {
                 return;
               }
-              body += chunk;
               bodySize += chunk.length;
               if (bodySize > OAUTH_PROXY_MAX_BODY_SIZE) {
                 fail();
+                return;
               }
+              bodyChunks.push(chunk);
             });
             // An aborted/errored request never emits "end"; settle the promise
             // instead of leaving the handler pending forever.
@@ -3754,7 +3764,7 @@ export class FastMCP<
                 const mockRequest = new Request(
                   `http://${host}${url.pathname}${url.search}`,
                   {
-                    body,
+                    body: Buffer.concat(bodyChunks).toString("utf8"),
                     headers: {
                       "Content-Type": "application/x-www-form-urlencoded",
                     },
@@ -3788,7 +3798,7 @@ export class FastMCP<
         // Token endpoint - POST /oauth/token
         if (req.method === "POST" && oauthPath === "/oauth/token") {
           await new Promise<void>((resolve) => {
-            let body = "";
+            const bodyChunks: Buffer[] = [];
             let bodySize = 0;
             let failed = false;
             const fail = () => {
@@ -3798,7 +3808,10 @@ export class FastMCP<
               }
               failed = true;
               res
-                .writeHead(400, { "Content-Type": "application/json" })
+                .writeHead(400, {
+                  Connection: "close",
+                  "Content-Type": "application/json",
+                })
                 .end(JSON.stringify({ error: "invalid_request" }));
               resolve();
             };
@@ -3806,11 +3819,12 @@ export class FastMCP<
               if (failed) {
                 return;
               }
-              body += chunk;
               bodySize += chunk.length;
               if (bodySize > OAUTH_PROXY_MAX_BODY_SIZE) {
                 fail();
+                return;
               }
+              bodyChunks.push(chunk);
             });
             // An aborted/errored request never emits "end"; settle the promise
             // instead of leaving the handler pending forever.
@@ -3821,7 +3835,9 @@ export class FastMCP<
                 return;
               }
               try {
-                const params = new URLSearchParams(body);
+                const params = new URLSearchParams(
+                  Buffer.concat(bodyChunks).toString("utf8"),
+                );
                 const grantType = params.get("grant_type");
 
                 // Parse Basic auth header (RFC 6749 Section 2.3.1)

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2490,6 +2490,14 @@ function parseBasicAuthHeader(
   }
 }
 
+/**
+ * Maximum request body size (in bytes) accepted by the OAuth proxy endpoints
+ * (registration, consent and token). These endpoints receive small JSON or
+ * form-urlencoded payloads, so 1 MiB is a generous bound that prevents
+ * unbounded memory growth from slow or malicious clients.
+ */
+const OAUTH_PROXY_MAX_BODY_SIZE = 1024 * 1024; // 1 MiB
+
 function stripBasePath(
   path: string,
   basePath: "" | `/${string}`,
@@ -3513,8 +3521,37 @@ export class FastMCP<
         if (req.method === "POST" && oauthPath === "/oauth/register") {
           await new Promise<void>((resolve) => {
             let body = "";
-            req.on("data", (chunk) => (body += chunk));
+            let bodySize = 0;
+            let failed = false;
+            const fail = () => {
+              if (failed || res.headersSent) {
+                resolve();
+                return;
+              }
+              failed = true;
+              res
+                .writeHead(400, { "Content-Type": "application/json" })
+                .end(JSON.stringify({ error: "invalid_request" }));
+              resolve();
+            };
+            req.on("data", (chunk) => {
+              if (failed) {
+                return;
+              }
+              body += chunk;
+              bodySize += chunk.length;
+              if (bodySize > OAUTH_PROXY_MAX_BODY_SIZE) {
+                fail();
+              }
+            });
+            // An aborted/errored request never emits "end"; settle the promise
+            // instead of leaving the handler pending forever.
+            req.on("aborted", fail);
+            req.on("error", fail);
             req.on("end", async () => {
+              if (failed) {
+                return;
+              }
               try {
                 const request = JSON.parse(body);
                 const response = await oauthProxy.registerClient(request);
@@ -3605,8 +3642,37 @@ export class FastMCP<
         if (req.method === "POST" && oauthPath === "/oauth/consent") {
           await new Promise<void>((resolve) => {
             let body = "";
-            req.on("data", (chunk) => (body += chunk));
+            let bodySize = 0;
+            let failed = false;
+            const fail = () => {
+              if (failed || res.headersSent) {
+                resolve();
+                return;
+              }
+              failed = true;
+              res
+                .writeHead(400, { "Content-Type": "application/json" })
+                .end(JSON.stringify({ error: "invalid_request" }));
+              resolve();
+            };
+            req.on("data", (chunk) => {
+              if (failed) {
+                return;
+              }
+              body += chunk;
+              bodySize += chunk.length;
+              if (bodySize > OAUTH_PROXY_MAX_BODY_SIZE) {
+                fail();
+              }
+            });
+            // An aborted/errored request never emits "end"; settle the promise
+            // instead of leaving the handler pending forever.
+            req.on("aborted", fail);
+            req.on("error", fail);
             req.on("end", async () => {
+              if (failed) {
+                return;
+              }
               try {
                 const mockRequest = new Request(
                   `http://${host}${url.pathname}${url.search}`,
@@ -3646,8 +3712,37 @@ export class FastMCP<
         if (req.method === "POST" && oauthPath === "/oauth/token") {
           await new Promise<void>((resolve) => {
             let body = "";
-            req.on("data", (chunk) => (body += chunk));
+            let bodySize = 0;
+            let failed = false;
+            const fail = () => {
+              if (failed || res.headersSent) {
+                resolve();
+                return;
+              }
+              failed = true;
+              res
+                .writeHead(400, { "Content-Type": "application/json" })
+                .end(JSON.stringify({ error: "invalid_request" }));
+              resolve();
+            };
+            req.on("data", (chunk) => {
+              if (failed) {
+                return;
+              }
+              body += chunk;
+              bodySize += chunk.length;
+              if (bodySize > OAUTH_PROXY_MAX_BODY_SIZE) {
+                fail();
+              }
+            });
+            // An aborted/errored request never emits "end"; settle the promise
+            // instead of leaving the handler pending forever.
+            req.on("aborted", fail);
+            req.on("error", fail);
             req.on("end", async () => {
+              if (failed) {
+                return;
+              }
               try {
                 const params = new URLSearchParams(body);
                 const grantType = params.get("grant_type");


### PR DESCRIPTION
## Summary

The three OAuth proxy endpoints that read request bodies — `POST /oauth/register`, `/oauth/consent` and `/oauth/token` (`src/FastMCP.ts:3514`, `:3606`, `:3647`) — only listen for `"data"`/`"end"`. A client that aborts mid-body never emits `"end"`, so the handler promise stays pending **forever**; and the body string is accumulated with no size bound, so a slow-chunking client grows memory without limit. Same availability class (CWE-400) as the missing timeouts in #304 and #305.

## Fix

Identical, minimal change in all three readers, plus one exported-style constant (`OAUTH_PROXY_MAX_BODY_SIZE = 1 MiB`, with the rationale in its JSDoc: these endpoints receive small JSON/form payloads, so 1 MiB is a generous bound):

- a `fail()` that settles the promise exactly once — no-op if already failed or `res.headersSent` — responding `400 {"error":"invalid_request"}` (the fallback shape these endpoints already use);
- `fail` is attached to both `"aborted"` and `"error"` — Node emits `aborted` first on premature close, and listening to both is the `raw-body` pattern;
- the `"data"` listener stops accumulating once failed and calls `fail()` past the byte cap (counted in bytes — chunks are Buffers here);
- the `"end"` handler returns early if failed.

## Tests

New `src/FastMCP.oauth-body-reader.test.ts` (5 tests, real sockets via `node:net` — a separate file because it needs raw sockets while the OAuth sister suite drives `fetch`; server setup mirrors that suite):

- abort mid-body on all three endpoints → without the fix each test exhausts its 3 s timeout (the hang *is* the demonstration); with it, the server settles a 400 and stays healthy (a follow-up `register` returns 201);
- `Content-Length: 4 MiB` trickled in 256 KiB chunks → 400 received on the wire after ~1.25 MiB (early rejection, `bytesWritten < 4 MiB`);
- regression: a valid JSON body in two chunks with a pause still returns 201 + `client_id`.

## Verification

- New suite **fails without the fix** (4 failed: the three abort tests hit their timeouts, the cap test its 5 s limit — and `server.stop()` itself hangs) and passes with it; revert/re-apply cycle re-confirmed.
- Touched suites + the full OAuth suite: **20/20** ✅
- `tsc --noEmit` ✅ · prettier ✅ · eslint ✅ (touched files)
- Full-suite flakes on this machine are the same pre-existing Windows ones seen on clean `main` (`diskStore > take > concurrent callers`, `DiscoveryDocumentCache` TTL timings) — no regression.

Not verified: only Node v24.14.1 on Windows (the dual listener covers other versions by construction but wasn't run); no proxies/TLS in front, no `basePath` in the new tests; no heap measurement for the DoS case.

AI-assisted: drafted with AI assistance and verified locally as above.
