### PR TITLE
feat(server): add opt-in streamKeepalive for long tool calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,6 +903,52 @@ By default, ping behavior is optimized for each transport type:
 
 This configurable approach helps reduce log verbosity and optimize performance for different usage scenarios.
 
+#### Keeping Long Tool Calls Alive (`streamKeepalive`)
+
+Pings travel on the standalone server-to-client stream, so they never keep an
+individual tool call's connection open — and in `stateless` mode that stream does
+not exist at all. A tool that runs for minutes without producing output leaves
+its response connection silent, and an idle-connection timeout in front of the
+server (AWS ALB defaults to 60 seconds) closes it before the result is written.
+
+This applies to **both** session modes. A stateful deployment keeps its
+standalone stream warm with pings while the connection carrying the tool call
+goes idle and is closed anyway; stateless has no standalone stream to begin
+with.
+
+`streamKeepalive` writes periodically to the in-flight tool call's own response
+stream, which is the connection that would otherwise be closed. It is opt-in:
+
+```ts
+const server = new FastMCP({
+  name: "My Server",
+  version: "1.0.0",
+  streamKeepalive: {
+    // Opt in; disabled by default
+    enabled: true,
+    // Keep comfortably below the shortest idle timeout on the path
+    intervalMs: 20000,
+  },
+});
+```
+
+Each keepalive is a `notifications/message` (level configurable via `logLevel`,
+default `debug`) tagged with the logger `fastmcp-keepalive`, related to the tool
+call being served. Keepalives start when a tool begins executing and stop when
+the request stops waiting for it — on success, error, timeout, or client
+cancellation — so idle connections stay quiet. Because the messages are related
+to the request, this works in stateful and `stateless` mode alike, and needs no
+client support beyond the standard logging notification.
+
+Limits worth knowing:
+
+- It has no effect with `httpStream.enableJsonResponse`, which buffers a single
+  JSON reply instead of streaming, so there is no open stream to write to.
+- It only covers tool calls. Other long-running requests (`resources/read`,
+  `prompts/get`) still write nothing until they finish.
+- On `stdio` there is no proxy to keep alive, so enabling it there only adds
+  notification traffic.
+
 ### Health-check Endpoint
 
 When you run FastMCP with the `httpStream` transport you can optionally expose a

--- a/src/FastMCP.keepalive.test.ts
+++ b/src/FastMCP.keepalive.test.ts
@@ -1,0 +1,331 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { LoggingMessageNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
+import { getRandomPort } from "get-port-please";
+import { setTimeout as delay } from "timers/promises";
+import { fetch } from "undici";
+import { describe, expect, it } from "vitest";
+
+import { FastMCP } from "./FastMCP.js";
+
+const KEEPALIVE_LOGGER = "fastmcp-keepalive";
+const TOOL_DURATION_MS = 100;
+const KEEPALIVE_INTERVAL_MS = 15;
+
+type ServerMessage = {
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: unknown;
+};
+
+// Reads the SSE frames of a tools/call POST. Asserting on the bytes of this
+// response is the whole point: it is the connection an idle-timeout proxy kills.
+const callSlowTool = async (
+  port: number,
+  sessionId?: string,
+): Promise<ServerMessage[]> => {
+  const response = await fetch(`http://localhost:${port}/mcp`, {
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { arguments: {}, name: "slow" },
+    }),
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+    },
+    method: "POST",
+  });
+
+  expect(response.status).toBe(200);
+
+  return (await response.text())
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => JSON.parse(line.slice("data:".length).trim()));
+};
+
+const startServer = async (
+  streamKeepalive?: {
+    enabled?: boolean;
+    intervalMs?: number;
+  },
+  stateless = true,
+) => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+    ...(streamKeepalive ? { streamKeepalive } : {}),
+  });
+
+  server.addTool({
+    description: "Sleeps without writing anything to the response",
+    execute: async () => {
+      await delay(TOOL_DURATION_MS);
+
+      return "done";
+    },
+    name: "slow",
+  });
+
+  await server.start({
+    httpStream: { port, stateless },
+    transportType: "httpStream",
+  });
+
+  return { port, server };
+};
+
+// A stateful server issues a session id and keeps a standalone stream, but a
+// tool call still answers on its own POST stream, which is what must stay open.
+const initializeSession = async (port: number): Promise<string> => {
+  const response = await fetch(`http://localhost:${port}/mcp`, {
+    body: JSON.stringify({
+      id: 0,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.0" },
+        protocolVersion: "2025-03-26",
+      },
+    }),
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+
+  const sessionId = response.headers.get("mcp-session-id");
+
+  await response.text();
+
+  expect(sessionId).toBeTruthy();
+
+  await fetch(`http://localhost:${port}/mcp`, {
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }),
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+      "mcp-session-id": sessionId as string,
+    },
+    method: "POST",
+  });
+
+  return sessionId as string;
+};
+
+// In-memory transports resolve every send, so a timer that outlives its request
+// keeps delivering to the client. That makes leaks observable, unlike a stateless
+// HTTP call whose stream mapping is torn down with the response.
+const connectInMemory = async (server: FastMCP) => {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+
+  const received: { logger?: string }[] = [];
+
+  client.setNotificationHandler(LoggingMessageNotificationSchema, (n) => {
+    received.push(n.params as { logger?: string });
+  });
+
+  const keepalivesSeen = () =>
+    received.filter((p) => p.logger === KEEPALIVE_LOGGER).length;
+
+  return { client, keepalivesSeen };
+};
+
+// The exact frame the server must write, so a change to the level, the logger,
+// the payload shape, or the interpolated tool name fails the test.
+const EXPECTED_KEEPALIVE = {
+  jsonrpc: "2.0",
+  method: "notifications/message",
+  params: {
+    data: { message: "keepalive while 'slow' is running" },
+    level: "debug",
+    logger: KEEPALIVE_LOGGER,
+  },
+};
+
+const EXPECTED_RESULT = {
+  id: 1,
+  jsonrpc: "2.0",
+  result: { content: [{ text: "done", type: "text" }] },
+};
+
+// Collapses repeats so the assertion can state "every frame was exactly this".
+const distinct = (frames: ServerMessage[]) => [
+  ...new Map(frames.map((frame) => [JSON.stringify(frame), frame])).values(),
+];
+
+describe("FastMCP stream keepalive", () => {
+  it("keeps a stateless tool call's stream alive while the tool runs", async () => {
+    const { port, server } = await startServer({
+      enabled: true,
+      intervalMs: KEEPALIVE_INTERVAL_MS,
+    });
+
+    try {
+      const frames = await callSlowTool(port);
+      const beforeResult = frames.slice(0, -1);
+
+      // The tool writes nothing for its whole duration, so every frame ahead of
+      // the result came from the keepalive - and must be exactly it.
+      expect(beforeResult.length).toBeGreaterThanOrEqual(2);
+      expect(distinct(beforeResult)).toEqual([EXPECTED_KEEPALIVE]);
+      expect(frames.at(-1)).toEqual(EXPECTED_RESULT);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("keeps a stateful tool call's stream alive too", async () => {
+    const { port, server } = await startServer(
+      { enabled: true, intervalMs: KEEPALIVE_INTERVAL_MS },
+      false,
+    );
+
+    try {
+      const sessionId = await initializeSession(port);
+      const frames = await callSlowTool(port, sessionId);
+      const beforeResult = frames.slice(0, -1);
+
+      // `ping` keeps the standalone stream warm, never this one, so a stateful
+      // deployment needs the keepalive just as much as a stateless one.
+      expect(beforeResult.length).toBeGreaterThanOrEqual(2);
+      expect(distinct(beforeResult)).toEqual([EXPECTED_KEEPALIVE]);
+      expect(frames.at(-1)).toEqual(EXPECTED_RESULT);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("writes no keepalives unless they are opted into", async () => {
+    const { port, server } = await startServer();
+
+    try {
+      const frames = await callSlowTool(port);
+
+      // Not just "no keepalives": nothing at all is added to the stream.
+      expect(frames).toEqual([EXPECTED_RESULT]);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("still runs tools whose execute returns a plain value", async () => {
+    // No streamKeepalive configured: this must behave exactly as it did before
+    // the option existed.
+    const server = new FastMCP({ name: "Test", version: "1.0.0" });
+
+    server.addTool({
+      description: "Synchronous tool",
+      // JS consumers can return a plain value; the handler awaited it before the
+      // keepalive existed, so it must keep working.
+      execute: (() => "done") as unknown as () => Promise<string>,
+      name: "sync",
+    });
+
+    const { client } = await connectInMemory(server);
+
+    const result = await client.callTool({ arguments: {}, name: "sync" });
+
+    expect(result).toMatchObject({ content: [{ text: "done", type: "text" }] });
+  });
+
+  it("stops keepalives when a tool throws synchronously", async () => {
+    const server = new FastMCP({
+      name: "Test",
+      streamKeepalive: { enabled: true, intervalMs: KEEPALIVE_INTERVAL_MS },
+      version: "1.0.0",
+    });
+
+    server.addTool({
+      description: "Throws before returning a promise",
+      execute: () => {
+        throw new Error("sync boom");
+      },
+      name: "boom",
+    });
+
+    const { client, keepalivesSeen } = await connectInMemory(server);
+
+    await client.callTool({ arguments: {}, name: "boom" });
+
+    const afterResponse = keepalivesSeen();
+
+    await delay(KEEPALIVE_INTERVAL_MS * 5);
+
+    expect(keepalivesSeen()).toBe(afterResponse);
+  });
+
+  it("stops keepalives when a tool call times out", async () => {
+    const server = new FastMCP({
+      name: "Test",
+      streamKeepalive: { enabled: true, intervalMs: KEEPALIVE_INTERVAL_MS },
+      version: "1.0.0",
+    });
+
+    server.addTool({
+      description: "Outlives its own timeout",
+      execute: async () => {
+        await delay(TOOL_DURATION_MS * 2);
+
+        return "late";
+      },
+      name: "hangs",
+      timeoutMs: KEEPALIVE_INTERVAL_MS * 2,
+    });
+
+    const { client, keepalivesSeen } = await connectInMemory(server);
+
+    await client.callTool({ arguments: {}, name: "hangs" });
+
+    const afterResponse = keepalivesSeen();
+
+    await delay(KEEPALIVE_INTERVAL_MS * 6);
+
+    // timeoutMs exists for tools that hang, so the keepalive must not keep
+    // writing for the rest of the abandoned tool's lifetime.
+    expect(keepalivesSeen()).toBe(afterResponse);
+  });
+
+  it("ignores a non-positive interval instead of flooding the stream", async () => {
+    const server = new FastMCP({
+      name: "Test",
+      streamKeepalive: { enabled: true, intervalMs: 0 },
+      version: "1.0.0",
+    });
+
+    server.addTool({
+      description: "Slow enough to be flooded",
+      execute: async () => {
+        await delay(TOOL_DURATION_MS);
+
+        return "done";
+      },
+      name: "slow",
+    });
+
+    const { client, keepalivesSeen } = await connectInMemory(server);
+
+    await client.callTool({ arguments: {}, name: "slow" });
+
+    // 0 must fall back to the default interval, not fire every tick.
+    expect(keepalivesSeen()).toBe(0);
+  });
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2,6 +2,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { EventStore } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   CallToolRequestSchema,
@@ -29,6 +30,8 @@ import {
   RootsListChangedNotificationSchema,
   Tool as SDKTool,
   ServerCapabilities,
+  ServerNotification,
+  ServerRequest,
   SetLevelRequestSchema,
   SubscribeRequestSchema,
   UnsubscribeRequestSchema,
@@ -55,9 +58,13 @@ import type {
 
 export interface Logger {
   debug(...args: unknown[]): void;
+
   error(...args: unknown[]): void;
+
   info(...args: unknown[]): void;
+
   log(...args: unknown[]): void;
+
   warn(...args: unknown[]): void;
 }
 
@@ -423,6 +430,10 @@ function assertToolSchemas(tool: {
     assertStandardSchema(tool.name, "outputSchema", tool.outputSchema);
   }
 }
+
+const STREAM_KEEPALIVE_LOGGER = "fastmcp-keepalive";
+
+const STREAM_KEEPALIVE_DEFAULT_INTERVAL_MS = 20_000;
 
 const TextContentZodSchema = z
   .object({
@@ -1050,6 +1061,36 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
     enabled?: boolean;
   };
   /**
+   * Writes periodically to an in-flight tool call's own response stream, so a
+   * proxy or load balancer does not close the connection as idle while a
+   * long-running tool produces no output.
+   *
+   * Unlike {@link ServerOptions.ping}, these messages are related to the
+   * request being served, so they travel on that request's stream instead of
+   * the standalone server-to-client stream. That makes them the only option
+   * that works with `httpStream.stateless`, where no standing server-to-client
+   * stream exists.
+   */
+  streamKeepalive?: {
+    /**
+     * Whether to write keepalives. Opt-in.
+     * @default false
+     */
+    enabled?: boolean;
+    /**
+     * Interval between keepalives. Keep it comfortably below the shortest idle
+     * timeout on the path (AWS ALB defaults to 60s). Values below 1ms fall back
+     * to the default.
+     * @default 20000 (20s)
+     */
+    intervalMs?: number;
+    /**
+     * Level reported on the keepalive notification.
+     * @default 'debug'
+     */
+    logLevel?: LoggingLevel;
+  };
+  /**
    * General utilities
    */
   utils?: {
@@ -1168,11 +1209,15 @@ export interface FastMCPRequest<
   auth?: T;
   body?: unknown;
   headers: http.IncomingHttpHeaders;
+
   json(): Promise<unknown>;
+
   method: string;
   params: Record<string, string>;
   query: Record<string, string | string[]>;
+
   text(): Promise<string>;
+
   url: string;
 }
 
@@ -1181,9 +1226,13 @@ export interface FastMCPRequest<
  */
 export interface FastMCPResponse {
   end(data?: Buffer | string): void;
+
   json(data: unknown): void;
+
   send(data: Buffer | string): void;
+
   setHeader(name: string, value: number | string | string[]): FastMCPResponse;
+
   status(code: number): FastMCPResponse;
 }
 
@@ -1231,30 +1280,38 @@ type Authenticate<T> = (
 type FastMCPSessionAuth = Record<string, unknown> | undefined;
 
 class FastMCPSessionEventEmitter extends FastMCPSessionEventEmitterBase {}
+
 export class FastMCPSession<
   T extends FastMCPSessionAuth = FastMCPSessionAuth,
 > extends FastMCPSessionEventEmitter {
   public get clientCapabilities(): ClientCapabilities | null {
     return this.#clientCapabilities ?? null;
   }
+
   public get isReady(): boolean {
     return this.#connectionState === "ready";
   }
+
   public get loggingLevel(): LoggingLevel {
     return this.#loggingLevel;
   }
+
   public get roots(): Root[] {
     return this.#roots;
   }
+
   public get server(): Server {
     return this.#server;
   }
+
   public get sessionId(): string | undefined {
     return this.#sessionId;
   }
+
   public set sessionId(value: string | undefined) {
     this.#sessionId = value;
   }
+
   #auth: T | undefined;
   #capabilities: ServerCapabilities = {};
   #clientCapabilities?: ClientCapabilities;
@@ -1292,6 +1349,8 @@ export class FastMCPSession<
    */
   #stateless: boolean;
 
+  #streamKeepaliveConfig: ServerOptions<T>["streamKeepalive"];
+
   /**
    * Resource URIs the connected client has subscribed to via
    * `resources/subscribe`. Used to scope `notifications/resources/updated`
@@ -1314,6 +1373,7 @@ export class FastMCPSession<
     roots,
     sessionId,
     stateless = false,
+    streamKeepalive,
     tools,
     transportType,
     utils,
@@ -1331,6 +1391,7 @@ export class FastMCPSession<
     roots?: ServerOptions<T>["roots"];
     sessionId?: string;
     stateless?: boolean;
+    streamKeepalive?: ServerOptions<T>["streamKeepalive"];
     tools: Tool<T>[];
     transportType?: "httpStream" | "stdio";
     utils?: ServerOptions<T>["utils"];
@@ -1345,6 +1406,7 @@ export class FastMCPSession<
     this.#rootsConfig = roots;
     this.#sessionId = sessionId;
     this.#stateless = stateless;
+    this.#streamKeepaliveConfig = streamKeepalive;
     this.#needsEventLoopFlush = transportType === "httpStream";
 
     if (tools.length) {
@@ -1765,6 +1827,67 @@ export class FastMCPSession<
     };
   }
 
+  /**
+   * Periodically writes to the response stream of an in-flight tool call, so an
+   * idle-connection timeout (proxy, load balancer) does not close it while a
+   * long-running tool produces no output of its own.
+   *
+   * The notification is related to the tool call, so it travels on that
+   * request's own stream, which is the only server-to-client route that exists
+   * when running stateless.
+   *
+   * @returns a function that stops the keepalive.
+   */
+  #startStreamKeepalive(
+    extra: Pick<
+      RequestHandlerExtra<ServerRequest, ServerNotification>,
+      "sendNotification" | "signal"
+    >,
+    toolName: string,
+  ): () => void {
+    const config = this.#streamKeepaliveConfig;
+
+    if (!config?.enabled) {
+      return () => {};
+    }
+
+    // A non-positive interval would fire on every tick and flood the stream.
+    const intervalMs =
+      config.intervalMs && config.intervalMs > 0
+        ? config.intervalMs
+        : STREAM_KEEPALIVE_DEFAULT_INTERVAL_MS;
+
+    const timer = setInterval(() => {
+      extra
+        .sendNotification({
+          method: "notifications/message",
+          params: {
+            data: { message: `keepalive while '${toolName}' is running` },
+            level: config.logLevel ?? "debug",
+            logger: STREAM_KEEPALIVE_LOGGER,
+          },
+        })
+        .catch((error: unknown) => {
+          // Left running: the caller stops it when the request finishes, and a
+          // transient write failure should not silence the connection.
+          this.#logger.debug(
+            `[FastMCP debug] stream keepalive for '${toolName}' failed:`,
+            error instanceof Error ? error.message : String(error),
+          );
+        });
+    }, intervalMs);
+
+    timer.unref?.();
+
+    const stop = () => clearInterval(timer);
+
+    // A cancelled or disconnected request stops waiting for the tool, so the
+    // keepalive must not outlive the abort.
+    extra.signal?.addEventListener("abort", stop, { once: true });
+
+    return stop;
+  }
+
   async #validateStructuredContent(
     tool: Tool<T>,
     value: Record<string, unknown>,
@@ -1944,11 +2067,13 @@ export class FastMCPSession<
       });
     });
   }
+
   private setupErrorHandling() {
     this.#server.onerror = (error) => {
       this.#logger.error("[FastMCP error]", error);
     };
   }
+
   private setupLoggingHandlers() {
     this.#server.setRequestHandler(SetLevelRequestSchema, (request) => {
       this.#loggingLevel = request.params.level;
@@ -1956,6 +2081,7 @@ export class FastMCPSession<
       return {};
     });
   }
+
   private setupPromptHandlers() {
     let cachedPromptsList: ListPromptsResult["prompts"] | null = null;
 
@@ -2285,226 +2411,240 @@ export class FastMCPSession<
       };
     });
 
-    this.#server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      const tool = toolsMap.get(request.params.name);
+    this.#server.setRequestHandler(
+      CallToolRequestSchema,
+      async (request, extra) => {
+        const tool = toolsMap.get(request.params.name);
 
-      if (!tool) {
-        throw new McpError(
-          ErrorCode.MethodNotFound,
-          `Unknown tool: ${request.params.name}`,
-        );
-      }
-
-      let args: unknown = undefined;
-
-      if (tool.parameters) {
-        const parsed = await tool.parameters["~standard"].validate(
-          request.params.arguments,
-        );
-
-        if (parsed.issues) {
-          const friendlyErrors = this.#formatSchemaIssues(parsed.issues);
-
+        if (!tool) {
           throw new McpError(
-            ErrorCode.InvalidParams,
-            `Tool '${request.params.name}' parameter validation failed: ${friendlyErrors}. Please check the parameter types and values according to the tool's schema.`,
+            ErrorCode.MethodNotFound,
+            `Unknown tool: ${request.params.name}`,
           );
         }
 
-        args = parsed.value;
-      }
+        let args: unknown = undefined;
 
-      const progressToken = request.params?._meta?.progressToken;
+        if (tool.parameters) {
+          const parsed = await tool.parameters["~standard"].validate(
+            request.params.arguments,
+          );
 
-      let result: ContentResult;
+          if (parsed.issues) {
+            const friendlyErrors = this.#formatSchemaIssues(parsed.issues);
 
-      try {
-        const reportProgress = async (progress: Progress) => {
-          // Progress notifications must reference the progressToken supplied by
-          // the client in the initiating request. If the client did not request
-          // progress, there is nothing to associate the update with, and sending
-          // a notification without a token produces an invalid message.
-          if (progressToken === undefined) {
-            return;
-          }
-
-          try {
-            await this.#server.notification({
-              method: "notifications/progress",
-              params: {
-                ...progress,
-                progressToken,
-              },
-            });
-
-            if (this.#needsEventLoopFlush) {
-              await new Promise((resolve) => setImmediate(resolve));
-            }
-          } catch (progressError) {
-            this.#logger.warn(
-              `[FastMCP warning] Failed to report progress for tool '${request.params.name}':`,
-              progressError instanceof Error
-                ? progressError.message
-                : String(progressError),
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              `Tool '${request.params.name}' parameter validation failed: ${friendlyErrors}. Please check the parameter types and values according to the tool's schema.`,
             );
           }
-        };
 
-        const log = this.#createLog();
-
-        // Create a promise for tool execution
-        // Streams partial results while a tool is still executing
-        // Enables progressive rendering and real-time feedback
-        const streamContent = async (content: Content | Content[]) => {
-          const contentArray = Array.isArray(content) ? content : [content];
-
-          try {
-            await this.#server.notification({
-              method: "notifications/tool/streamContent",
-              params: {
-                content: contentArray,
-                toolName: request.params.name,
-              },
-            });
-
-            if (this.#needsEventLoopFlush) {
-              await new Promise((resolve) => setImmediate(resolve));
-            }
-          } catch (streamError) {
-            this.#logger.warn(
-              `[FastMCP warning] Failed to stream content for tool '${request.params.name}':`,
-              streamError instanceof Error
-                ? streamError.message
-                : String(streamError),
-            );
-          }
-        };
-
-        if (this.#onToolCall) {
-          await this.#onToolCall({
-            arguments: (args ?? {}) as Record<string, unknown>,
-            toolName: request.params.name,
-          });
+          args = parsed.value;
         }
 
-        const executeToolPromise = tool.execute(args, {
-          client: {
-            version: this.#server.getClientVersion(),
-          },
-          elicit: (
-            params: ElicitRequestFormParams | ElicitRequestURLParams,
-            options?: RequestOptions,
-          ) => this.#server.elicitInput(params, options),
-          log,
-          reportProgress,
-          requestId:
-            typeof request.params?._meta?.requestId === "string"
-              ? request.params._meta.requestId
-              : undefined,
-          session: this.#auth,
-          sessionId: this.#sessionId,
-          streamContent,
-        });
+        const progressToken = request.params?._meta?.progressToken;
 
-        // Handle timeout if specified
-        const maybeStringResult = (await (tool.timeoutMs
-          ? Promise.race([
-              executeToolPromise,
-              new Promise<never>((_, reject) => {
-                const timeoutId = setTimeout(() => {
-                  reject(
-                    new UserError(
-                      `Tool '${request.params.name}' timed out after ${tool.timeoutMs}ms. Consider increasing timeoutMs or optimizing the tool implementation.`,
-                    ),
-                  );
-                }, tool.timeoutMs);
+        let result: ContentResult;
 
-                // If promise resolves first
-                executeToolPromise.then(
-                  () => clearTimeout(timeoutId),
-                  () => clearTimeout(timeoutId),
-                );
-              }),
-            ])
-          : executeToolPromise)) as
-          | AudioContent
-          | ContentResult
-          | ImageContent
-          | null
-          | Record<string, unknown>
-          | ResourceContent
-          | ResourceLink
-          | string
-          | TextContent
-          | undefined;
+        try {
+          const reportProgress = async (progress: Progress) => {
+            // Progress notifications must reference the progressToken supplied by
+            // the client in the initiating request. If the client did not request
+            // progress, there is nothing to associate the update with, and sending
+            // a notification without a token produces an invalid message.
+            if (progressToken === undefined) {
+              return;
+            }
 
-        // Without this test, we are running into situations where the last progress update is not reported.
-        // See the 'reports multiple progress updates without buffering' test in FastMCP.test.ts before refactoring.
-        await delay(1);
+            try {
+              await this.#server.notification({
+                method: "notifications/progress",
+                params: {
+                  ...progress,
+                  progressToken,
+                },
+              });
 
-        if (maybeStringResult === undefined || maybeStringResult === null) {
-          result = ContentResultZodSchema.parse({
-            content: [],
-          });
-        } else if (typeof maybeStringResult === "string") {
-          result = ContentResultZodSchema.parse({
-            content: [{ text: maybeStringResult, type: "text" }],
-          });
-        } else if ("type" in maybeStringResult) {
-          result = ContentResultZodSchema.parse({
-            content: [maybeStringResult],
-          });
-        } else if ("content" in maybeStringResult) {
-          result = ContentResultZodSchema.parse(maybeStringResult);
-          if (result.structuredContent !== undefined && tool.outputSchema) {
-            result.structuredContent = await this.#validateStructuredContent(
-              tool,
-              result.structuredContent,
-              request.params.name,
-            );
+              if (this.#needsEventLoopFlush) {
+                await new Promise((resolve) => setImmediate(resolve));
+              }
+            } catch (progressError) {
+              this.#logger.warn(
+                `[FastMCP warning] Failed to report progress for tool '${request.params.name}':`,
+                progressError instanceof Error
+                  ? progressError.message
+                  : String(progressError),
+              );
+            }
+          };
+
+          const log = this.#createLog();
+
+          // Create a promise for tool execution
+          // Streams partial results while a tool is still executing
+          // Enables progressive rendering and real-time feedback
+          const streamContent = async (content: Content | Content[]) => {
+            const contentArray = Array.isArray(content) ? content : [content];
+
+            try {
+              await this.#server.notification({
+                method: "notifications/tool/streamContent",
+                params: {
+                  content: contentArray,
+                  toolName: request.params.name,
+                },
+              });
+
+              if (this.#needsEventLoopFlush) {
+                await new Promise((resolve) => setImmediate(resolve));
+              }
+            } catch (streamError) {
+              this.#logger.warn(
+                `[FastMCP warning] Failed to stream content for tool '${request.params.name}':`,
+                streamError instanceof Error
+                  ? streamError.message
+                  : String(streamError),
+              );
+            }
+          };
+
+          if (this.#onToolCall) {
+            await this.#onToolCall({
+              arguments: (args ?? {}) as Record<string, unknown>,
+              toolName: request.params.name,
+            });
           }
-        } else if (tool.outputSchema) {
-          const structuredContent = await this.#validateStructuredContent(
-            tool,
-            maybeStringResult,
+
+          const executeToolPromise = Promise.resolve(
+            tool.execute(args, {
+              client: {
+                version: this.#server.getClientVersion(),
+              },
+              elicit: (
+                params: ElicitRequestFormParams | ElicitRequestURLParams,
+                options?: RequestOptions,
+              ) => this.#server.elicitInput(params, options),
+              log,
+              reportProgress,
+              requestId:
+                typeof request.params?._meta?.requestId === "string"
+                  ? request.params._meta.requestId
+                  : undefined,
+              session: this.#auth,
+              sessionId: this.#sessionId,
+              streamContent,
+            }),
+          );
+
+          // Started only once execute has returned a promise, so a tool that
+          // throws synchronously cannot leave a timer behind.
+          const stopStreamKeepalive = this.#startStreamKeepalive(
+            extra,
             request.params.name,
           );
-          result = ContentResultZodSchema.parse({
+
+          // Handle timeout if specified
+          const maybeStringResult = (await (
+            tool.timeoutMs
+              ? Promise.race([
+                  executeToolPromise,
+                  new Promise<never>((_, reject) => {
+                    const timeoutId = setTimeout(() => {
+                      reject(
+                        new UserError(
+                          `Tool '${request.params.name}' timed out after ${tool.timeoutMs}ms. Consider increasing timeoutMs or optimizing the tool implementation.`,
+                        ),
+                      );
+                    }, tool.timeoutMs);
+
+                    // If promise resolves first
+                    executeToolPromise.then(
+                      () => clearTimeout(timeoutId),
+                      () => clearTimeout(timeoutId),
+                    );
+                  }),
+                ])
+              : executeToolPromise
+          ).finally(stopStreamKeepalive)) as
+            | AudioContent
+            | ContentResult
+            | ImageContent
+            | null
+            | Record<string, unknown>
+            | ResourceContent
+            | ResourceLink
+            | string
+            | TextContent
+            | undefined;
+
+          // Without this test, we are running into situations where the last progress update is not reported.
+          // See the 'reports multiple progress updates without buffering' test in FastMCP.test.ts before refactoring.
+          await delay(1);
+
+          if (maybeStringResult === undefined || maybeStringResult === null) {
+            result = ContentResultZodSchema.parse({
+              content: [],
+            });
+          } else if (typeof maybeStringResult === "string") {
+            result = ContentResultZodSchema.parse({
+              content: [{ text: maybeStringResult, type: "text" }],
+            });
+          } else if ("type" in maybeStringResult) {
+            result = ContentResultZodSchema.parse({
+              content: [maybeStringResult],
+            });
+          } else if ("content" in maybeStringResult) {
+            result = ContentResultZodSchema.parse(maybeStringResult);
+            if (result.structuredContent !== undefined && tool.outputSchema) {
+              result.structuredContent = await this.#validateStructuredContent(
+                tool,
+                result.structuredContent,
+                request.params.name,
+              );
+            }
+          } else if (tool.outputSchema) {
+            const structuredContent = await this.#validateStructuredContent(
+              tool,
+              maybeStringResult,
+              request.params.name,
+            );
+            result = ContentResultZodSchema.parse({
+              content: [
+                {
+                  text: JSON.stringify(structuredContent),
+                  type: "text",
+                },
+              ],
+              structuredContent,
+            });
+          } else {
+            result = ContentResultZodSchema.parse(maybeStringResult);
+          }
+        } catch (error) {
+          if (error instanceof UserError) {
+            return {
+              content: [{ text: error.message, type: "text" }],
+              isError: true,
+              ...(error.extras ? { structuredContent: error.extras } : {}),
+            };
+          }
+
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          return {
             content: [
               {
-                text: JSON.stringify(structuredContent),
+                text: `Tool '${request.params.name}' execution failed: ${errorMessage}`,
                 type: "text",
               },
             ],
-            structuredContent,
-          });
-        } else {
-          result = ContentResultZodSchema.parse(maybeStringResult);
-        }
-      } catch (error) {
-        if (error instanceof UserError) {
-          return {
-            content: [{ text: error.message, type: "text" }],
             isError: true,
-            ...(error.extras ? { structuredContent: error.extras } : {}),
           };
         }
 
-        const errorMessage =
-          error instanceof Error ? error.message : String(error);
-        return {
-          content: [
-            {
-              text: `Tool '${request.params.name}' execution failed: ${errorMessage}`,
-              type: "text",
-            },
-          ],
-          isError: true,
-        };
-      }
-
-      return result;
-    });
+        return result;
+      },
+    );
   }
 }
 
@@ -2613,6 +2753,7 @@ export class FastMCP<
   public get sessions(): FastMCPSession<T>[] {
     return this.#sessions;
   }
+
   #authenticate: Authenticate<T> | undefined;
   #honoApp = new Hono();
   #httpStreamServer: null | SSEServer = null;
@@ -2666,6 +2807,7 @@ export class FastMCP<
       this.#promptsListChanged(this.#prompts);
     }
   }
+
   /**
    * Adds prompts to the server.
    */
@@ -2680,6 +2822,7 @@ export class FastMCP<
       this.#promptsListChanged(this.#prompts);
     }
   }
+
   /**
    * Adds a resource to the server.
    */
@@ -2691,6 +2834,7 @@ export class FastMCP<
       this.#resourcesListChanged(this.#resources);
     }
   }
+
   /**
    * Adds resources to the server.
    */
@@ -2707,6 +2851,7 @@ export class FastMCP<
       this.#resourcesListChanged(this.#resources);
     }
   }
+
   /**
    * Adds a resource template to the server.
    */
@@ -2722,6 +2867,7 @@ export class FastMCP<
       this.#resourceTemplatesListChanged(this.#resourcesTemplates);
     }
   }
+
   /**
    * Adds resource templates to the server.
    */
@@ -2740,6 +2886,7 @@ export class FastMCP<
       this.#resourceTemplatesListChanged(this.#resourcesTemplates);
     }
   }
+
   /**
    * Adds a tool to the server.
    */
@@ -2753,6 +2900,7 @@ export class FastMCP<
       this.#toolsListChanged(this.#tools);
     }
   }
+
   /**
    * Adds tools to the server.
    */
@@ -2891,6 +3039,7 @@ export class FastMCP<
 
     throw new UnexpectedStateError(`Resource not found: ${uri}`, { uri });
   }
+
   /**
    * Returns the underlying Hono app instance for direct access to Hono's native API.
    * This allows you to add custom routes, middleware, and handlers using Hono's standard methods.
@@ -2915,6 +3064,7 @@ export class FastMCP<
   public getApp(): Hono {
     return this.#honoApp;
   }
+
   /**
    * Removes a prompt from the server.
    */
@@ -2924,6 +3074,7 @@ export class FastMCP<
       this.#promptsListChanged(this.#prompts);
     }
   }
+
   /**
    * Removes prompts from the server.
    */
@@ -2945,6 +3096,7 @@ export class FastMCP<
       this.#resourcesListChanged(this.#resources);
     }
   }
+
   /**
    * Removes resources from the server.
    */
@@ -2956,6 +3108,7 @@ export class FastMCP<
       this.#resourcesListChanged(this.#resources);
     }
   }
+
   /**
    * Removes a resource template from the server.
    */
@@ -2967,6 +3120,7 @@ export class FastMCP<
       this.#resourceTemplatesListChanged(this.#resourcesTemplates);
     }
   }
+
   /**
    * Removes resource templates from the server.
    */
@@ -3076,6 +3230,7 @@ export class FastMCP<
         resources: this.#resources,
         resourcesTemplates: this.#resourcesTemplates,
         roots: this.#options.roots,
+        streamKeepalive: this.#options.streamKeepalive,
         tools: this.#tools,
         transportType: "stdio",
         utils: this.#options.utils,
@@ -3340,6 +3495,7 @@ export class FastMCP<
       roots: this.#options.roots,
       sessionId,
       stateless,
+      streamKeepalive: this.#options.streamKeepalive,
       tools: allowedTools,
       transportType: "httpStream",
       utils: this.#options.utils,
@@ -4128,6 +4284,7 @@ export class FastMCP<
       session.resourcesListChanged(resources);
     }
   }
+
   /**
    * Notifies all sessions that the resource templates list has changed.
    */
@@ -4136,6 +4293,7 @@ export class FastMCP<
       session.resourceTemplatesListChanged(templates);
     }
   }
+
   /**
    * Notifies all sessions that the tools list has changed.
    */


### PR DESCRIPTION
## Summary

A tool that runs for minutes without producing output leaves its HTTP response stream silent, and any idle-connection timeout in front of the server (AWS ALB defaults to 60s) closes the connection before the result is written. The existing `ping` option cannot help: pings travel on the standalone server-to-client stream, not the tool call's own connection — and in `stateless` mode that standalone stream doesn't exist at all. This PR adds an opt-in `streamKeepalive` server option that periodically writes a request-scoped `notifications/message` to the in-flight tool call's own response stream, which is the connection that would otherwise be idle-closed. Because the notifications are fire-and-forget and tied to the request being served, this works identically in stateful and stateless mode and needs no client support beyond standard logging notifications.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| Long tool call behind a proxy/LB with an idle timeout | Response stream is silent while the tool runs; the connection is closed as idle (ALB: 60s) and the client never receives the result | With `streamKeepalive.enabled: true`, a keepalive notification is written to the call's own stream every `intervalMs` (default 20s), keeping it open until the tool finishes |
| Same, in `httpStream.stateless` mode | No standalone server-to-client stream exists, so `ping` never runs — there was no keepalive mechanism at all | Works the same as stateful, since keepalives are scoped to the in-flight request |
| Tool finishes, errors, times out, or the client disconnects | — | Keepalives stop immediately (also wired to the request's abort signal), so idle connections stay quiet |
| Default (option not set) | — | Unchanged; the feature is opt-in and disabled by default |

Each keepalive is a `notifications/message` with logger `fastmcp-keepalive` and a configurable `logLevel` (default `debug`). Documented limits: no effect with `enableJsonResponse` (nothing streams), covers tool calls only, and pointless on `stdio`.

```mermaid
flowchart LR
  subgraph before ["Before"]
    C1[Client] -- "GET /mcp (standalone stream)<br/>ping every 5s ✓ kept alive" --> S1[Server]
    C1 -- "POST tools/call<br/>silent for minutes ✗ idle-closed by LB" --> S1
  end
  subgraph after ["After (streamKeepalive)"]
    C2[Client] -- "GET /mcp (standalone stream)<br/>ping unchanged" --> S2[Server]
    C2 -- "POST tools/call<br/>keepalive notification every 20s ✓ stays open" --> S2
  end
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3bZWvRWJsJH2Sr971TKck
