### PR TITLE
fix: resolve sessionId from the transport instead of at connect time

### DIFF
--- a/src/FastMCP.session-id.test.ts
+++ b/src/FastMCP.session-id.test.ts
@@ -1,5 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
@@ -324,6 +325,54 @@ describe("FastMCP Session ID Support", () => {
         await client.close();
       } finally {
         await server.stop();
+      }
+    });
+
+    it("should expose a sessionId the transport assigns after connect resolves", async () => {
+      const server = new FastMCP<TestAuth>({
+        name: "test-server",
+        version: "1.0.0",
+      });
+
+      let capturedSessionId: string | undefined;
+
+      server.addTool({
+        description: "Test tool that captures the session ID",
+        execute: async (_args, context) => {
+          capturedSessionId = context.sessionId;
+          return "ok";
+        },
+        name: "capture-session",
+        parameters: z.object({}),
+      });
+
+      const [clientTransport, serverTransport] =
+        InMemoryTransport.createLinkedPair();
+
+      const client = new Client(
+        { name: "test-client", version: "1.0.0" },
+        { capabilities: {} },
+      );
+
+      const [session] = await Promise.all([
+        server.connect(serverTransport),
+        client.connect(clientTransport),
+      ]);
+
+      // StreamableHTTPServerTransport assigns its sessionId while handling
+      // `initialize`, which happens after connect() resolves — so a session ID
+      // that only appears at this point still has to reach tool handlers.
+      (serverTransport as { sessionId?: string }).sessionId =
+        "1b4e28ba-2fa1-11d2-883f-0016d3cca427";
+
+      try {
+        expect(session.sessionId).toBe("1b4e28ba-2fa1-11d2-883f-0016d3cca427");
+
+        await client.callTool({ arguments: {}, name: "capture-session" });
+
+        expect(capturedSessionId).toBe("1b4e28ba-2fa1-11d2-883f-0016d3cca427");
+      } finally {
+        await client.close();
       }
     });
   });

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1341,8 +1341,26 @@ export class FastMCPSession<
     return this.#server;
   }
 
+  /**
+   * The HTTP session ID, or `undefined` for transports that do not have one.
+   *
+   * Resolved from the transport on every read rather than captured when the
+   * session connects: `StreamableHTTPServerTransport` assigns its `sessionId`
+   * while it handles `initialize`, which happens after `connect()` resolves.
+   * A value read at connect time is therefore still `undefined`.
+   */
   public get sessionId(): string | undefined {
-    return this.#sessionId;
+    if (this.#sessionId !== undefined) {
+      return this.#sessionId;
+    }
+
+    const transport = this.#server.transport as
+      | ({ sessionId?: string } & Transport)
+      | undefined;
+
+    return typeof transport?.sessionId === "string"
+      ? transport.sessionId
+      : undefined;
   }
 
   public set sessionId(value: string | undefined) {
@@ -1539,16 +1557,6 @@ export class FastMCPSession<
 
     try {
       await this.#server.connect(transport);
-
-      // Extract session ID from transport if available (HTTP transports only)
-      if ("sessionId" in transport) {
-        const transportWithSessionId = transport as {
-          sessionId?: string;
-        } & Transport;
-        if (typeof transportWithSessionId.sessionId === "string") {
-          this.#sessionId = transportWithSessionId.sessionId;
-        }
-      }
 
       // Skipped in stateless mode: a session there serves one request, and the
       // initialize that carried the client's capabilities was handled by a
@@ -1796,7 +1804,7 @@ export class FastMCPSession<
       requestId:
         typeof meta?.requestId === "string" ? meta.requestId : undefined,
       session: this.#auth,
-      sessionId: this.#sessionId,
+      sessionId: this.sessionId,
     };
   }
 
@@ -2584,7 +2592,7 @@ export class FastMCPSession<
                   ? request.params._meta.requestId
                   : undefined,
               session: this.#auth,
-              sessionId: this.#sessionId,
+              sessionId: this.sessionId,
               streamContent,
             }),
           );


### PR DESCRIPTION
`FastMCPSession.connect()` read `transport.sessionId` immediately after `server.connect(transport)`
resolved. `StreamableHTTPServerTransport` only assigns its `sessionId` while it handles `initialize`,
which happens *after* `connect()` returns — so the value read there is always `undefined`.

This was masked by a dependency detail rather than being correct. mcp-proxy 6.4.6 calls
`server.connect(transport)` **without awaiting it** (`dist/stdio-*.mjs`: `server.connect(transport);`
then `await transport.handleRequest(req, res, body)`). The floating promise let `handleRequest()`
assign the session ID before `connect()` resumed, so the read happened to win the race.

mcp-proxy 6.7.0 changed that line to `await server.connect(transport);`. That is the correct ordering,
and it settles the race the other way permanently: `connect()` now fully completes before `initialize`
is ever handled.

### Impact

`fastmcp` declares `"mcp-proxy": "^6.4.6"`, so a fresh install today resolves 6.7.x and
`context.sessionId` is silently `undefined` on `httpStream` for every tool call. The lockfile pins
6.4.6, so CI stays green and the breakage is invisible in-repo.

Reproduced by installing `mcp-proxy@6.7.4` alone, with no other change (`@modelcontextprotocol/sdk`
untouched at 1.24.3):

| `src/FastMCP.session-id.test.ts` | mcp-proxy 6.4.6 | mcp-proxy 6.7.4 |
|---|---|---|
| before this PR | 5 passed | **3 failed** (`expected undefined to be defined`) |
| after this PR | 6 passed | 6 passed |

### The fix

Drop the connect-time read and resolve the ID from the live transport in the `sessionId` getter
instead. An explicitly assigned ID (the `Mcp-Session-Id` header path) still takes precedence. The
tool context and `#createLoadContext()` now read through that getter so every caller sees one value,
rather than two of them reading a stale private field.

This makes the session ID correct under both mcp-proxy orderings, so it does not depend on when the
transport happens to assign it.

Stateless mode and stdio are unaffected — neither transport ever assigns a session ID, so both keep
reporting `undefined`. Their existing tests still pass unchanged.

### Test

Added to the existing `src/FastMCP.session-id.test.ts`: a session whose transport is assigned a
`sessionId` *after* `connect()` resolves must surface it from both `session.sessionId` and
`context.sessionId` inside a tool call. It fails on `main` on the **locked 6.4.6 dependencies**
(`expected undefined to be '1b4e28ba-…'`) and passes with this change, so the regression is pinned
without needing a dependency bump to reproduce.

### Verification

`pnpm test` 561/561 pass · `eslint` clean · `tsc --noEmit` clean · `jsr publish --dry-run` succeeds.
