### PR TITLE
fix(edge): reject a replayed stream that collides with one already live

### DIFF
--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -264,6 +264,37 @@ describe("WebStreamableHTTPServerTransport", () => {
     await first.body?.cancel("test cleanup");
   });
 
+  it("should reject a colliding replay from a store without getStreamIdForEventId", async () => {
+    // `getStreamIdForEventId` is optional and most stores do not implement it,
+    // so a guard that only runs when it exists would leave the majority of
+    // stores overwriting live writers exactly as before. The id
+    // `replayEventsAfter` returns is the one the writer is registered under,
+    // and checking that one needs no cooperation from the store at all.
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      eventStore: {
+        replayEventsAfter: async () => "resumed-stream",
+        storeEvent: async () => "evt-1",
+      },
+      sessionIdGenerator: () => "test-session",
+    });
+    await createServer().connect(transport);
+    await transport.handleRequest(createInitializeRequest("application/json"));
+
+    const internals = transport as unknown as TransportInternals;
+
+    const first = await transport.handleRequest(createGetRequest("evt-0"));
+    expect(first.status).toBe(200);
+    const firstWriter = internals._streamMapping.get("resumed-stream");
+    expect(firstWriter).toBeDefined();
+
+    const second = await transport.handleRequest(createGetRequest("evt-0"));
+    expect(second.status).toBe(409);
+    expect(internals._streamMapping.get("resumed-stream")).toBe(firstWriter);
+
+    await first.body?.cancel("test cleanup");
+  });
+
   it("should not remove a replacement stream when an old writer closes", async () => {
     const transport = new WebStreamableHTTPServerTransport({
       enableJsonResponse: true,

--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -230,6 +230,40 @@ describe("WebStreamableHTTPServerTransport", () => {
     await afterCancel.body?.cancel();
   });
 
+  it("should reject a replayed stream that collides with one already live", async () => {
+    // Two reconnects with Last-Event-Id can resolve to the same streamId (the
+    // event store groups events by stream, not by connection). The second one
+    // must not silently overwrite the first writer in `_streamMapping` — that
+    // orphans the first connection's stream forever and hands its future
+    // events to the second writer instead. `getStreamIdForEventId` exists
+    // precisely so this can be checked before the swap happens.
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      eventStore: {
+        getStreamIdForEventId: async () => "resumed-stream",
+        replayEventsAfter: async () => "resumed-stream",
+        storeEvent: async () => "evt-1",
+      },
+      sessionIdGenerator: () => "test-session",
+    });
+    await createServer().connect(transport);
+    await transport.handleRequest(createInitializeRequest("application/json"));
+
+    const internals = transport as unknown as TransportInternals;
+
+    const first = await transport.handleRequest(createGetRequest("evt-0"));
+    expect(first.status).toBe(200);
+    const firstWriter = internals._streamMapping.get("resumed-stream");
+    expect(firstWriter).toBeDefined();
+
+    const second = await transport.handleRequest(createGetRequest("evt-0"));
+    expect(second.status).toBe(409);
+    // The first writer must still be the one tracked for this streamId.
+    expect(internals._streamMapping.get("resumed-stream")).toBe(firstWriter);
+
+    await first.body?.cancel("test cleanup");
+  });
+
   it("should not remove a replacement stream when an old writer closes", async () => {
     const transport = new WebStreamableHTTPServerTransport({
       enableJsonResponse: true,

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -625,10 +625,12 @@ export class WebStreamableHTTPServerTransport implements Transport {
       );
     }
 
-    // `getStreamIdForEventId` is optional: an event store that does not
-    // implement it cannot be asked which stream a reconnect would land on
-    // ahead of time, so this degrades to the old (racy) behavior for it, same
-    // as the official SDK's Node transport does for the equivalent check.
+    // `getStreamIdForEventId` is optional, so this only asks stores that can
+    // answer which stream the reconnect would land on before any work is done.
+    // Unlike the SDK's Node transport, an event id the store does not
+    // recognise is not rejected outright here: that store may still resolve it
+    // in `replayEventsAfter`, and answering 400 for it would turn reconnects
+    // that work today into errors.
     if (this._eventStore.getStreamIdForEventId) {
       const existingStreamId =
         await this._eventStore.getStreamIdForEventId(lastEventId);
@@ -639,7 +641,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
         return this.createErrorResponse(
           409,
           -32000,
-          "Conflict: stream already exists for this replay",
+          "Conflict: SSE stream already exists for this replay",
         );
       }
     }
@@ -654,6 +656,23 @@ export class WebStreamableHTTPServerTransport implements Transport {
           await this.writeSSEEventWithId(writer, eventId, message);
         },
       });
+
+      // The check above runs against the id the store predicts, and only for
+      // stores that implement the optional lookup. This one runs against the
+      // id the writer is about to be registered under, with no await between
+      // it and the `set` inside `trackStream` — so it also covers stores
+      // without `getStreamIdForEventId` (the common case), a store whose two
+      // methods disagree, and a second reconnect that raced past the check
+      // above while this one was awaiting its replay.
+      if (this._streamMapping.has(streamId)) {
+        await writer.close();
+        return this.createErrorResponse(
+          409,
+          -32000,
+          "Conflict: SSE stream already exists for this replay",
+        );
+      }
+
       this.trackStream(streamId, writer);
     } catch (error) {
       await writer.close();

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -625,6 +625,25 @@ export class WebStreamableHTTPServerTransport implements Transport {
       );
     }
 
+    // `getStreamIdForEventId` is optional: an event store that does not
+    // implement it cannot be asked which stream a reconnect would land on
+    // ahead of time, so this degrades to the old (racy) behavior for it, same
+    // as the official SDK's Node transport does for the equivalent check.
+    if (this._eventStore.getStreamIdForEventId) {
+      const existingStreamId =
+        await this._eventStore.getStreamIdForEventId(lastEventId);
+      if (
+        existingStreamId !== undefined &&
+        this._streamMapping.has(existingStreamId)
+      ) {
+        return this.createErrorResponse(
+          409,
+          -32000,
+          "Conflict: stream already exists for this replay",
+        );
+      }
+    }
+
     const { readable, writable } = new TransformStream<Uint8Array>();
     const writer = writable.getWriter();
 


### PR DESCRIPTION
## What's wrong

`WebStreamableHTTPServerTransport.handleReplayEvents` (the resumability path for a GET
reconnect carrying `Last-Event-Id`) registers the new stream's writer in `_streamMapping`
without checking whether a connection for that same `streamId` is already live. If a second
reconnect resolves to a `streamId` that's still tracked, it silently overwrites the first
writer instead of rejecting the conflict:

```ts
const first = await transport.handleRequest(getRequestWithLastEventId);   // 200, writer A
const second = await transport.handleRequest(getRequestWithLastEventId);  // 200, writer B — should be 409
```

The first connection's stream is now orphaned: no more bytes, no close, no signal to the
client that anything went wrong.

## Root cause

The equivalent guard already exists for the standalone stream (line ~332) and in the official
SDK's Node transport (`@modelcontextprotocol/sdk`, `streamableHttp.js`, `replayEvents`), which
checks `this._streamMapping.get(streamId) !== undefined` via `EventStore.getStreamIdForEventId`
before touching the mapping. `handleReplayEvents` in this file never calls
`getStreamIdForEventId` at all — the conflict check that exists one method up simply isn't
mirrored here.

## The fix

Before creating the replay stream, if `EventStore.getStreamIdForEventId` is implemented (it's
optional on the interface), resolve the `streamId` the reconnect would land on and, if it's
already tracked in `_streamMapping`, answer `409` — same status and error shape as the
standalone-stream guard. If the store doesn't implement `getStreamIdForEventId`, this degrades
to the previous (racy) behavior, matching what the SDK's own transport does in that case.

## Tests

New test in `src/edge/WebStreamableHTTPServerTransport.test.ts`: two `GET` reconnects with the
same `Last-Event-Id` against a store whose `getStreamIdForEventId` always resolves to the same
`streamId`. First reconnect: `200`, writer tracked. Second: `409`, and the tracked writer is
still the first one (no silent swap).

`npx vitest run src/edge/`: 42/42 passing (2 files). No other suites touched.
