### PR TITLE
fix: trim completions over 100 values instead of failing

### DIFF
--- a/src/FastMCP.completions.test.ts
+++ b/src/FastMCP.completions.test.ts
@@ -122,6 +122,46 @@ describe("FastMCP Completions", () => {
     });
   });
 
+  it("trims completions to 100 values and flags hasMore instead of failing", async () => {
+    const server = new FastMCP({ name: "Test", version: "1.0.0" });
+    server.addPrompt({
+      arguments: [
+        {
+          description: "First argument",
+          name: "arg1",
+        },
+      ],
+      complete: async () => ({
+        values: Array.from({ length: 150 }, (_, index) => `value-${index}`),
+      }),
+      load: async () => ({
+        messages: [],
+      }),
+      name: "test-prompt",
+    });
+
+    await runWithTestServer({
+      run: async ({ client }) => {
+        const result = await client.complete({
+          argument: {
+            name: "arg1",
+            value: "value",
+          },
+          ref: {
+            name: "test-prompt",
+            type: "ref/prompt",
+          },
+        });
+
+        expect(result.completion.values).toHaveLength(100);
+        expect(result.completion.values[0]).toBe("value-0");
+        expect(result.completion.values[99]).toBe("value-99");
+        expect(result.completion.hasMore).toBe(true);
+      },
+      server,
+    });
+  });
+
   it("supports resource completions", async () => {
     const server = new FastMCP({ name: "Test", version: "1.0.0" });
     server.addResourceTemplate({

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -552,10 +552,31 @@ const CompletionZodSchema = z.object({
    */
   total: z.optional(z.number().int()),
   /**
-   * An array of completion values. Must not exceed 100 items.
+   * An array of completion values. The MCP spec caps this at 100 items; values
+   * beyond the cap are trimmed by `capCompletionValues` (which sets `hasMore`)
+   * rather than rejected, so the schema itself does not enforce the limit.
    */
-  values: z.array(z.string()).max(100),
+  values: z.array(z.string()),
 }) satisfies z.ZodType<Completion>;
+
+/**
+ * The MCP completion result must not exceed 100 values. Rather than failing when
+ * a user-supplied completer returns more, trim to the cap and flag `hasMore` so
+ * the client knows the list was truncated.
+ */
+const COMPLETION_VALUES_LIMIT = 100;
+
+const capCompletionValues = (completion: Completion): Completion => {
+  if (completion.values.length <= COMPLETION_VALUES_LIMIT) {
+    return completion;
+  }
+
+  return {
+    ...completion,
+    hasMore: true,
+    values: completion.values.slice(0, COMPLETION_VALUES_LIMIT),
+  };
+};
 
 type ArgumentValueCompleter<T extends FastMCPSessionAuth = FastMCPSessionAuth> =
   (value: string, auth?: T) => Promise<Completion>;
@@ -1878,11 +1899,13 @@ export class FastMCPSession<
           });
         }
 
-        const completion = CompletionZodSchema.parse(
-          await prompt.complete(
-            request.params.argument.name,
-            request.params.argument.value,
-            this.#auth,
+        const completion = capCompletionValues(
+          CompletionZodSchema.parse(
+            await prompt.complete(
+              request.params.argument.name,
+              request.params.argument.value,
+              this.#auth,
+            ),
           ),
         );
 
@@ -1919,11 +1942,13 @@ export class FastMCPSession<
           );
         }
 
-        const completion = CompletionZodSchema.parse(
-          await resource.complete(
-            request.params.argument.name,
-            request.params.argument.value,
-            this.#auth,
+        const completion = capCompletionValues(
+          CompletionZodSchema.parse(
+            await resource.complete(
+              request.params.argument.name,
+              request.params.argument.value,
+              this.#auth,
+            ),
           ),
         );
 


### PR DESCRIPTION
## What's wrong

When a user-supplied argument completer returns more than 100 values, the completion request
fails instead of returning results. `CompletionZodSchema` enforces `values: z.array(z.string()).max(100)`
and is applied with `.parse()` to the raw completer output, so 101+ values throw a `ZodError`
that reaches the client as:

```
McpError: MCP error -32603: [ ... "message": "Too big: expected array to have <=100 items" ]
```

The MCP spec caps completion `values` at 100 but expects the server to **truncate and set
`hasMore`**, not to error:

> The `completion.values` array MUST NOT exceed 100 items. `completion.hasMore` indicates
> whether there are additional options beyond those returned.

## Root cause

`src/FastMCP.ts`:

- `CompletionZodSchema` (~:557): `values: z.array(z.string()).max(100)`.
- Prompt completion call site (~:1881) and resource completion call site (~:1922) both do
  `CompletionZodSchema.parse(await ...complete(...))`, so the `.max(100)` failure propagates.

## The fix

Small and localized:

- Drop `.max(100)` from `CompletionZodSchema` so validation no longer rejects large lists.
- Add `capCompletionValues(completion)`: if `values.length > 100`, slice to 100 and set
  `hasMore: true`; otherwise return as-is (respecting any `hasMore`/`total` the completer
  already provided).
- Wrap both call sites: `capCompletionValues(CompletionZodSchema.parse(await ...))`. Capping the
  **validated** result keeps clean validation errors for genuinely malformed completer output,
  while the cap becomes a spec-compliant truncation rather than a hard failure.

## Tests

One test added to `src/FastMCP.completions.test.ts` (`FastMCP Completions` describe): a prompt
completer returns 150 values; the response now has exactly 100 values (`value-0` .. `value-99`)
and `hasMore: true`, with no error.

## Verification

- Before the fix, the new test fails with `McpError -32603` / "Too big: expected array to have
  <=100 items".
- After the fix, it passes.
- Full suite green: **42 files, 527 tests passed** (`vitest run`).
- `tsc --noEmit`, `prettier --check`, and `eslint` all clean on the changed files.

