### PR TITLE
fix: register the resource-templates handler whenever resources are advertised

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -2197,6 +2197,43 @@ test("lists resource templates", async () => {
   });
 });
 
+test("lists an empty set of resource templates when the server only has resources", async () => {
+  // Regression test: a server with a resource and no resource template
+  // advertises the `resources` capability but used to register the
+  // `resources/templates/list` handler only when a template existed, so the
+  // method it had just advertised answered -32601 Method not found. The
+  // reference SDK registers list/templates/read together and returns an empty
+  // array. @wong2/mcp-cli - the client `fastmcp dev` spawns - calls
+  // listResourceTemplates() whenever the capability is present, so this took
+  // `npx fastmcp dev` down on any resources-only server.
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(client.getServerCapabilities()?.resources).toBeDefined();
+
+      expect(await client.listResourceTemplates()).toEqual({
+        resourceTemplates: [],
+      });
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addResource({
+        load: async () => {
+          return { text: "Example log content" };
+        },
+        mimeType: "text/plain",
+        name: "Application Logs",
+        uri: "file:///logs/app.log",
+      });
+
+      return server;
+    },
+  });
+});
+
 test(
   "HTTP Stream: custom endpoint works with /another-mcp",
   { timeout: 20000 },

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1499,16 +1499,18 @@ export class FastMCPSession<
         this.addResource(resource);
       }
 
+      for (const resourceTemplate of resourcesTemplates) {
+        this.addResourceTemplate(resourceTemplate);
+      }
+
       this.setupResourceHandlers();
       this.setupResourceSubscriptionHandlers();
-
-      if (resourcesTemplates.length) {
-        for (const resourceTemplate of resourcesTemplates) {
-          this.addResourceTemplate(resourceTemplate);
-        }
-
-        this.setupResourceTemplateHandlers();
-      }
+      // `resources/templates/list` belongs to the `resources` capability that
+      // was just advertised, so the handler has to answer even when there is
+      // nothing to list - the reference SDK returns an empty array. Gating it
+      // on having templates made a resources-only server reply -32601 Method
+      // not found to any client that lists templates.
+      this.setupResourceTemplateHandlers();
     }
 
     if (prompts.length) {


### PR DESCRIPTION
A server that registers a resource and no resource *template* advertises `capabilities.resources` but has no handler for `resources/templates/list`, so that method answers `-32601 Method not found`.

`src/FastMCP.ts:1459-1461` sets the capability when `resources.length || resourcesTemplates.length`. But `:1503-1512` registers the templates handler only inside `if (resourcesTemplates.length)`. The two conditions disagree.

### Why that combination is wrong

The SDK this depends on registers all three resource handlers together and returns an empty list — `@modelcontextprotocol/sdk/dist/esm/server/mcp.js:333-375`, `setResourceRequestHandlers()`: `ListResourcesRequestSchema`, `ListResourceTemplatesRequestSchema` and `ReadResourceRequestSchema` are set unconditionally, with the templates handler returning `{ resourceTemplates: [] }`. There is no separate capability flag for templates in MCP — advertising `resources` is advertising all three methods.

### Why it bites in practice

`fastmcp dev` spawns `@wong2/mcp-cli` (`src/bin/devCommand.ts:93-100`), and that CLI calls `listResourceTemplates()` unconditionally whenever `capabilities.resources` is present (`node_modules/@wong2/mcp-cli/src/mcp.js:40-52`). So fastmcp ships the combination that breaks its own dev command.

Protocol level, with a control:

```
[server with a resource and NO template]
  capabilities.resources: {"subscribe":true,"listChanged":true}
  resources/list           -> OK 1 item(s)
  resources/templates/list -> THREW: MCP error -32601: Method not found
[control: server with a resource AND a template]
  resources/templates/list -> OK 1 item(s)
```

End-to-end through the actual CLI:

```
McpError: MCP error -32601: Method not found
    at Client._onresponse (.../shared/protocol.js:473:36)
    at StdioClientTransport.processReadBuffer (.../client/stdio.js:138:79)
```

Control (same server plus one template) reaches the interactive picker. After the fix, the previously-crashing server connects too.

This is the same error and the same stack shape as #148. I am **not** claiming it is that report's original cause — the reporter's server had only a tool, and the gating for that case was already in place at `19f500d`. What I can say is that this reproduces the same `-32601` on today's `main` and breaks `fastmcp dev`.

### The fix

Move the `addResourceTemplate` loop and `setupResourceTemplateHandlers()` out of the `if (resourcesTemplates.length)` guard. `setupResourceTemplateHandlers` already handles an empty map (`:2364-2376` → `{ resourceTemplates: [] }`, and `[]` is truthy so the cache still works). +10/−8, one file.

### Verification

Source reverted, test kept: **1 failed | 4 passed** for `-t "resource templates"`, failure `McpError: MCP error -32601: Method not found`. With the fix: 5/5, full suite **561/561 across 45 files**. `tsc --noEmit` 0, `eslint` 0, `prettier --check` clean on both touched files.

A pristine-`main` control run showed 3 unrelated flakes (`DiscoveryDocumentCache` TTL ×2, `diskStore` concurrency ×1); none appeared in the fixed run.

### What I did not verify

Windows / Node 24.14.1 only — not Workers, Deno or Bun. `dist/` was built locally to drive the end-to-end repro; I did not check the published npm artifacts.

*Prepared with AI assistance; every claim above was executed and the outputs are verbatim.*
