### PR TITLE
docs: fix the advanced OAuth example so it compiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2015,20 +2015,23 @@ For more control over OAuth behavior, you can use the `oauth` option directly:
 import { FastMCP } from "fastmcp";
 import { GoogleProvider } from "fastmcp/auth";
 
-const authProxy = new GoogleProvider({
-  clientId: process.env.GOOGLE_CLIENT_ID,
-  clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+const authProvider = new GoogleProvider({
   baseUrl: "https://your-server.com",
+  clientId: process.env.GOOGLE_CLIENT_ID!,
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
   scopes: ["openid", "profile", "email"],
 });
 
 const server = new FastMCP({
   name: "My Server",
   oauth: {
+    authorizationServer: authProvider
+      .getProxy()
+      .getAuthorizationServerMetadata(),
     enabled: true,
-    authorizationServer: authProxy.getAuthorizationServerMetadata(),
-    proxy: authProxy,
+    proxy: authProvider.getProxy(),
   },
+  version: "1.0.0",
 });
 ```
 

--- a/docs/oauth-proxy-guide.md
+++ b/docs/oauth-proxy-guide.md
@@ -125,6 +125,7 @@ const server = new FastMCP({
     authorizationServer: authProxy.getAuthorizationServerMetadata(),
     proxy: authProxy,
   },
+  version: "1.0.0",
 });
 
 await server.start({


### PR DESCRIPTION
### What was broken

README → *OAuth Proxy* → **Advanced Configuration** builds a `GoogleProvider`
and then treats it as an `OAuthProxy`:

```ts
const authProxy = new GoogleProvider({ ... });

const server = new FastMCP({
  name: "My Server",
  oauth: {
    enabled: true,
    authorizationServer: authProxy.getAuthorizationServerMetadata(),
    proxy: authProxy,
  },
});
```

`getAuthorizationServerMetadata()` is on `OAuthProxy`; `GoogleProvider` extends
`AuthProvider`, which exposes the proxy through `getProxy()` (or the whole
config through `getOAuthConfig()`). The quick-start snippet right above it is
correct — this advanced one is the outlier, and it is the snippet you reach for
exactly when you have stopped using the `auth:` shortcut.

### How I checked

Pasted the snippet verbatim into a type-check against this repo's own `src`
(`tsc --strict`, TS 5.9.3):

```
error TS2339: Property 'getAuthorizationServerMetadata' does not exist on type 'GoogleProvider'.
error TS2740: Type 'GoogleProvider' is missing the following properties from type 'OAuthProxy': claimsExtractor, cleanupInterval, consentManager, registeredClientsByClientId, and 33 more.
error TS2322: Type 'string | undefined' is not assignable to type 'string'.   (clientId, clientSecret)
error TS2345: Property 'version' is missing in type '{ name: string; oauth: {...} }' but required in type 'ServerOptions<FastMCPSessionAuth>'.
```

Then ran the provider at runtime under vitest to confirm which member actually
exists:

```
getOAuthConfig keys: authorizationServer,enabled,protectedResource,proxy
(provider).getAuthorizationServerMetadata -> undefined
server constructed OK
✓ 1 test passed
```

The replacement snippet type-checks clean (`tsc` exit 0), and
`npx prettier --check README.md docs/oauth-proxy-guide.md` passes.

### What it is now

```ts
const authProvider = new GoogleProvider({
  baseUrl: "https://your-server.com",
  clientId: process.env.GOOGLE_CLIENT_ID!,
  clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
  scopes: ["openid", "profile", "email"],
});

const server = new FastMCP({
  name: "My Server",
  oauth: {
    authorizationServer: authProvider
      .getProxy()
      .getAuthorizationServerMetadata(),
    enabled: true,
    proxy: authProvider.getProxy(),
  },
  version: "1.0.0",
});
```

`docs/oauth-proxy-guide.md` has the same server options one section over; there
the object really is an `OAuthProxy`, so only the missing `version` is added.

Docs only — no source files touched. Happy to switch the README example to
`oauth: authProvider.getOAuthConfig()` instead if you prefer the shorter form;
I kept the explicit object because the section is about spelling the options out.

---
Assisted-by: Claude Opus 5 — drafted and verified by Anton's AI cofounder
running on his account; the errors and test output above are from real runs.
