### PR TITLE
fix: drop the direct undici dependency in favour of global fetch

### DIFF
--- a/docs/oauth-python-typescript.md
+++ b/docs/oauth-python-typescript.md
@@ -107,7 +107,7 @@ fastmcp/src/auth/
 Dependencies:
 - crypto (Node.js built-in)
 - fs/promises (Node.js built-in)
-- undici (HTTP, already in dependencies)
+- fetch (Node.js built-in)
 ```
 
 **Key Difference:** TypeScript uses mostly built-in Node.js modules, while Python relies on external battle-tested libraries.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "hono": "^4.11.5",
     "mcp-proxy": "^6.4.6",
     "strict-event-emitter-types": "^2.0.0",
-    "undici": "^7.16.0",
     "uri-templates": "^0.2.0",
     "xsschema": "^0.4.3",
     "yargs": "^18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       strict-event-emitter-types:
         specifier: ^2.0.0
         version: 2.0.0
-      undici:
-        specifier: ^7.16.0
-        version: 7.16.0
       uri-templates:
         specifier: ^0.2.0
         version: 0.2.0
@@ -604,19 +601,23 @@ packages:
 
   '@modelcontextprotocol/inspector-cli@0.16.8':
     resolution: {integrity: sha512-u8x8Dbb8Dos34M7N8p4e4AF++Bi1D+lq+dkRCvLi5Qub/dI75Z7YTIXBezA4LbIISly+Ecn05fdofzZwqyOvpg==}
+    deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
   '@modelcontextprotocol/inspector-client@0.16.8':
     resolution: {integrity: sha512-4sTk/jUnQ1lDv9kbx1nN45SsoApDxW8hjKLKcHnHh9nfRVEN9SW+ylUjNvVCDP74xSNpD8v5p6NJyVWtZYfPWA==}
+    deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
   '@modelcontextprotocol/inspector-server@0.16.8':
     resolution: {integrity: sha512-plv0SiPgQAT0/LjC0MmGsoo/sdpS6V4TpOUAxO4J3DnvnLLaInnNh9hiU1SlGgCjsRv0nN9TvX9pWRqVnZH9kw==}
+    deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
   '@modelcontextprotocol/inspector@0.16.8':
     resolution: {integrity: sha512-7kk6uOGY9ySgCFsRuRplWzvjiEwulG876pfnjQxqaBJAcUlp3N1yrOt7YQMBZsxvop+RGw50IehiPuGs+7oh+w==}
     engines: {node: '>=22.7.5'}
+    deprecated: 'v1 is deprecated. Upgrade to v2: npm i @modelcontextprotocol/inspector@latest. v1 gets security fixes only, published under the v1-latest tag.'
     hasBin: true
 
   '@modelcontextprotocol/sdk@1.24.3':

--- a/src/FastMCP.keepalive.test.ts
+++ b/src/FastMCP.keepalive.test.ts
@@ -3,7 +3,6 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { LoggingMessageNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { getRandomPort } from "get-port-please";
 import { setTimeout as delay } from "timers/promises";
-import { fetch } from "undici";
 import { describe, expect, it } from "vitest";
 
 import { FastMCP } from "./FastMCP.js";

--- a/src/FastMCP.media-timeout.test.ts
+++ b/src/FastMCP.media-timeout.test.ts
@@ -2,7 +2,7 @@
  * Regression tests for unbounded media fetches in imageContent/audioContent:
  * both helpers fetched an arbitrary tool-author URL with no timeout, so a
  * server that never answers stalled the tool call indefinitely (the only
- * ceiling was undici's 300s default).
+ * ceiling was the platform's own default).
  *
  * These tests verify that both fetches now carry an AbortSignal bounded by
  * MEDIA_FETCH_TIMEOUT_MS (30s) and that a timeout surfaces as a clear
@@ -13,18 +13,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { audioContent, imageContent } from "./FastMCP.js";
 
-const { mediaFetchMock } = vi.hoisted(() => ({
-  mediaFetchMock: vi.fn(),
-}));
-
-// FastMCP.ts binds `fetch` from the undici module at import time, so spying
-// on global.fetch cannot intercept it; mock the undici module instead and
-// keep every other export intact.
-vi.mock("undici", async (importOriginal) => {
-  const original = await importOriginal<typeof import("undici")>();
-
-  return { ...original, fetch: mediaFetchMock };
-});
+// FastMCP.ts calls the global fetch, so spying on it here intercepts both
+// media helpers. Installed per-test in beforeEach because the afterEach
+// restore puts the real implementation back.
+const mediaFetchMock = vi.fn();
 
 const realAbortTimeout = AbortSignal.timeout;
 
@@ -59,6 +51,9 @@ const mockHungServer = () => {
 describe("imageContent/audioContent fetch timeout", () => {
   beforeEach(() => {
     mediaFetchMock.mockReset();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      mediaFetchMock as unknown as typeof globalThis.fetch,
+    );
     // MEDIA_FETCH_TIMEOUT_MS is 30s of wall-clock time; compress every
     // AbortSignal.timeout() to 10ms so the hung-server tests stay fast.
     // The mapped error still reports the real constant.

--- a/src/FastMCP.routes.test.ts
+++ b/src/FastMCP.routes.test.ts
@@ -3,7 +3,6 @@ import type { Context } from "hono";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { getRandomPort } from "get-port-please";
-import { fetch } from "undici";
 import { expect, test } from "vitest";
 import { z } from "zod";
 

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -14,7 +14,6 @@ import {
 import { createEventSource, EventSourceClient } from "eventsource-client";
 import { getRandomPort } from "get-port-please";
 import { setTimeout as delay } from "timers/promises";
-import { fetch } from "undici";
 import { expect, test, vi } from "vitest";
 import { z } from "zod";
 import { z as z4 } from "zod/v4";

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -46,7 +46,6 @@ import http from "http";
 import { type CorsOptions, startHTTPServer } from "mcp-proxy";
 import { StrictEventEmitter } from "strict-event-emitter-types";
 import { setTimeout as delay } from "timers/promises";
-import { fetch } from "undici";
 import parseURITemplate from "uri-templates";
 import { strictJsonSchema, toJsonSchema } from "xsschema";
 import { z } from "zod";


### PR DESCRIPTION
Closes #314.

## The report

`undici: ^7.16.0` caps at `<8.0.0`, so consumers who want undici 8 have to carry an override around us. The request was to bump the pin or widen it to `>=7.16.0`.

## Why not bump or widen

Neither option is free:

- **`>=7.16.0`** is unbounded — a future undici 9 with breaking changes would resolve silently into our dependents.
- **`^8.0.0`** raises the Node floor. undici 7 requires Node `>=20.18.1`; undici 8 requires Node `>=22.19.0`. We declare no `engines`, so bumping would drop Node 20/21 users with no signal beyond an `EBADENGINE` warning.
- **`^7.16.0 || ^8.0.0`** has the same problem in practice: resolvers pick the newest match, so fresh installs land on 8 and inherit the 22.19.0 floor anyway.

## What this does instead

We only ever used `fetch(url, { signal })` plus `response.ok` / `status` / `statusText` / `arrayBuffer()` — all standard WHATWG surface, and Node's global `fetch` *is* undici internally. So the dependency was buying us nothing that the platform doesn't already provide.

Removing it resolves the report permanently: there is no range left to fight over, and consumers can use any undici version they like.

It also fixes an existing inconsistency — `src/auth/OAuthProxy.ts` already used the global `fetch`; only the media helpers went through the undici import.

### Proxy configuration is unaffected

The one real risk was users who configure a proxy via `undici.setGlobalDispatcher()`. That writes to `Symbol.for('undici.globalDispatcher.1')` on `globalThis`, which is the same symbol Node's built-in fetch reads, so proxy setups keep working. Verified directly rather than assumed.

## Changes

- Drop `undici` from `dependencies` and remove the import from `src/FastMCP.ts`.
- Drop the now-unneeded `fetch` imports from three test files.
- `FastMCP.media-timeout.test.ts` mocked the `undici` module because the source bound `fetch` at import time; it now spies on `globalThis.fetch`, which is what the test's own comment said it wanted to do.
- Update a stale docs line that listed undici as a dependency.

## Verification

- Full suite: 45 files, 560/560.
- `tsc --noEmit`, ESLint, Prettier: pass.
- `tsup` ESM/CJS/DTS build: pass; no `undici` reference in `dist/`.
- `pnpm install` confirms undici is gone from the root dependency set (it remains only under `semantic-release` in devDependencies, which does not affect consumers).