### PR TITLE
fix(edge): persist SSE responses that arrive after a client disconnect

### DIFF
--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -254,8 +254,11 @@ describe("WebStreamableHTTPServerTransport", () => {
   });
 
   it("stores a response produced after the client disconnected, for later replay", async () => {
-    const stored: { eventId: string; message: JsonResponse; streamId: string }[] =
-      [];
+    const stored: {
+      eventId: string;
+      message: JsonResponse;
+      streamId: string;
+    }[] = [];
     const transport = new WebStreamableHTTPServerTransport({
       eventStore: {
         replayEventsAfter: async () => "unused",

--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -253,6 +253,51 @@ describe("WebStreamableHTTPServerTransport", () => {
     expect(internals._requestToStreamMapping.size).toBe(0);
   });
 
+  it("stores a response produced after the client disconnected, for later replay", async () => {
+    const stored: { eventId: string; message: JsonResponse; streamId: string }[] =
+      [];
+    const transport = new WebStreamableHTTPServerTransport({
+      eventStore: {
+        replayEventsAfter: async () => "unused",
+        storeEvent: async (streamId, message) => {
+          const eventId = `evt-${stored.length + 1}`;
+          stored.push({ eventId, message, streamId });
+          return eventId;
+        },
+      },
+      sessionIdGenerator: () => "test-session",
+    });
+    await createSlowToolServer(50).connect(transport);
+    // Consume initialize so only the tool call is left in the mappings.
+    await readSSEBody(
+      await transport.handleRequest(
+        createInitializeRequest("application/json, text/event-stream"),
+      ),
+    );
+
+    const before = stored.length;
+    const response = await transport.handleRequest(
+      createPostRequest(
+        createToolCall(2, "one"),
+        "text/event-stream",
+        "test-session",
+      ),
+    );
+    expect(response.status).toBe(200);
+
+    // The client gives up before the 50 ms tool answers.
+    await response.body?.cancel("client disconnected");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // The event store is the durable side of resumability: a reconnect with
+    // Last-Event-Id replays from it. If the response never reaches storeEvent,
+    // it is lost for good even though the socket is what actually failed.
+    const toolResponse = stored
+      .slice(before)
+      .find((event) => event.message.id === 2 && "result" in event.message);
+    expect(toolResponse).toBeDefined();
+  });
+
   it("should wait for a slow handler in JSON response mode", async () => {
     const transport = new WebStreamableHTTPServerTransport({
       enableJsonResponse: true,

--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -301,6 +301,58 @@ describe("WebStreamableHTTPServerTransport", () => {
     expect(toolResponse).toBeDefined();
   });
 
+  it("stores a notification produced after the client dropped the GET stream", async () => {
+    // The POST-response arm above rides `_requestToStreamMapping`; this one rides
+    // the standalone GET stream, whose id is a constant (`_GET_stream`) with no
+    // routing entry. A refactor that gates persistence on "was this actually
+    // requested" (e.g. `requestId !== undefined`) keeps every other test green
+    // and silently drops server-initiated notifications after a GET disconnect —
+    // which is the #322 regression on the path where Last-Event-Id replay of
+    // server pushes matters most. This pins that arm on its own.
+    const stored: {
+      eventId: string;
+      message: JsonResponse;
+      streamId: string;
+    }[] = [];
+    const transport = new WebStreamableHTTPServerTransport({
+      eventStore: {
+        replayEventsAfter: async () => "unused",
+        storeEvent: async (streamId, message) => {
+          const eventId = `evt-${stored.length + 1}`;
+          stored.push({ eventId, message, streamId });
+          return eventId;
+        },
+      },
+      sessionIdGenerator: () => "test-session",
+    });
+    await createSlowToolServer(10).connect(transport);
+    await readSSEBody(
+      await transport.handleRequest(
+        createInitializeRequest("application/json, text/event-stream"),
+      ),
+    );
+
+    const get = await transport.handleRequest(createGetRequest());
+    expect(get.status).toBe(200);
+    // The client opens the standalone stream and then drops it.
+    await get.body?.cancel("client disconnected");
+    await flushMicrotasks();
+
+    // `send()` is awaited, so the store call has happened by the time it returns:
+    // no sleep needed here, unlike the wall-clock POST-response arm.
+    const before = stored.length;
+    await transport.send({
+      jsonrpc: "2.0",
+      method: "notifications/message",
+      params: { data: "after the disconnect", level: "info" },
+    });
+
+    const notification = stored
+      .slice(before)
+      .find((event) => event.message.method === "notifications/message");
+    expect(notification).toBeDefined();
+  });
+
   it("releases the routing entry of a request the client cancelled", async () => {
     const transport = new WebStreamableHTTPServerTransport({
       eventStore: {

--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -301,6 +301,95 @@ describe("WebStreamableHTTPServerTransport", () => {
     expect(toolResponse).toBeDefined();
   });
 
+  it("releases the routing entry of a request the client cancelled", async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      eventStore: {
+        replayEventsAfter: async () => "unused",
+        storeEvent: async () => "evt-1",
+      },
+      sessionIdGenerator: () => "test-session",
+    });
+    await createSlowToolServer(50).connect(transport);
+    // Consume initialize so only the tool call is left in the mappings.
+    await readSSEBody(
+      await transport.handleRequest(
+        createInitializeRequest("application/json, text/event-stream"),
+      ),
+    );
+
+    const internals = transport as unknown as TransportInternals;
+    const response = await transport.handleRequest(
+      createPostRequest(
+        createToolCall(2, "one"),
+        "text/event-stream",
+        "test-session",
+      ),
+    );
+    expect(response.status).toBe(200);
+    expect(internals._requestToStreamMapping.size).toBe(1);
+
+    // Cancel, then drop the stream — what a client does on a user abort. The
+    // SDK suppresses the response of a cancelled request, so send() never runs
+    // for this id and nothing else would ever drop its routing entry.
+    const cancelled = await transport.handleRequest(
+      createPostRequest(
+        {
+          jsonrpc: "2.0",
+          method: "notifications/cancelled",
+          params: { reason: "user aborted", requestId: 2 },
+        },
+        "application/json, text/event-stream",
+        "test-session",
+      ),
+    );
+    expect(cancelled.status).toBe(202);
+    await response.body?.cancel("client disconnected");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(internals._requestToStreamMapping.size).toBe(0);
+    expect(internals._streamMapping.size).toBe(0);
+  });
+
+  it("closes a POST stream whose only request was cancelled", async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      sessionIdGenerator: () => "test-session",
+    });
+    await createSlowToolServer(50).connect(transport);
+    await readSSEBody(
+      await transport.handleRequest(
+        createInitializeRequest("application/json, text/event-stream"),
+      ),
+    );
+
+    const response = await transport.handleRequest(
+      createPostRequest(
+        createToolCall(2, "one"),
+        "text/event-stream",
+        "test-session",
+      ),
+    );
+    expect(response.status).toBe(200);
+
+    // The client cancels but keeps reading. No response will ever be written
+    // to this stream, so it must end rather than hang until the client
+    // gives up.
+    await transport.handleRequest(
+      createPostRequest(
+        {
+          jsonrpc: "2.0",
+          method: "notifications/cancelled",
+          params: { reason: "user aborted", requestId: 2 },
+        },
+        "application/json, text/event-stream",
+        "test-session",
+      ),
+    );
+
+    const body = await readSSEBody(response);
+    expect(body).not.toBeNull();
+    expect(body).toBe("");
+  });
+
   it("should wait for a slow handler in JSON response mode", async () => {
     const transport = new WebStreamableHTTPServerTransport({
       enableJsonResponse: true,

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -8,6 +8,7 @@
 
 import { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
+  CancelledNotificationSchema,
   isInitializeRequest,
   isJSONRPCError,
   isJSONRPCRequest,
@@ -515,6 +516,16 @@ export class WebStreamableHTTPServerTransport implements Transport {
       }
     }
 
+    // A cancelled request is never answered — the SDK suppresses the response
+    // of a request whose abort signal fired — so send() never runs for its id
+    // and nothing else would ever drop its routing entry. Release it here.
+    for (const message of messages) {
+      const cancelled = CancelledNotificationSchema.safeParse(message);
+      if (cancelled.success) {
+        await this.releaseCancelledRequest(cancelled.data.params.requestId);
+      }
+    }
+
     // Process messages through the transport
     for (const message of messages) {
       this.onmessage?.(message, { authInfo: undefined });
@@ -599,6 +610,44 @@ export class WebStreamableHTTPServerTransport implements Transport {
    */
   private handleUnsupportedRequest(): Response {
     return this.createErrorResponse(405, -32000, "Method not allowed");
+  }
+
+  /**
+   * Settle the routing state of a request the client cancelled, which will
+   * therefore never produce a response: the same drain `send()` performs once
+   * a response has been written, minus the response. Idempotent, so it is a
+   * no-op if the response won the race against the cancellation.
+   *
+   * JSON-mode POSTs are left alone: `_jsonResponseCollectors` owns their
+   * settlement.
+   */
+  private async releaseCancelledRequest(requestId: RequestId): Promise<void> {
+    const streamId = this._requestToStreamMapping.get(requestId);
+    if (streamId === undefined || this._jsonResponseCollectors.has(streamId)) {
+      return;
+    }
+
+    this._requestToStreamMapping.delete(requestId);
+    const streamInUse = Array.from(
+      this._requestToStreamMapping.values(),
+    ).includes(streamId);
+    if (streamInUse) {
+      return;
+    }
+
+    // Nothing will ever be written to this stream again; close it rather than
+    // leaving the client reading a stream that can only hang.
+    const writer = this._streamMapping.get(streamId);
+    this._streamMapping.delete(streamId);
+    if (writer) {
+      try {
+        await writer.close();
+      } catch (error) {
+        this.onerror?.(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+      }
+    }
   }
 
   /**

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -180,16 +180,21 @@ export class WebStreamableHTTPServerTransport implements Transport {
       }
 
       const writer = this._streamMapping.get(streamId);
-      if (writer) {
+      // With an event store the message must be persisted even if the client
+      // has already disconnected, so a reconnect with Last-Event-Id can replay
+      // it. The live write to the SSE stream is best-effort on top of that.
+      if (writer || this._eventStore) {
         try {
+          let eventId: string | undefined;
           if (this._eventStore) {
-            const eventId = await this._eventStore.storeEvent(
-              streamId,
-              message,
-            );
-            await this.writeSSEEventWithId(writer, eventId, message);
-          } else {
-            await this.writeSSEEvent(writer, message);
+            eventId = await this._eventStore.storeEvent(streamId, message);
+          }
+          if (writer) {
+            if (eventId === undefined) {
+              await this.writeSSEEvent(writer, message);
+            } else {
+              await this.writeSSEEventWithId(writer, eventId, message);
+            }
           }
 
           // Close the POST stream once all of its requests are answered
@@ -200,7 +205,9 @@ export class WebStreamableHTTPServerTransport implements Transport {
             ).includes(streamId);
             if (!streamInUse) {
               this._streamMapping.delete(streamId);
-              await writer.close();
+              if (writer) {
+                await writer.close();
+              }
             }
           }
         } catch (error) {
@@ -645,10 +652,16 @@ export class WebStreamableHTTPServerTransport implements Transport {
         return;
       }
       this._streamMapping.delete(streamId);
-      // Drop the routing entries that pointed at this stream, so a response
-      // arriving after the client gave up is not looked up against a writer
-      // that no longer exists. No-op for the standalone GET stream, which is
-      // never a request target.
+      // With an event store, a response can still arrive after the client gave
+      // up, and it must be persisted for replay. Keep the routing entry so
+      // send() can resolve the stream id and store under it; send() drops the
+      // entry once the response has been stored.
+      if (this._eventStore) {
+        return;
+      }
+      // No event store: nothing will be persisted for this stream, so drop the
+      // routing entries now rather than leaking them. No-op for the standalone
+      // GET stream, which is never a request target.
       for (const [requestId, mappedStreamId] of this._requestToStreamMapping) {
         if (mappedStreamId === streamId) {
           this._requestToStreamMapping.delete(requestId);


### PR DESCRIPTION
## Problem

This is a follow-up to #322, which shipped in **v4.15.0** — and it fixes a regression that PR
introduced. @tonydzi flagged it on that thread; I reproduced it rather than taking it on faith, and
the report is correct.

With an event store configured, a tool response produced **after** the client cancels its SSE
stream is no longer persisted for replay. It is not delayed or errored — it never exists.

`send()` reaches `storeEvent` only through `if (streamId)` and then `if (writer)`. The `trackStream`
helper added in #322 registers a `writer.closed` callback that purges **both**
`_streamMapping[streamId]` and the `_requestToStreamMapping[requestId]` routing entry on
disconnect. So a late response resolves `streamId → undefined` and skips `storeEvent` entirely.

Before #322 the event was kept (the code reached `storeEvent` before failing on the dead socket) —
at the cost of the very map leak #322 was fixed to close. Both properties should hold.

### Reproduced

Probe: in-memory event store, tool answering after the client cancels, sampled after the response
is produced.

| Version | Result |
|---|---|
| v4.15.0 (`294d438`, with #322) | `storedResponseForId2=false totalStored=1 ids=[1]` — the response is lost |
| direct parent (`b8f43be`, pre-#322) | same probe passes — the response is persisted |

Comparing against the direct parent rather than an older tag isolates #322 as the cause: one commit
of difference.

## Fix

Decouple persistence from the live writer:

- `send()` calls `storeEvent` whenever an event store is configured (the SSE write stays gated on
  the writer, as before).
- `trackStream` keeps the routing entry while an event store is present, so `send()` can still
  resolve the stream id, and drops it once the response is stored.

**Without an event store, #322's release behaviour is unchanged** — the existing #322 cancellation
tests stay green, so the map leak it closed stays closed.

### Follow-up round: cancelled requests (`05de97b`)

@tonydzi [reviewed this branch](https://github.com/punkpeye/fastmcp/pull/326#issuecomment-5281725697)
and found that the fix above reintroduces #322's leak class on one path: a request that is
**cancelled** is never answered, so `send()` never runs for its id and nothing drops the routing
entry that `trackStream` now keeps. Cancel-then-disconnect is what a client does on a user abort —
the exact scenario in the headline — so the entry leaked once per aborted request, until session
teardown.

Reproduced and fixed here rather than deferred: an incoming `notifications/cancelled` is treated as
terminal for routing. `releaseCancelledRequest()` performs the same drain `send()` does after a
response, minus the response — drop the entry, and close the POST stream once no other request is
waiting on it. It is idempotent, so a response that wins the race still settles normally. JSON-mode
POSTs are left to `_jsonResponseCollectors` (that path is #325).

For reference, the SDK's own `StreamableHTTPServerTransport` has the same leak: its `res.on("close")`
drops only `_streamMapping`, routing entries go only after a response is written, and it has no
`notifications/cancelled` handling.

## Tests

`src/edge/WebStreamableHTTPServerTransport.test.ts` gains four tests: the disconnect →
late-response → replay regression, two for the cancellation path (routing entry released after
cancel-then-disconnect; POST stream closed when the client cancels but keeps reading), and one
for the standalone-GET arm (a notification produced after the client drops the GET stream still
reaches `storeEvent`). The last was flagged by @tonydzi on the thread: it rides the
`_standaloneSseStreamId` constant, so a refactor gating persistence on `requestId !== undefined`
keeps every other test green while silently dropping server-initiated notifications after a GET
disconnect — the #322 regression on the path where replay of server pushes matters most.

- **Red before:** each test was written before its fix and failed on the specific assertion —
  `AssertionError: expected undefined to be defined` for the replay path;
  `expected 1 to be +0` on `_requestToStreamMapping.size` for the leak; `expected null not to be null`
  (the 2 s stream guard) for the hanging stream.
- **Non-vacuity:** reverting only the source half brings every red back, so none of them passes on
  anything.
- **Green after:** `src/edge/` 33/33; full suite 563/563.
- `prettier --check .`, `eslint .`, `tsc --noEmit` and `jsr publish --dry-run` all clean.

**One trade worth stating.** After this change, a session whose client never returns keeps
calling `storeEvent` for every notification on `_GET_stream` indefinitely, where `main` stopped
writing at the disconnect. That is the correct side of the trade for resumability, and the
store lifetime is the host's to cap — but it is a new unbounded write path, so an event-store
implementer should know the lifetime is theirs to bound.

**Not verified:** Windows and Node 24 only — no Cloudflare Workers, Deno or Bun runtime, and no
event store other than the in-test spy. The full suite is flaky on this machine under parallel load
(`FastMCP.completions`, keepalive/close cases in `FastMCP.test`); they pass in isolation and a
control run on the pre-fix tree flakes the same way, so 563/563 is one clean run among several
rather than a stable number. The cancel-versus-response race is argued from the map mutations being
synchronous, not probed under load, and there is no test for a cancel arriving mid-batch while a
sibling request on the same stream is still running.

