### PR TITLE
fix(auth): escape regex metacharacters in redirect URI patterns

### DIFF
--- a/src/auth/OAuthProxy.pattern-escaping.test.ts
+++ b/src/auth/OAuthProxy.pattern-escaping.test.ts
@@ -1,0 +1,71 @@
+/**
+ * RED: matchesPattern() builds a RegExp from the configured pattern without
+ * escaping regex metacharacters, so `.` matches any character and the pattern
+ * is far wider than the glob the operator wrote.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { TokenStorage } from "./types.js";
+
+import { OAuthProxy } from "./OAuthProxy.js";
+
+class MemStore implements TokenStorage {
+  private store = new Map<string, unknown>();
+  async cleanup(): Promise<void> {}
+  async delete(k: string): Promise<void> {
+    this.store.delete(k);
+  }
+  async get(k: string): Promise<null | unknown> {
+    return this.store.get(k) ?? null;
+  }
+  async save(k: string, v: unknown): Promise<void> {
+    this.store.set(k, v);
+  }
+  async take(k: string): Promise<null | unknown> {
+    const v = this.store.get(k) ?? null;
+    this.store.delete(k);
+    return v;
+  }
+}
+
+const makeProxy = (patterns: string[]) =>
+  new OAuthProxy({
+    allowedRedirectUriPatterns: patterns,
+    baseUrl: "http://localhost:4200",
+    consentRequired: false,
+    encryptionKey: false,
+    redirectPath: "/oauth/callback",
+    tokenStorage: new MemStore(),
+    upstreamAuthorizationEndpoint: "https://provider.com/oauth/authorize",
+    upstreamClientId: "id",
+    upstreamClientSecret: "secret",
+    upstreamTokenEndpoint: "https://provider.com/oauth/token",
+  });
+
+describe("allowedRedirectUriPatterns regex metacharacters", () => {
+  it("does not let `.` in the pattern match an arbitrary character", async () => {
+    // Operator intent: only the host client.example.com.
+    const proxy = makeProxy(["https://client.example.com/*"]);
+
+    // Attacker registers a host they control where each `.` is replaced by
+    // another character. `.` is unescaped in the generated RegExp, so it
+    // matches.
+    await expect(
+      proxy.registerClient({
+        client_name: "evil",
+        redirect_uris: ["https://clientXexampleYcom/steal"],
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("does not treat a `+` in the pattern as a regex quantifier", async () => {
+    const proxy = makeProxy(["https://a+.example.com/cb"]);
+
+    await expect(
+      proxy.registerClient({
+        client_name: "evil",
+        redirect_uris: ["https://aaaaZexampleZcom/cb"],
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -1308,7 +1308,11 @@ export class OAuthProxy {
    */
   private matchesPattern(uri: string, pattern: string): boolean {
     const regex = new RegExp(
-      "^" + pattern.replace(/\*/g, ".*").replace(/\?/g, ".") + "$",
+      "^" +
+        pattern.replace(/[.*+?^${}()|[\]\\]/g, (char) =>
+          char === "*" ? ".*" : char === "?" ? "." : "\\" + char,
+        ) +
+        "$",
     );
     return regex.test(uri);
   }


### PR DESCRIPTION
## Problem

`matchesPattern()` in `src/auth/OAuthProxy.ts` builds a `RegExp` from each configured `allowedRedirectUriPatterns` entry by expanding `*` → `.*` and `?` → `.`, but it leaves every other regex metacharacter unescaped. In a glob a `.` is a literal dot; in the generated regex it matches any character.

So the entry `https://client.example.com/*`, written to mean one host, also matches `https://clientXexampleYcom/steal`. That flows `validateRedirectUri` → `registerClient` → an attacker completes DCR with a redirect URI on a host they control, and `handleCallback` later 302s a fresh authorization code to it.

This is the same open-redirect / code-theft path the security advisory and #262 hardened. The exact-match arm is correct; this is a residual hole in the pattern arm of the allow-list that was meant to close it. `+ ^ $ ( ) [ ] { } |` are unescaped too, so a pattern containing any of them is wider still.

## Fix

Escape in a **single pass**: one `replace` whose callback maps `*` → `.*`, `?` → `.`, and everything else → `\` + char. Single-pass matters, because escaping in two passes would let the inserted backslash be re-processed as a metacharacter.

## Test

`OAuthProxy.pattern-escaping.test.ts` drives real `registerClient()` calls (not `matchesPattern` directly), so it asserts the reachable behaviour: registration of a lookalike host must be rejected.

```
# without the fix:
× does not let `.` in the pattern match an arbitrary character
  AssertionError: promise resolved "{ …(19) }" instead of rejecting
    + "redirect_uris": [ "https://clientXexampleYcom/steal" ]
× does not treat a `+` in the pattern as a regex quantifier
  AssertionError: promise resolved "{ …(19) }" instead of rejecting

# with the fix:
✓ src/auth/OAuthProxy.pattern-escaping.test.ts (2 tests) 13ms

 Test Files  21 passed (21)
      Tests  264 passed (264)
```

`npx vitest run src/auth` — all 15 existing `open-redirect` regression tests still pass. `npx tsc --noEmit` clean.

## Scope

Six lines in `matchesPattern()` plus one new test file. No public API or config change: patterns that were already correct keep matching exactly what they matched.

**What I did not verify:** whether any deployment relies on a pattern's `.` loosely matching today. Such a pattern is strictly narrowed by this change, which I believe is the intended reading of a glob allow-list.
