### PR TITLE
fix(auth): stop the token storage timer in OAuthProxy.destroy()

### DIFF
--- a/src/auth/OAuthProxy.destroy.test.ts
+++ b/src/auth/OAuthProxy.destroy.test.ts
@@ -1,0 +1,75 @@
+/**
+ * `destroy()` is the only teardown the proxy exposes, so it has to release
+ * everything the proxy allocated. A `setInterval` that is never cleared keeps
+ * the Node event loop alive: a process that has stopped serving never exits on
+ * its own. The proxy cleared its own sweep timer, but not the one belonging to
+ * the `MemoryTokenStorage` it creates when the caller supplies no storage —
+ * which, once wrapped in `EncryptedTokenStorage` (no `destroy()`), was no
+ * longer reachable from anywhere.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { OAuthProxy } from "./OAuthProxy.js";
+import { MemoryTokenStorage } from "./utils/tokenStore.js";
+
+const baseConfig = {
+  baseUrl: "https://proxy.example.com",
+  upstreamAuthorizationEndpoint: "https://provider.com/oauth/authorize",
+  upstreamClientId: "upstream-client-id",
+  upstreamClientSecret: "upstream-client-secret",
+  upstreamTokenEndpoint: "https://provider.com/oauth/token",
+};
+
+/** How many timers are currently keeping the event loop alive. */
+const activeTimers = () =>
+  process.getActiveResourcesInfo().filter((type) => type === "Timeout").length;
+
+describe("OAuthProxy destroy", () => {
+  it("releases the timers of the token storage it created for itself", () => {
+    const before = activeTimers();
+
+    const proxy = new OAuthProxy(baseConfig);
+
+    // Sanity check, so the assertion below cannot pass vacuously: two timers
+    // start here, the proxy's own cleanup sweep and the fallback storage's.
+    expect(activeTimers()).toBeGreaterThan(before);
+
+    proxy.destroy();
+
+    // Nothing between the reads awaits, so no other task can add or remove a
+    // timer in between. Before the fix the storage timer survived and this
+    // came back one over the baseline.
+    expect(activeTimers()).toBe(before);
+  });
+
+  it("leaves a caller-supplied storage running", async () => {
+    const before = activeTimers();
+
+    const tokenStorage = new MemoryTokenStorage();
+    const withCallerStorage = activeTimers();
+
+    const proxy = new OAuthProxy({ ...baseConfig, tokenStorage });
+    proxy.destroy();
+
+    // The proxy tears down what it created, not what it was handed: the caller
+    // may share one storage between proxies, or keep using it afterwards.
+    expect(activeTimers()).toBe(withCallerStorage);
+
+    await tokenStorage.save("still-usable", "value");
+    expect(await tokenStorage.get("still-usable")).toBe("value");
+
+    tokenStorage.destroy();
+    expect(activeTimers()).toBe(before);
+  });
+
+  it("can be called twice", () => {
+    const before = activeTimers();
+
+    const proxy = new OAuthProxy(baseConfig);
+    proxy.destroy();
+    proxy.destroy();
+
+    expect(activeTimers()).toBe(before);
+  });
+});

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -66,6 +66,14 @@ export class OAuthProxy {
   private consentManager: ConsentManager;
   private jwtIssuer?: JWTIssuer;
   /**
+   * The fallback storage this proxy created for itself, if any. It runs a
+   * cleanup timer that keeps the event loop alive, so `destroy()` has to stop
+   * it — and once the storage is wrapped for encryption it is reachable
+   * through nothing else. A caller-supplied storage is deliberately not
+   * recorded here: its lifetime belongs to the caller.
+   */
+  private ownedTokenStorage: MemoryTokenStorage | null = null;
+  /**
    * Keyed by proxy-issued client_id for authorize/token-exchange lookups and
    * for the defence-in-depth callback checks. A registration never changes
    * after it is written, so caching it locally cannot go stale; it is also
@@ -88,7 +96,12 @@ export class OAuthProxy {
     };
 
     // Set up token storage with encryption by default (matches Python's secure defaults)
-    let storage = config.tokenStorage || new MemoryTokenStorage();
+    let storage = config.tokenStorage;
+
+    if (!storage) {
+      this.ownedTokenStorage = new MemoryTokenStorage();
+      storage = this.ownedTokenStorage;
+    }
 
     // Wrap storage with encryption if not already encrypted
     // Check if it's already an EncryptedTokenStorage instance
@@ -210,6 +223,10 @@ export class OAuthProxy {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = null;
     }
+
+    // Only the storage this proxy created for itself; a caller-supplied one is
+    // theirs to destroy.
+    this.ownedTokenStorage?.destroy();
 
     this.registeredClientsByClientId.clear();
   }


### PR DESCRIPTION
## Summary

`OAuthProxy.destroy()` (`src/auth/OAuthProxy.ts:208`) is documented as "Stop cleanup interval and destroy resources", and it is the only teardown the proxy exposes. It clears its own sweep timer but not the one owned by the storage it built for itself.

When no `tokenStorage` is configured the constructor falls back to `new MemoryTokenStorage()` (`:91`), whose constructor starts a 60 s `setInterval` (`src/auth/utils/tokenStore.ts:145`). That interval is not `unref()`ed — `grep -rn "unref" src/` has no hits anywhere in the tree — so it counts as an active handle and keeps the Node event loop alive. `MemoryTokenStorage` does have a `destroy()` (`tokenStore.ts:173`), but the instance is immediately wrapped in `EncryptedTokenStorage` (`OAuthProxy.ts:105`), which exposes no `destroy()`, so after the constructor returns nothing holds a reference to it.

Net effect: a process that constructs an `OAuthProxy` never exits on its own, and calling `destroy()` does not change that.

```
$ node exit-demo.mjs          # build a proxy, destroy it, fall off the end of the script
[before destroy] [ 'Timeout', 'Timeout' ]
[after  destroy] [ 'Timeout' ]
[end of script] nothing left to do
                              # ...and then nothing. Killed at 20 s; the "exit" handler never ran.
```

With the fix, same script:

```
[before destroy] [ 'Timeout', 'Timeout' ]
[after  destroy] []
[end of script] nothing left to do
[exit] after 44 ms
```

(Reproduced identically on Linux/Node 24.19 and Windows/Node 24.14, against `pnpm build` output.)

## Fix

Keep a reference to the storage the proxy creates for itself and destroy it next to the sweep timer — 3 lines of code plus comments, no public API change.

The alternative was to give `EncryptedTokenStorage` a `destroy()` that delegates to its backend. I did not take it, because the wrapper cannot tell an owned backend from a borrowed one: with `tokenStorage` supplied by the caller, `proxy.destroy()` would reach through the wrapper and stop a timer — and clear a `Map` — belonging to an object the proxy never created and may not be the last user of. Sharing one storage between two proxies is a supported configuration (`OAuthProxy.storage-persistence.test.ts` does exactly that), and it would break. The second test below pins that boundary down; I prototyped the delegating variant and it fails on it:

```
 FAIL  src/auth/OAuthProxy.destroy.test.ts > OAuthProxy destroy > leaves a caller-supplied storage running
AssertionError: expected 1 to be 2
```

**Why not `unref()` the interval instead?** It would silence this symptom, and it is strictly weaker:

- It hides the leak rather than releasing it. The timer, the closure and the entry `Map` stay alive for the life of the process; only the event-loop keep-alive vote is dropped. A long-running host that creates and discards proxies (tests, dynamic reconfiguration) still accumulates them without bound, and `destroy()` still fails to do what it says.
- It would make the leak untestable by exactly the check used here: `process.getActiveResourcesInfo()` reports only resources that keep the loop alive, so an `unref()`ed `Timeout` disappears from it. The regression test would go green while the handle remained.
- It also changes behaviour for the intended use — a storage that only sweeps while something else keeps the process up is a reasonable default, but that is a separate design decision, not this bug.

I left it out; the two are independent and `unref()` can still be added later on top.

**Also deliberately out of scope:** `FastMCP.stop()` (`src/FastMCP.ts:3289`) does not call `oauthProxy.destroy()`, so a FastMCP user who only calls `stop()` keeps both timers. Adding the call is one line, but it has the same ownership problem in a different place — the proxy arrives from user config (`oauth.proxy`), FastMCP does not own it, and destroying it would also wipe `registeredClientsByClientId`, breaking a `stop()` → `start()` cycle on the same proxy. That needs a decision about lifecycle ownership rather than a one-liner, so I would rather raise it separately if you want it.

## Tests

New `src/auth/OAuthProxy.destroy.test.ts`, 3 tests, style copied from the sister OAuth suites. The counts are read synchronously either side of `destroy()`, so nothing else can add or remove a timer in between:

- **releases the timers of the token storage it created for itself** — the red one. Also asserts the count goes *up* on construction first, so it cannot pass vacuously.
- **leaves a caller-supplied storage running** — with `tokenStorage` passed in, `destroy()` must not touch it; the storage is still usable afterwards. This is the guard against the delegating variant described above.
- **can be called twice** — idempotent.

Without the fix (both platforms):

```
 ❯ src/auth/OAuthProxy.destroy.test.ts (3 tests | 2 failed) 119ms
     × releases the timers of the token storage it created for itself 45ms
     ✓ leaves a caller-supplied storage running 37ms
     × can be called twice 36ms

 FAIL  ... > releases the timers of the token storage it created for itself
AssertionError: expected 2 to be 1

 FAIL  ... > can be called twice
AssertionError: expected 3 to be 2
```

(The second failure's `3` rather than `2` is the accumulation: the leaked timer from the first test is still there.)

With the fix:

```
 ✓ src/auth/OAuthProxy.destroy.test.ts (3 tests) 133ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Revert/re-apply cycle re-confirmed on both platforms.

## Verification

- Full suite, Linux / Node 24.19.0: **502 passed (502)**, 38 files — same environment as CI.
- `pnpm lint` on Linux: prettier ✅ · eslint ✅ · `tsc --noEmit` ✅ · `jsr publish --dry-run` ✅.
- Full suite, Windows / Node 24.14.1: 502/502, three consecutive runs, no flakes.
- Clean `main` on the same Windows box is not reliably green (one run failed `FastMCP.validators.test.ts > tool parameters via ArkType` on a 5 s timeout, another failed two `DiscoveryDocumentCache` TTL tests, a third was green). Both are timing-sensitive and unrelated to auth; the branch was green 3/3.

**Not verified:** only Node 24 (the change is plain `clearInterval` bookkeeping, but no other major was run); no test asserts that a real FastMCP server process exits — the exit demo drives `OAuthProxy` directly from `dist/` output. Out of scope but adjacent: `DiskStore` starts the same kind of 60 s interval (`src/auth/utils/diskStore.ts:62`), but it is always constructed explicitly by the caller and exposes its own `destroy()` (`:122`), so it is reachable and not part of this bug.

AI-assisted: drafted with AI assistance and verified locally as above.
