### PR TITLE
fix: report unsupported tool schemas early

### DIFF
--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -351,6 +351,38 @@ export class UnexpectedStateError extends FastMCPError {
  */
 export class UserError extends UnexpectedStateError {}
 
+function assertStandardSchema(
+  toolName: string,
+  schemaName: "outputSchema" | "parameters",
+  schema: ToolParameters,
+): void {
+  const standard = (schema as { "~standard"?: { validate?: unknown } })[
+    "~standard"
+  ];
+
+  if (typeof standard?.validate === "function") {
+    return;
+  }
+
+  throw new UserError(
+    `Tool '${toolName}' ${schemaName} must implement Standard Schema. If you are using Zod, upgrade to version 3.24 or later.`,
+  );
+}
+
+function assertToolSchemas(tool: {
+  name: string;
+  outputSchema?: ToolParameters;
+  parameters?: ToolParameters;
+}): void {
+  if (tool.parameters) {
+    assertStandardSchema(tool.name, "parameters", tool.parameters);
+  }
+
+  if (tool.outputSchema) {
+    assertStandardSchema(tool.name, "outputSchema", tool.outputSchema);
+  }
+}
+
 const TextContentZodSchema = z
   .object({
     /**
@@ -2656,6 +2688,8 @@ export class FastMCP<
    * Adds a tool to the server.
    */
   public addTool<Params extends ToolParameters>(tool: Tool<T, Params>) {
+    assertToolSchemas(tool);
+
     // Remove existing tool with the same name
     this.#tools = this.#tools.filter((t) => t.name !== tool.name);
     this.#tools.push(tool as unknown as Tool<T>);
@@ -2667,6 +2701,8 @@ export class FastMCP<
    * Adds tools to the server.
    */
   public addTools<Params extends ToolParameters>(tools: Tool<T, Params>[]) {
+    tools.forEach(assertToolSchemas);
+
     const newToolNames = new Set(tools.map((tool) => tool.name));
     this.#tools = this.#tools.filter((t) => !newToolNames.has(t.name));
     this.#tools.push(...(tools as unknown as Tool<T>[]));

--- a/src/FastMCP.validators.test.ts
+++ b/src/FastMCP.validators.test.ts
@@ -15,6 +15,36 @@ import { FastMCP, FastMCPSession } from "./FastMCP.js";
 // validation on tools/call — so a regression in the non-Zod validators or
 // their JSON-Schema conversion can't slip through unnoticed.
 
+describe("tool schema registration", () => {
+  it("rejects parameters without Standard Schema support before starting a server", () => {
+    const server = new FastMCP({ name: "Test", version: "1.0.0" });
+
+    expect(() =>
+      server.addTool({
+        execute: async () => "ok",
+        name: "legacy-zod",
+        parameters: {} as never,
+      }),
+    ).toThrow(
+      "Tool 'legacy-zod' parameters must implement Standard Schema. If you are using Zod, upgrade to version 3.24 or later.",
+    );
+  });
+
+  it("rejects output schemas without Standard Schema support before starting a server", () => {
+    const server = new FastMCP({ name: "Test", version: "1.0.0" });
+
+    expect(() =>
+      server.addTool({
+        execute: async () => ({ answer: "ok" }),
+        name: "legacy-zod-output",
+        outputSchema: {} as never,
+      }),
+    ).toThrow(
+      "Tool 'legacy-zod-output' outputSchema must implement Standard Schema. If you are using Zod, upgrade to version 3.24 or later.",
+    );
+  });
+});
+
 const runWithTestServer = async ({
   run,
   server: providedServer,


### PR DESCRIPTION
## Summary

Validate tool `parameters` and `outputSchema` when tools are registered. Schemas that do not implement Standard Schema now fail immediately with an actionable message, including the Zod `>= 3.24` compatibility boundary.

## Why

Passing a Zod version older than 3.24 currently reaches `tools/list` and crashes inside `xsschema` with a cryptic internal error because the schema lacks `~standard`. The failure should identify the unsupported schema at `addTool()` / `addTools()` time instead.

## Validation

- `vitest run src/FastMCP.validators.test.ts` — 9 passing
- `tsc --noEmit`
- `prettier --check src/FastMCP.ts src/FastMCP.validators.test.ts`
- `git diff --check`

`vitest run` across the entire repository still encounters parallel HTTP-test fixture collisions and unhandled connection rejections in this Windows environment. The focused suite is clean.

Closes #168