### PR TITLE
fix(auth): normalize scope in JWKS claim mapping

### DIFF
--- a/src/auth/utils/jwks.test.ts
+++ b/src/auth/utils/jwks.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import type { JWTClaims } from "./jwtIssuer.js";
+
+import { requireScopes } from "../helpers.js";
+import { JWKSVerifier } from "./jwks.js";
+
+/**
+ * Drive `JWKSVerifier.verify()` against a stubbed `jose` so the claim-mapping
+ * block can be exercised without a live JWKS endpoint.
+ */
+async function verifyPayload(payload: Record<string, unknown>) {
+  const verifier = new JWKSVerifier({
+    jwksUri: "https://example.com/.well-known/jwks.json",
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const internals = verifier as any;
+  internals.joseLoaded = true;
+  internals.jose = {
+    jwtVerify: async () => ({ payload }),
+  };
+
+  return verifier.verify("header.payload.signature");
+}
+
+describe("JWKSVerifier", () => {
+  describe("scope normalization", () => {
+    it("should parse a space-delimited scope string into an array", async () => {
+      const result = await verifyPayload({
+        scope: "read:user write:data",
+        sub: "user-1",
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.claims?.scope).toEqual(["read:user", "write:data"]);
+    });
+
+    it("should pass an array scope through unchanged", async () => {
+      const result = await verifyPayload({
+        scope: ["read:user", "write:data"],
+        sub: "user-1",
+      });
+
+      expect(result.claims?.scope).toEqual(["read:user", "write:data"]);
+    });
+
+    it("should default a missing scope to an empty array", async () => {
+      const result = await verifyPayload({ sub: "user-1" });
+
+      expect(result.claims?.scope).toEqual([]);
+    });
+
+    it("should always produce the string[] that JWTClaims declares", async () => {
+      for (const scope of ["read", ["read"], undefined, "", 42]) {
+        const result = await verifyPayload({ scope, sub: "user-1" });
+
+        expect(Array.isArray(result.claims?.scope)).toBe(true);
+      }
+    });
+  });
+
+  describe("scope consumers", () => {
+    it("should satisfy requireScopes for a space-delimited upstream scope", async () => {
+      // RFC 9068 puts `scope` in an access token as a space-delimited string.
+      // A raw string reaching `requireScopes` fails every check, because the
+      // Set is built from the string's absence of array-ness.
+      const result = await verifyPayload({
+        scope: "read:user write:data",
+        sub: "user-1",
+      });
+
+      const canAccess = requireScopes("read:user");
+      expect(canAccess({ scopes: result.claims?.scope } as never)).toBe(true);
+    });
+
+    it("should not let a longer scope satisfy a prefix of it", async () => {
+      // `"read:userdata".includes("read:user")` is true for a string but false
+      // for the correctly-split array, so leaking the string form widens
+      // access rather than merely breaking it.
+      const result = await verifyPayload({
+        scope: "read:userdata",
+        sub: "user-1",
+      });
+
+      const canAccess = requireScopes("read:user");
+      expect(canAccess({ scopes: result.claims?.scope } as never)).toBe(false);
+    });
+
+    it("should expose a scope that supports array methods", async () => {
+      const result = await verifyPayload({ scope: "read write", sub: "u" });
+
+      const scope = (result.claims as unknown as JWTClaims).scope;
+      expect(scope.join(" ")).toBe("read write");
+      expect(scope.includes("read")).toBe(true);
+    });
+  });
+
+  describe("claim mapping", () => {
+    it("should preserve custom claims from the payload", async () => {
+      const result = await verifyPayload({
+        email: "user@example.com",
+        role: "admin",
+        scope: "read",
+        sub: "user-1",
+      });
+
+      expect(result.claims?.email).toBe("user@example.com");
+      expect(result.claims?.role).toBe("admin");
+      expect(result.claims?.sub).toBe("user-1");
+    });
+
+    it("should copy the standard claims through", async () => {
+      const result = await verifyPayload({
+        aud: "https://mcp.example.com",
+        exp: 2000,
+        iat: 1000,
+        iss: "https://issuer.example.com",
+        jti: "token-id",
+        sub: "user-1",
+      });
+
+      expect(result.claims?.aud).toBe("https://mcp.example.com");
+      expect(result.claims?.exp).toBe(2000);
+      expect(result.claims?.iat).toBe(1000);
+      expect(result.claims?.iss).toBe("https://issuer.example.com");
+      expect(result.claims?.jti).toBe("token-id");
+    });
+
+    it("should fall back to sub for a missing client_id", async () => {
+      const result = await verifyPayload({ sub: "user-42" });
+
+      expect(result.claims?.client_id).toBe("user-42");
+    });
+
+    it("should keep an explicit client_id over sub", async () => {
+      const result = await verifyPayload({
+        client_id: "client-abc",
+        sub: "user-42",
+      });
+
+      expect(result.claims?.client_id).toBe("client-abc");
+    });
+
+    it("should default a missing jti to an empty string", async () => {
+      const result = await verifyPayload({ sub: "user-1" });
+
+      expect(result.claims?.jti).toBe("");
+    });
+  });
+
+  describe("verify failures", () => {
+    it("should report the error when jose rejects the token", async () => {
+      const verifier = new JWKSVerifier({
+        jwksUri: "https://example.com/.well-known/jwks.json",
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const internals = verifier as any;
+      internals.joseLoaded = true;
+      internals.jose = {
+        jwtVerify: async () => {
+          throw new Error("signature verification failed");
+        },
+      };
+
+      const result = await verifier.verify("bad.token.here");
+
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe("signature verification failed");
+      expect(result.claims).toBeUndefined();
+    });
+  });
+
+  describe("getJwksUri", () => {
+    it("should return the configured URI", () => {
+      const verifier = new JWKSVerifier({
+        jwksUri: "https://example.com/.well-known/jwks.json",
+      });
+
+      expect(verifier.getJwksUri()).toBe(
+        "https://example.com/.well-known/jwks.json",
+      );
+    });
+  });
+});

--- a/src/auth/utils/jwks.ts
+++ b/src/auth/utils/jwks.ts
@@ -153,8 +153,15 @@ export class JWKSVerifier implements TokenVerifier {
       );
 
       // Map jose claims to TokenVerificationResult format
-      // Store all claims as Record<string, unknown> for compatibility
+      // Store all claims as Record<string, unknown> for compatibility.
+      //
+      // `...payload` comes first so the normalized entries below win. Spreading
+      // it last would undo them: `scope` in particular is declared `string[]`
+      // on JWTClaims, but RFC 9068 puts it in the token as a space-delimited
+      // string, so the raw value would leak through and break every consumer
+      // that treats it as an array.
       const claims: Record<string, unknown> = {
+        ...payload, // Include all other claims
         aud: payload.aud,
         client_id: payload.client_id || payload.sub,
         exp: payload.exp,
@@ -162,7 +169,6 @@ export class JWKSVerifier implements TokenVerifier {
         iss: payload.iss,
         jti: payload.jti || "",
         scope: this.parseScope(payload.scope),
-        ...payload, // Include all other claims
       };
 
       return {


### PR DESCRIPTION
Fixes #308

## Summary

`JWKSVerifier.verify()` built its claim object with the normalized standard claims first and then spread the raw jose payload **on top**, so the spread overwrote every normalization above it. `parseScope()` was dead code whenever the token carried a `scope` claim.

`scope` is the only entry actually damaged, which is why this went unnoticed: `aud`/`exp`/`iat`/`iss` are plain copies of the same payload keys, so overwriting them is a no-op, and the `client_id || sub` / `jti || ""` fallbacks only apply when those keys are absent — in which case the spread has nothing to overwrite with. Only the entry that is a genuine *transformation* breaks.

## Root cause

```ts
const claims: Record<string, unknown> = {
  aud: payload.aud,
  client_id: payload.client_id || payload.sub,
  exp: payload.exp,
  iat: payload.iat,
  iss: payload.iss,
  jti: payload.jti || "",
  scope: this.parseScope(payload.scope),   // computed...
  ...payload,                              // ...then overwritten
};
```

`JWKSVerificationResult.claims` is typed `JWTClaims`, whose `scope` is `string[]`. RFC 9068 puts `scope` in an access token as a space-delimited **string**, so that string is what reached the caller — a runtime value that contradicts its own declared type.

## Measured consequences

**1. Scope-based `canAccess` never passes for a JWKS-verified token.** `requireScopes` builds its Set only from arrays and Sets; a string falls through to `new Set()`, so every check denies:

```
payload.scope="read write"        -> claims.scope="read write"        requireScopes("read") = false
payload.scope=["read","write"]    -> claims.scope=["read","write"]    requireScopes("read") = true
```

**2. Array methods are absent.**

```
typeof scope.join = undefined
join() threw: s.join is not a function
```

`.map`, `.filter`, `.some`, `.every` likewise.

**3. `.includes()` degrades from array membership to a substring test — and it fails open.** `requireScopes` itself fails *closed*, but the obvious hand-rolled check against a declared `string[]` is `claims.scope.includes(...)`, and on a string that widens access:

| granted scope | required | `string.includes` | correct (array) | |
| --- | --- | --- | --- | --- |
| `read:userdata` | `read:user` | true | false | MISMATCH |
| `admin_readonly` | `admin` | true | false | MISMATCH |
| `profile` | `prof` | true | false | MISMATCH |
| `openid email` | `mail` | true | false | MISMATCH |

A token granted only `read:userdata` passes a `read:user` check; `admin_readonly` passes an `admin` check. 4/4 probe cases mismatched.

## Fix

Move `...payload` to the top of the object literal so the normalized entries win — a one-line move plus a comment explaining the ordering constraint, so it does not regress. All fallback and passthrough semantics are unchanged (verified by the tests below).

## Tests

`src/auth/utils/jwks.ts` had no test file; this adds one with 14 tests across 5 groups:

- **scope normalization** — space-delimited string, array passthrough, missing scope, and a loop over `["read", ["read"], undefined, "", 42]` asserting the result is always the `string[]` the type declares.
- **scope consumers** — the `requireScopes` round-trip; a guard that `read:userdata` must **not** satisfy `read:user` (pins the fix against a naive substring workaround); and array-method availability (`scope.join(" ") === "read write"`).
- **claim mapping** — custom claims (`email`/`role`/`sub`) pass through, the standard claims copy through, `client_id` falls back to `sub` and an explicit `client_id` wins, `jti` defaults to `""`.
- **verify failures** — a rejecting `jose` yields `valid: false` with the error and no claims.
- **getJwksUri**.

`verify()` is driven against a stubbed `jose` (`joseLoaded = true` plus a fake `jwtVerify`), so the claim-mapping block is exercised with arbitrary payloads and no live JWKS endpoint.

**Red-check on the unmodified source** — 4 of the 14 fail without the fix:

```
FAIL  src/auth/utils/jwks.test.ts > JWKSVerifier > scope normalization >
      should parse a space-delimited scope string into an array
AssertionError: expected 'read:user write:data' to deeply equal [ 'read:user', 'write:data' ]

FAIL  ... > should always produce the string[] that JWTClaims declares
AssertionError: expected false to be true

FAIL  ... > scope consumers > should satisfy requireScopes for a space-delimited upstream scope
AssertionError: expected false to be true

FAIL  ... > scope consumers > should expose a scope that supports array methods
TypeError: scope.join is not a function

Tests  4 failed | 10 passed (14)
```

The other 10 pass on the unmodified source and stay passing — they are contract guards, not regressions.

## Verification

- `npx vitest run` — **474 passed, 35 files** (up from 460 / 34 on `main`)
- `npx vitest run src/auth/utils/jwks.test.ts` — 14 passed
- `npx prettier --check` — clean
- `npx eslint` — clean
- `npx tsc --noEmit` — clean

(`pnpm lint` also runs `jsr publish --dry-run`, which I skipped; the other three gates were run individually as above.)
