### PR TITLE
fix: give outputSchema precedence over type/content result shorthands

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -5505,6 +5505,104 @@ test("validates explicit structuredContent against outputSchema", async () => {
   });
 });
 
+test("returns structuredContent when the outputSchema result has a top-level `type` key", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {
+            city: "San Francisco",
+          },
+          name: "get-forecast",
+        }),
+      ).toEqual({
+        content: [
+          {
+            text: JSON.stringify({ temperature: 72, type: "sunny" }),
+            type: "text",
+          },
+        ],
+        structuredContent: {
+          temperature: 72,
+          type: "sunny",
+        },
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Get a weather forecast for a city",
+        execute: async () => {
+          return { temperature: 72, type: "sunny" };
+        },
+        name: "get-forecast",
+        outputSchema: z.object({
+          temperature: z.number(),
+          type: z.string(),
+        }),
+        parameters: z.object({
+          city: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("returns structuredContent when the outputSchema result has a top-level `content` key", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {
+            city: "San Francisco",
+          },
+          name: "get-forecast",
+        }),
+      ).toEqual({
+        content: [
+          {
+            text: JSON.stringify({ content: "clear skies", version: 3 }),
+            type: "text",
+          },
+        ],
+        structuredContent: {
+          content: "clear skies",
+          version: 3,
+        },
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "Get a weather forecast for a city",
+        execute: async () => {
+          return { content: "clear skies", version: 3 };
+        },
+        name: "get-forecast",
+        outputSchema: z.object({
+          content: z.string(),
+          version: z.number(),
+        }),
+        parameters: z.object({
+          city: z.string(),
+        }),
+      });
+
+      return server;
+    },
+  });
+});
+
 test("passes through result _meta from tool execute", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2443,11 +2443,15 @@ export class FastMCPSession<
           result = ContentResultZodSchema.parse({
             content: [{ text: maybeStringResult, type: "text" }],
           });
-        } else if ("type" in maybeStringResult) {
-          result = ContentResultZodSchema.parse({
-            content: [maybeStringResult],
-          });
-        } else if ("content" in maybeStringResult) {
+        } else if (
+          "content" in maybeStringResult &&
+          Array.isArray(maybeStringResult.content)
+        ) {
+          // Explicit ContentResult: the tool returned MCP content directly
+          // (`{ content: [...], structuredContent? }`). An array-valued
+          // `content` is the ContentResult signature, so this takes precedence
+          // over outputSchema, letting a tool ship custom content blocks
+          // alongside its structured payload.
           result = ContentResultZodSchema.parse(maybeStringResult);
           if (result.structuredContent !== undefined && tool.outputSchema) {
             result.structuredContent = await this.#validateStructuredContent(
@@ -2457,6 +2461,12 @@ export class FastMCPSession<
             );
           }
         } else if (tool.outputSchema) {
+          // A tool that declares an outputSchema returns its structured payload
+          // directly, so outputSchema wins over the `type`/`content` shorthands
+          // below. Without this precedence a payload whose top-level shape
+          // happens to include a `type` key (the common discriminated-union
+          // case) or a non-array `content` key would be misrouted as MCP
+          // content and never surface as structuredContent.
           const structuredContent = await this.#validateStructuredContent(
             tool,
             maybeStringResult,
@@ -2471,6 +2481,12 @@ export class FastMCPSession<
             ],
             structuredContent,
           });
+        } else if ("type" in maybeStringResult) {
+          result = ContentResultZodSchema.parse({
+            content: [maybeStringResult],
+          });
+        } else if ("content" in maybeStringResult) {
+          result = ContentResultZodSchema.parse(maybeStringResult);
         } else {
           result = ContentResultZodSchema.parse(maybeStringResult);
         }


### PR DESCRIPTION
## What's wrong

A tool that declares an `outputSchema` and returns an object whose top-level shape carries a
`type` key — the most common case in TypeScript, a discriminated union — or a `content` key is
treated as raw MCP content instead of `structuredContent`. The call comes back with
`isError: true` and `structuredContent: undefined`.

```ts
server.addTool({
  name: "get-forecast",
  outputSchema: z.object({ temperature: z.number(), type: z.string() }),
  parameters: z.object({ city: z.string() }),
  execute: async () => ({ temperature: 72, type: "sunny" }),
});
// callTool -> { content: [{ type: "text", text: "Tool 'get-forecast' execution failed: [{ code: 'invalid_union', note: 'No matching discriminator' ... }]" }], isError: true }
// structuredContent is never sent.
```

The README promises the opposite (currently around line 678):

> Tools can declare an `outputSchema` and return structured data. FastMCP exposes that value
> as MCP `structuredContent`, while also returning a JSON text fallback for clients that only
> render text content.

## Root cause

In `src/FastMCP.ts`, the tool-result handling routes on the *shape* of the returned value, and
the `type`/`content` shorthands are checked **before** the `outputSchema` branch:

```ts
} else if ("type" in maybeStringResult) {        // ~:2446  -> wraps as content: [value]
  ...
} else if ("content" in maybeStringResult) {     // ~:2450  -> parses as ContentResult
  ...
} else if (tool.outputSchema) {                  // ~:2459  -> the structuredContent branch
  ...
}
```

So when the structured payload happens to include a top-level `type` (discriminated union) or a
`content` key, it is captured by an earlier branch and never reaches the `outputSchema` branch:

- `{ type: "sunny", temperature: 72 }` is wrapped as `content: [value]`, then
  `ContentResultZodSchema.parse` rejects `"sunny"` against the content discriminated union
  (`invalid_union` / "No matching discriminator") -> error.
- `{ content: "clear skies", version: 3 }` is fed to `ContentResultZodSchema.parse` directly,
  which is `.strict()` and requires `content` to be an array, so it fails on both the type of
  `content` and the unrecognized `version` key -> error.

This slipped through because the only existing structured-output test returns
`{ humidity, temperature }` (no `type`/`content` key), so the shorthands never fired.

## The fix

Give `outputSchema` precedence over the `type`/`content` shorthands, while **preserving** the
one legitimate case where a tool with an `outputSchema` still returns MCP content directly.

The disambiguation is the shape of an explicit `ContentResult`: an object whose `content` is an
**array** (`{ content: [...], structuredContent? }`). That is the MCP `ContentResult` signature
and is exactly what the existing "validates explicit structuredContent against outputSchema"
test returns. New branch order:

1. `undefined` / `null`
2. `string`
3. **explicit ContentResult** — `"content" in result && Array.isArray(result.content)` — parse
   as `ContentResult`, and still validate its `structuredContent` against `outputSchema` when
   present. *(Checked before `outputSchema` so a tool can ship custom content blocks alongside
   its structured payload — the case the existing test covers.)*
4. **`tool.outputSchema`** — validate the whole object against the schema and emit
   `structuredContent` + the JSON text fallback. *(Now catches the `type`-keyed and non-array
   `content`-keyed payloads.)*
5. `"type" in result` — single-content-block shorthand (only reached without an `outputSchema`)
6. `"content" in result` / fallback — unchanged

Why the array check is the right seam: a discriminated-union payload like
`{ type: "text", text: "..." }` is *shape-indistinguishable* from a single text content block,
so no structural heuristic can separate them. The `outputSchema` declaration is the tiebreaker —
if the author declared it, the return value is their structured payload. The only shape that is
unambiguously MCP content is an explicit `ContentResult` (array-valued `content`), so that is the
sole case kept ahead of `outputSchema`.

### Behaviour note (intended)

With this change, a tool that declares an `outputSchema` **and** returns a bare content block
such as `{ type: "text", text: "..." }` will now have that object validated against the
`outputSchema` (and error if it does not match) instead of being emitted as content. That is the
intended contract: once you declare an `outputSchema`, the returned object is your structured
output; to return content blocks as well, use the explicit `ContentResult` form
(`{ content: [...], structuredContent }`), which keeps working.

## Tests

Two tests added next to the existing `outputSchema` suite in `src/FastMCP.test.ts`:

- `returns structuredContent when the outputSchema result has a top-level` **`type`** `key`
- `returns structuredContent when the outputSchema result has a top-level` **`content`** `key`

Both assert the correct `structuredContent` plus the JSON text fallback. The existing
`validates explicit structuredContent against outputSchema` (explicit `ContentResult`) and
`returns an error when structuredContent fails outputSchema validation` tests stay green,
confirming the precedence and the explicit-content path both hold.

## Verification

- Before the fix, the two new tests fail with `isError: true` and no `structuredContent`
  (`invalid_union` / "No matching discriminator" for the `type` case; `invalid_type`
  expected array + `unrecognized_keys` for the `content` case).
- After the fix, both pass.
- Full suite green: **42 files, 528 tests passed** (`vitest run`).
- `tsc --noEmit`, `prettier --check`, and `eslint` all clean on the changed files.

