### PR TITLE
fix(edge): validate tool arguments before execution

### DIFF
--- a/src/edge/edge.test.ts
+++ b/src/edge/edge.test.ts
@@ -157,6 +157,51 @@ describe("EdgeFastMCP", () => {
     expect(execute).not.toHaveBeenCalled();
   });
 
+  it("should return a JSON-RPC error when tool validation throws", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+    const execute = vi.fn(async () => "unexpected");
+
+    server.addTool({
+      description: "Throw during validation",
+      execute,
+      name: "explode",
+      parameters: z.object({ value: z.string() }).transform(() => {
+        throw new Error("validator exploded");
+      }),
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 11,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: {
+            arguments: { value: "boom" },
+            name: "explode",
+          },
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body).toMatchObject({
+      error: { code: -32603 },
+      id: 11,
+      jsonrpc: "2.0",
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it("should pass transformed tool arguments to execute", async () => {
     const server = new EdgeFastMCP({
       name: "TestServer",

--- a/src/edge/edge.test.ts
+++ b/src/edge/edge.test.ts
@@ -1,5 +1,5 @@
 import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import { EdgeFastMCP } from "./index.js";
@@ -114,6 +114,92 @@ describe("EdgeFastMCP", () => {
     expect(body.result.content).toEqual([
       { text: "Hello, World!", type: "text" },
     ]);
+  });
+
+  it("should reject invalid tool arguments before execute", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+    const execute = vi.fn(
+      async ({ count }: { count: number }) => `Count: ${count}`,
+    );
+
+    server.addTool({
+      description: "Count something",
+      execute,
+      name: "count",
+      parameters: z.object({ count: z.number() }),
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 9,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: {
+            arguments: { count: "not-a-number" },
+            name: "count",
+          },
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect.soft(body.error?.code).toBe(-32602);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("should pass transformed tool arguments to execute", async () => {
+    const server = new EdgeFastMCP({
+      name: "TestServer",
+      version: "1.0.0",
+    });
+    const execute = vi.fn(
+      async ({ normalized }: { normalized: string }) => normalized,
+    );
+
+    server.addTool({
+      description: "Normalize a value",
+      execute,
+      name: "normalize",
+      parameters: z
+        .object({ value: z.string() })
+        .transform(({ value }) => ({ normalized: value.trim().toUpperCase() })),
+    });
+
+    const response = await server.fetch(
+      new Request("http://localhost/mcp", {
+        body: JSON.stringify({
+          id: 10,
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: {
+            arguments: { value: "  transformed  " },
+            name: "normalize",
+          },
+        }),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body: JsonResponse = await response.json();
+    expect(body.result.content).toEqual([
+      { text: "TRANSFORMED", type: "text" },
+    ]);
+    expect(execute).toHaveBeenCalledWith({ normalized: "TRANSFORMED" });
   });
 
   it("should list resources", async () => {

--- a/src/edge/index.ts
+++ b/src/edge/index.ts
@@ -514,7 +514,17 @@ export class EdgeFastMCP {
     let args: unknown = toolArgs ?? {};
 
     if (tool.parameters) {
-      const parsed = await tool.parameters["~standard"].validate(toolArgs);
+      let parsed: StandardSchemaV1.Result<unknown>;
+
+      try {
+        parsed = await tool.parameters["~standard"].validate(toolArgs);
+      } catch (error) {
+        return this.#rpcError(
+          id,
+          ErrorCode.InternalError,
+          `Tool '${toolName}' parameter validation failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
 
       if (parsed.issues) {
         const friendlyErrors = parsed.issues

--- a/src/edge/index.ts
+++ b/src/edge/index.ts
@@ -511,8 +511,31 @@ export class EdgeFastMCP {
       );
     }
 
+    let args: unknown = toolArgs ?? {};
+
+    if (tool.parameters) {
+      const parsed = await tool.parameters["~standard"].validate(toolArgs);
+
+      if (parsed.issues) {
+        const friendlyErrors = parsed.issues
+          .map((issue) => {
+            const path = issue.path?.join(".") || "root";
+            return `${path}: ${issue.message}`;
+          })
+          .join(", ");
+
+        return this.#rpcError(
+          id,
+          ErrorCode.InvalidParams,
+          `Tool '${toolName}' parameter validation failed: ${friendlyErrors}. Please check the parameter types and values according to the tool's schema.`,
+        );
+      }
+
+      args = parsed.value;
+    }
+
     try {
-      const result = await tool.execute(toolArgs ?? {});
+      const result = await tool.execute(args);
 
       // Normalize result to content array
       const content =


### PR DESCRIPTION
## Summary

- validate EdgeFastMCP tool arguments through their Standard Schema before executing the tool
- pass the validated/transformed value to `execute`, including schema and field defaults
- return JSON-RPC `-32602` for reported validation issues and `-32603` when a validator itself throws, without invoking the tool

This ports the input-validation behavior already present in the Node FastMCP path to the edge implementation. It is deliberately limited to `tools/call`; batch framing, manifests, dependencies, and public APIs are unchanged.

## Tests

- `vitest run src/edge/edge.test.ts --maxWorkers=1` — 15/15 passed
- `vitest run --maxWorkers=4` — 45/45 files, 551/551 tests passed
- public `EdgeFastMCP.fetch()` probe — validator throw returns HTTP 200 JSON-RPC `-32603`, validation issues/refinements remain `-32602`, transforms/defaults reach `execute`, and execution errors remain `-32603`
- `tsc --noEmit`
- `eslint .`
- `prettier --check src/edge/index.ts src/edge/edge.test.ts`
- `pnpm build`
- `jsr publish --dry-run`

The repository-wide `pnpm lint` command is not claimed as green: its first phase, `prettier --check .`, reports 98 pre-existing files outside this diff. Both touched files pass Prettier, and the remaining lint phases pass when run separately.
