### PR TITLE
fix(auth): use a constant-time comparison for the PKCE challenge

### DIFF
--- a/src/auth/utils/pkce.test.ts
+++ b/src/auth/utils/pkce.test.ts
@@ -92,6 +92,54 @@ describe("PKCEUtils", () => {
       expect(PKCEUtils.validateChallenge("", "challenge", "S256")).toBe(false);
       expect(PKCEUtils.validateChallenge("verifier", "", "S256")).toBe(false);
     });
+
+    // Regression tests for CWE-208: both branches compare with
+    // crypto.timingSafeEqual behind a length guard, like the cookie signature
+    // in consent.ts and the JWT signature in jwtIssuer.ts.
+    //
+    // These pin behaviour and the length guard, not the timing itself: a
+    // statistical timing assertion is flaky in CI and would be the kind of test
+    // that fails for reasons unrelated to the change.
+    it("rejects a same-length wrong verifier in the plain branch", () => {
+      const verifier = PKCEUtils.generateVerifier();
+      // Flip one character while preserving length → reaches timingSafeEqual
+      // instead of short-circuiting on the length guard.
+      const forged = (verifier[0] === "a" ? "b" : "a") + verifier.slice(1);
+      expect(forged).toHaveLength(verifier.length);
+      expect(forged).not.toBe(verifier);
+
+      expect(PKCEUtils.validateChallenge(forged, verifier, "plain")).toBe(
+        false,
+      );
+      expect(PKCEUtils.validateChallenge(verifier, verifier, "plain")).toBe(
+        true,
+      );
+    });
+
+    // timingSafeEqual throws on length mismatch, so without the length guard
+    // this would be a 500 from the token endpoint instead of invalid_grant.
+    it("rejects a different-length verifier without throwing", () => {
+      const verifier = PKCEUtils.generateVerifier();
+
+      expect(() =>
+        PKCEUtils.validateChallenge(`${verifier}extra`, verifier, "plain"),
+      ).not.toThrow();
+      expect(
+        PKCEUtils.validateChallenge(`${verifier}extra`, verifier, "plain"),
+      ).toBe(false);
+    });
+
+    it("rejects a same-length wrong challenge in the S256 branch", () => {
+      const verifier = PKCEUtils.generateVerifier();
+      const challenge = PKCEUtils.generateChallenge(verifier, "S256");
+      const forged = (challenge[0] === "a" ? "b" : "a") + challenge.slice(1);
+      expect(forged).toHaveLength(challenge.length);
+
+      expect(PKCEUtils.validateChallenge(verifier, forged, "S256")).toBe(false);
+      expect(PKCEUtils.validateChallenge(verifier, challenge, "S256")).toBe(
+        true,
+      );
+    });
   });
 
   describe("generatePair", () => {

--- a/src/auth/utils/pkce.timing-safe.test.ts
+++ b/src/auth/utils/pkce.timing-safe.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Pass-through spy: every other crypto export keeps its real implementation, so
+// generateVerifier/generateChallenge behave normally.
+//
+// This lives in its own file on purpose. Mocking `crypto` is file-scoped, and
+// keeping it out of pkce.test.ts means the existing suite runs against the real
+// module untouched.
+vi.mock("crypto", async (importOriginal) => {
+  const real = await importOriginal<typeof import("crypto")>();
+  return { ...real, timingSafeEqual: vi.fn(real.timingSafeEqual) };
+});
+
+import { timingSafeEqual } from "crypto";
+
+import { PKCEUtils } from "./pkce.js";
+
+/**
+ * These assert the *mechanism*, not the behaviour, and that is deliberate.
+ *
+ * A constant-time comparison returns exactly what `===` returned, so no
+ * behavioural test can tell the two apart — I checked: the behavioural cases in
+ * pkce.test.ts pass identically with and without the fix. For CWE-208 the
+ * mechanism is the contract, so the mechanism is what gets pinned.
+ *
+ * A statistical timing assertion would be the other option and a bad one: it is
+ * flaky under CI load and would fail for reasons unrelated to this code.
+ */
+describe("PKCEUtils.validateChallenge is constant-time (CWE-208)", () => {
+  it("routes the plain branch through timingSafeEqual", () => {
+    vi.mocked(timingSafeEqual).mockClear();
+    const verifier = PKCEUtils.generateVerifier();
+
+    expect(PKCEUtils.validateChallenge(verifier, verifier, "plain")).toBe(true);
+    expect(vi.mocked(timingSafeEqual)).toHaveBeenCalled();
+  });
+
+  it("routes the S256 branch through timingSafeEqual", () => {
+    vi.mocked(timingSafeEqual).mockClear();
+    const verifier = PKCEUtils.generateVerifier();
+    const challenge = PKCEUtils.generateChallenge(verifier, "S256");
+
+    expect(PKCEUtils.validateChallenge(verifier, challenge, "S256")).toBe(true);
+    expect(vi.mocked(timingSafeEqual)).toHaveBeenCalled();
+  });
+
+  // The length guard has to short-circuit: timingSafeEqual throws on buffers of
+  // different sizes, which would turn an invalid_grant into a 500 at the token
+  // endpoint.
+  it("short-circuits on a length mismatch without reaching timingSafeEqual", () => {
+    vi.mocked(timingSafeEqual).mockClear();
+    const verifier = PKCEUtils.generateVerifier();
+
+    expect(
+      PKCEUtils.validateChallenge(`${verifier}extra`, verifier, "plain"),
+    ).toBe(false);
+    expect(vi.mocked(timingSafeEqual)).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth/utils/pkce.ts
+++ b/src/auth/utils/pkce.ts
@@ -3,7 +3,7 @@
  * Implements RFC 7636 for OAuth 2.0 public clients
  */
 
-import { createHash, randomBytes } from "crypto";
+import { createHash, randomBytes, timingSafeEqual } from "crypto";
 
 import type { PKCEPair } from "../types.js";
 
@@ -84,12 +84,20 @@ export class PKCEUtils {
     }
 
     if (method === "plain") {
-      return verifier === challenge;
+      // `verifier` arrives straight from the token request and `challenge` is
+      // the stored secret, so this is the comparison that has to be constant
+      // time: with `===` the number of matching leading bytes is observable.
+      return equalsConstantTime(verifier, challenge);
     }
 
     if (method === "S256") {
       const computedChallenge = PKCEUtils.generateChallenge(verifier, "S256");
-      return computedChallenge === challenge;
+      // Weaker exposure than the plain branch — `challenge` travelled in the
+      // authorization request and is not secret, so timing here reveals how
+      // close a hash is to a value the attacker already holds. Compared the
+      // same way anyway: one comparison helper is easier to keep correct than
+      // two, and a future caller should not have to know which branch is safe.
+      return equalsConstantTime(computedChallenge, challenge);
     }
 
     // Unknown method
@@ -108,4 +116,19 @@ export class PKCEUtils {
       .replace(/\//g, "_")
       .replace(/=/g, "");
   }
+}
+
+/**
+ * Constant-time string comparison (CWE-208).
+ *
+ * `timingSafeEqual` throws when the two buffers differ in length, so the length
+ * check has to come first — same guard already used for cookie signatures in
+ * `consent.ts` and JWT signatures in `jwtIssuer.ts`. Comparing lengths is not a
+ * leak worth worrying about here: the verifier length is bounded by RFC 7636 to
+ * 43-128 characters and is not secret.
+ */
+function equalsConstantTime(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB);
 }


### PR DESCRIPTION
## Summary

`PKCEUtils.validateChallenge` compares the PKCE challenge with `===`, so the number of matching leading bytes is observable through timing (CWE-208). This is the same class of issue as #301, which you merged on 2026-08-01 for the JWT and consent signatures.

```ts
// src/auth/utils/pkce.ts
if (method === "plain") {
  return verifier === challenge;
}
if (method === "S256") {
  const computedChallenge = PKCEUtils.generateChallenge(verifier, "S256");
  return computedChallenge === challenge;
}
```

## Why the `plain` branch is the one that matters

I want to be precise about the exposure rather than overstate it, because the two branches are not equally affected.

**`plain` is reachable and exploitable.** The proxy advertises it — `OAuthProxy.ts:368` returns `codeChallengeMethodsSupported: ["S256", "plain"]` — so a client can legitimately pick it. At the token endpoint (`OAuthProxy.ts:280`) the call is:

```ts
PKCEUtils.validateChallenge(
  request.code_verifier,      // attacker-controlled, straight off the request
  clientCode.codeChallenge,   // the stored secret
  clientCode.codeChallengeMethod,
);
```

With `method === "plain"` that reduces to `verifier === challenge`: an attacker holding a stolen authorization code can probe the stored verifier byte by byte instead of having to know it. PKCE-plain is already the weaker mode by RFC 7636, and this erodes the one barrier it still provides.

**`S256` leaks much less.** There, `challenge` travelled in the authorization request and is not secret, so timing reveals how close `SHA-256(guess)` is to a value the attacker already holds — no path to the verifier without a preimage.

I changed both anyway. One comparison helper is easier to keep correct than two, and a future caller should not have to work out which branch happens to be safe.

**Not changed, deliberately:** `plain` stays advertised. Dropping it from `codeChallengeMethodsSupported` would break clients that use it, and that is a compatibility decision for you rather than part of a security fix.

## Fix

A module-level `equalsConstantTime` using `crypto.timingSafeEqual` behind a length guard — the same shape already in `consent.ts:286` and `jwtIssuer.ts`. The guard is required, not stylistic: `timingSafeEqual` throws on buffers of different sizes, which would turn an `invalid_grant` into a 500 at the token endpoint. Comparing lengths is not a meaningful leak here, since RFC 7636 bounds the verifier to 43–128 characters and the length is not secret.

## Tests

**The behavioural tests cannot prove this fix, and I checked rather than assumed.** A constant-time comparison returns exactly what `===` returned, so I ran the extended `pkce.test.ts` against unpatched `main`: **16/16 passed**. Behaviour is identical by design.

So the mechanism is what gets pinned, in a separate file (`pkce.timing-safe.test.ts`) whose `vi.mock("crypto")` is a pass-through spy — every other crypto export keeps its real implementation, and the existing suite is untouched because the mock is file-scoped:

| Test | Asserts |
|---|---|
| routes the plain branch through timingSafeEqual | the exploitable path is covered |
| routes the S256 branch through timingSafeEqual | the other path is covered |
| short-circuits on a length mismatch | the guard runs *before* the throw-prone call |

Against unpatched `main`:

```
 × routes the plain branch through timingSafeEqual
 × routes the S256 branch through timingSafeEqual
AssertionError: expected "vi.fn()" to be called at least once
 Tests  2 failed | 1 passed (3)
```

With the fix: `Tests  19 passed (19)` across both PKCE files, and **`src/auth` is 241 passed (241), 16 files**.

`prettier --check`, `eslint` and `tsc --noEmit` are clean.

## What I did not verify

I did **not** measure timing. There is no statistical timing assertion here and I make no claim about how many bytes were actually recoverable in practice — that depends on network jitter, the JIT and the deployment, and a timing test would be flaky under CI load. The claim is narrower and checkable: an attacker-controlled value was compared against a stored secret with a comparison that short-circuits, and now it is not.

I also did not run the suite on anything but Node 24 on Windows, and I did not exercise a real OAuth client end to end against the token endpoint — the reasoning about reachability comes from reading `OAuthProxy.ts`, not from driving a live flow.

AI-assisted: drafted with AI assistance and verified locally as described.
