### PR TITLE
fix(edge): deliver SSE responses on POST streams

### DIFF
--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -1,0 +1,96 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+
+import { WebStreamableHTTPServerTransport } from "./WebStreamableHTTPServerTransport.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type JsonResponse = any;
+
+const createInitializeRequest = (accept: string) =>
+  new Request("http://localhost/mcp", {
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "1.0.0" },
+        protocolVersion: LATEST_PROTOCOL_VERSION,
+      },
+    }),
+    headers: {
+      Accept: accept,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+
+const createServer = () =>
+  new Server({ name: "TestServer", version: "1.0.0" }, { capabilities: {} });
+
+describe("WebStreamableHTTPServerTransport", () => {
+  it("should deliver the response on the SSE stream", async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      sessionIdGenerator: () => "test-session",
+    });
+    await createServer().connect(transport);
+
+    const response = await transport.handleRequest(
+      createInitializeRequest("application/json, text/event-stream"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+
+    // The SDK produces the response asynchronously; the stream must deliver
+    // it and then close instead of hanging forever.
+    const stream = response.body;
+    expect(stream).not.toBeNull();
+    if (!stream) {
+      throw new Error("Expected an SSE stream body");
+    }
+
+    const readBody = async (): Promise<string> => {
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let text = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        text += decoder.decode(value, { stream: true });
+      }
+      return text;
+    };
+
+    const body = await Promise.race([
+      readBody(),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
+    ]);
+
+    expect(body).not.toBeNull();
+    expect(body).toContain("data: ");
+    expect(body).toContain('"serverInfo"');
+    expect(body).toContain("TestServer");
+  });
+
+  it("should respond with JSON when enableJsonResponse is set", async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: () => "test-session",
+    });
+    await createServer().connect(transport);
+
+    const response = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.id).toBe(1);
+    expect(body.result.serverInfo.name).toBe("TestServer");
+  });
+});

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -9,7 +9,9 @@
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   isInitializeRequest,
+  isJSONRPCError,
   isJSONRPCNotification,
+  isJSONRPCRequest,
   isJSONRPCResponse,
   JSONRPCMessage,
   JSONRPCMessageSchema,
@@ -147,9 +149,16 @@ export class WebStreamableHTTPServerTransport implements Transport {
     this._pendingResponses.push(message);
 
     // Send to SSE streams
-    const streamId = options?.relatedRequestId
-      ? this._requestToStreamMapping.get(options.relatedRequestId)
-      : this._standaloneSseStreamId;
+    let requestId = options?.relatedRequestId;
+    if (isJSONRPCResponse(message) || isJSONRPCError(message)) {
+      // Responses are routed by the id of the request they answer
+      requestId = message.id;
+    }
+
+    const streamId =
+      requestId === undefined
+        ? this._standaloneSseStreamId
+        : this._requestToStreamMapping.get(requestId);
 
     if (streamId) {
       const writer = this._streamMapping.get(streamId);
@@ -163,6 +172,21 @@ export class WebStreamableHTTPServerTransport implements Transport {
             await this.writeSSEEventWithId(writer, eventId, message);
           } else {
             await this.writeSSEEvent(writer, message);
+          }
+
+          // Close the POST stream once all of its requests are answered
+          if (
+            requestId !== undefined &&
+            (isJSONRPCResponse(message) || isJSONRPCError(message))
+          ) {
+            this._requestToStreamMapping.delete(requestId);
+            const streamInUse = Array.from(
+              this._requestToStreamMapping.values(),
+            ).includes(streamId);
+            if (!streamInUse) {
+              this._streamMapping.delete(streamId);
+              await writer.close();
+            }
           }
         } catch (error) {
           this.onerror?.(
@@ -423,6 +447,28 @@ export class WebStreamableHTTPServerTransport implements Transport {
       }
     }
 
+    const isOnlyNotificationsOrResponses = messages.every(
+      (msg) => isJSONRPCNotification(msg) || isJSONRPCResponse(msg),
+    );
+    const useJsonResponse =
+      this._enableJsonResponse &&
+      Boolean(acceptHeader?.includes("application/json"));
+
+    // Open the SSE response stream before dispatching: the SDK produces
+    // responses asynchronously and send() routes them back by request id.
+    let sseReadable: ReadableStream<Uint8Array> | undefined;
+    if (!isOnlyNotificationsOrResponses && !useJsonResponse) {
+      const { readable, writable } = new TransformStream<Uint8Array>();
+      const streamId = `post_${Date.now()}`;
+      this._streamMapping.set(streamId, writable.getWriter());
+      for (const message of messages) {
+        if (isJSONRPCRequest(message)) {
+          this._requestToStreamMapping.set(message.id, streamId);
+        }
+      }
+      sseReadable = readable;
+    }
+
     // Process messages through the transport
     this._pendingResponses = [];
     for (const message of messages) {
@@ -430,11 +476,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
     }
 
     // If all messages are notifications/responses, return 202
-    if (
-      messages.every(
-        (msg) => isJSONRPCNotification(msg) || isJSONRPCResponse(msg),
-      )
-    ) {
+    if (isOnlyNotificationsOrResponses) {
       return new Response(null, {
         headers: this.getResponseHeaders(),
         status: 202,
@@ -442,10 +484,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
     }
 
     // Return JSON response if enabled and client accepts it
-    if (
-      this._enableJsonResponse &&
-      acceptHeader?.includes("application/json")
-    ) {
+    if (useJsonResponse) {
       // Wait a tick for responses to be collected
       await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -464,25 +503,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
     }
 
     // Return SSE stream
-    const { readable, writable } = new TransformStream<Uint8Array>();
-    const writer = writable.getWriter();
-    const streamId = `post_${Date.now()}`;
-    this._streamMapping.set(streamId, writer);
-
-    // Send any pending responses as SSE events
-    (async () => {
-      try {
-        for (const response of this._pendingResponses) {
-          await this.writeSSEEvent(writer, response);
-        }
-      } catch (error) {
-        this.onerror?.(
-          error instanceof Error ? error : new Error(String(error)),
-        );
-      }
-    })();
-
-    return new Response(readable, {
+    return new Response(sseReadable ?? null, {
       headers: {
         ...this.getResponseHeaders(),
         "Cache-Control": "no-cache, no-transform",


### PR DESCRIPTION
## What's wrong

`WebStreamableHTTPServerTransport` (the `fastmcp/edge` streaming transport for
Workers/Deno/Bun) responds to a POST with `200 text/event-stream` but **never writes the
response** to the stream. A client doing `POST /mcp` with `Accept: text/event-stream` (SSE
mode, the default) hangs forever waiting for the `initialize` result:

```ts
const response = await transport.handleRequest(initializeRequest); // 200, but the body never yields
const first = await response.body!.getReader().read(); // never resolves
```

## Root cause

Two independent defects in `src/edge/WebStreamableHTTPServerTransport.ts`:

1. `_requestToStreamMapping` (request id -> SSE stream) is declared and read in `send()` but
   **never written**: `send()` can never resolve which POST stream a response belongs to, so
   `streamId` is `undefined` and the response is dropped.
2. The flush of `_pendingResponses` runs in an IIFE immediately after dispatching the message,
   **before** the SDK produces the response asynchronously — in practice it always iterated an
   empty array.

The SDK itself (v1.24.x) sends responses **without** `relatedRequestId`; the SDK's Node
transport routes them by `message.id` (`streamableHttp.js`), and that is exactly what this
transport did not do.

## The fix

In `src/edge/WebStreamableHTTPServerTransport.ts`:

1. Open the POST's SSE stream and populate `_requestToStreamMapping` **before** dispatching, so
   responses produced asynchronously by the SDK are routed back to the right stream.
2. In `send()`, route responses by `message.id` (falling back to the standalone stream id for
   notifications), matching the SDK's Node transport.
3. Close the POST stream once all of its requests have an answer, so well-behaved clients get
   an EOF instead of hanging on an open stream.

The synchronous IIFE flush is gone: responses are written when they actually arrive.

## Tests

New `src/edge/WebStreamableHTTPServerTransport.test.ts` (vitest, real `Server` from the SDK
plus the Web `Request`/`Response` APIs, mirroring the existing `edge.test.ts` harness):

- `should deliver the response on the SSE stream` — POST initialize with
  `Accept: application/json, text/event-stream`; asserts `200`, `text/event-stream`, and that
  the body eventually carries `serverInfo` (with a 2 s guard so the test fails — rather than
  hangs — when the stream never yields).
- `should respond with JSON when enableJsonResponse is set` — control: same request in JSON
  mode still returns the full `initialize` response.

## Verification

- Before the fix, the SSE test fails with `AssertionError: expected null not to be null` (the
  stream never yields within the 2 s guard). The JSON control passes before and after.
- After the fix, both pass; the existing 12 edge tests stay green (**14/14**).
- Full suite: **543/543 passed** (`vitest run`). One run showed 4 flakes in unrelated files
  (`completions` timeout, `keepalive` frame count, `GetPortError`) that all pass in isolation
  and on re-run — they are parallel-port/timing contention, not this change (it only touches
  `src/edge/`).
- `tsc --noEmit`, `prettier --check .`, `eslint .` all clean.
- Independent verification record (rojo -> verde, stable across 3 runs): see the acta block
  below.

<details><summary>Verification record (acta)</summary>

## Verification

Every command below was run and its output captured verbatim. The record is reproducible — the exact commands are included so you can re-run them yourself.

**rojo — fuente de origin/main sin el fix** (must fail without the fix)

```
$ pnpm exec vitest run src/edge/WebStreamableHTTPServerTransport.test.ts
[…]
   Duration  9.65s (transform 117ms, setup 0ms, import 6.15s, tests 2.07s, environment 0ms)
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/edge/WebStreamableHTTPServerTransport.test.ts > WebStreamableHTTPServerTransport > should deliver the response on the SSE stream
AssertionError: expected null not to be null
 ❯ src/edge/WebStreamableHTTPServerTransport.test.ts:73:22
     71|     ]);
     72|
     73|     expect(body).not.toBeNull();
       |                      ^
     74|     expect(body).toContain("data: ");
     75|     expect(body).toContain('"serverInfo"');
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
[exit code 1]
```

**verde — con el fix del commit 6b0400a** (must pass) — 3 runs, identical exit code

```
$ pnpm exec vitest run src/edge/WebStreamableHTTPServerTransport.test.ts src/edge/edge.test.ts
 RUN  v4.0.15 C:/work/fastmcp-wt
 ✓ src/edge/WebStreamableHTTPServerTransport.test.ts (2 tests) 52ms
 ✓ src/edge/edge.test.ts (12 tests) 63ms
 Test Files  2 passed (2)
      Tests  14 passed (14)
   Start at  12:40:19
   Duration  1.83s (transform 220ms, setup 0ms, import 1.97s, tests 115ms, environment 0ms)
[exit code 0]
```

<details><summary>Environment and output hashes</summary>

```
so: Windows 11 (AMD64)
python: 3.13.14
node --version: v24.14.1
git rev-parse HEAD: 6b0400a4db58655180432b108639f1171e83f703
git status --short:
sha256(rojo — fuente de origin/main sin el fix run 1) = 611d76dc1ed3ab0a…  exit 1  16.95s
sha256(verde — con el fix del commit 6b0400a run 1) = f64f7686a4d4e317…  exit 0  3.65s
sha256(verde — con el fix del commit 6b0400a run 2) = a83cd9d6d9fedb54…  exit 0  3.04s
sha256(verde — con el fix del commit 6b0400a run 3) = c06cb2a8bfb1a1d7…  exit 0  2.49s
acta: ffda59c6016d0735
```

</details>

</details>

## Honest scope

`EdgeFastMCP` does not use this class internally (it has its own JSON-only implementation), so
no first-party user hits this today: the transport is exported for anyone streaming over
Workers/Deno/Bun, which is its declared purpose, and the edge tests only ever used
`Accept: application/json`. Not verified: real Workers/Deno/Bun runtimes, eventStore replay,
GET-stream traffic, and client disconnect mid-stream — covered in Node 24 with the Web APIs
the transport uses.
