### PR TITLE
fix(edge): cap a POST body that arrives without a Content-Length

### DIFF
--- a/src/edge/WebStreamableHTTPServerTransport.body-cap.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.body-cap.test.ts
@@ -1,0 +1,59 @@
+/**
+ * RED: handlePostRequest caps the body only by trusting the Content-Length
+ * header. A streamed (chunked) POST carries no Content-Length, so the header
+ * reads as "0", the 4 MiB check passes, and `request.json()` buffers the whole
+ * body into memory unbounded.
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { describe, expect, it } from "vitest";
+
+import { WebStreamableHTTPServerTransport } from "./WebStreamableHTTPServerTransport.js";
+
+const MiB = 1024 * 1024;
+
+describe("POST body size cap", () => {
+  it("rejects an oversized body that arrives without a Content-Length header", async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    const server = new Server(
+      { name: "TestServer", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    await server.connect(transport);
+
+    // 8 MiB of padding inside a syntactically valid JSON-RPC notification,
+    // i.e. double the documented 4 MiB maximum.
+    const padding = "A".repeat(8 * MiB);
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: { padding },
+    });
+
+    // A ReadableStream body is sent chunked: fetch/Request sets no
+    // Content-Length for it, which is exactly what a streaming client does.
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(body));
+        controller.close();
+      },
+    });
+
+    const request = new Request("http://localhost/mcp", {
+      body: stream,
+      duplex: "half",
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(request.headers.get("content-length")).toBeNull();
+
+    const response = await transport.handleRequest(request);
+
+    expect(response.status).toBe(413);
+  });
+});

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -449,7 +449,22 @@ export class WebStreamableHTTPServerTransport implements Transport {
     // Parse body
     let rawMessage: unknown;
     try {
-      rawMessage = parsedBody ?? (await request.json());
+      if (parsedBody !== undefined && parsedBody !== null) {
+        rawMessage = parsedBody;
+      } else {
+        // A chunked request carries no Content-Length, so the header check
+        // above cannot bound it. Measure the bytes actually read and stop at
+        // the cap rather than buffering the whole body into memory.
+        const text = await this.readBodyWithLimit(request);
+        if (text === null) {
+          return this.createErrorResponse(
+            413,
+            -32000,
+            `Request body too large. Maximum size is ${MAXIMUM_MESSAGE_SIZE} bytes`,
+          );
+        }
+        rawMessage = JSON.parse(text);
+      }
     } catch {
       return this.createErrorResponse(400, -32700, "Parse error: Invalid JSON");
     }
@@ -733,6 +748,45 @@ export class WebStreamableHTTPServerTransport implements Transport {
    */
   private handleUnsupportedRequest(): Response {
     return this.createErrorResponse(405, -32000, "Method not allowed");
+  }
+
+  /**
+   * Read a request body as text, giving up once it exceeds
+   * `MAXIMUM_MESSAGE_SIZE`. Returns `null` when the cap is exceeded so the
+   * caller can answer 413 without ever holding the whole body.
+   */
+  private async readBodyWithLimit(request: Request): Promise<null | string> {
+    if (!request.body) {
+      return "";
+    }
+
+    const reader = request.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let size = 0;
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        size += value.byteLength;
+        if (size > MAXIMUM_MESSAGE_SIZE) {
+          await reader.cancel();
+          return null;
+        }
+        chunks.push(value);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    const joined = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) {
+      joined.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return new TextDecoder().decode(joined);
   }
 
   /**


### PR DESCRIPTION
## Problem

In `WebStreamableHTTPServerTransport.handlePostRequest`, the 4 MiB `MAXIMUM_MESSAGE_SIZE` cap is enforced only by trusting a client-supplied header:

```ts
const contentLength = parseInt(request.headers.get("content-length") ?? "0", 10);
if (contentLength > MAXIMUM_MESSAGE_SIZE) { /* 413 */ }
rawMessage = parsedBody ?? (await request.json());
```

A chunked / streamed POST carries **no** `Content-Length` — that is what `fetch` sends for any `ReadableStream` body. So `?? "0"` gives `0`, `0 > 4 MiB` is false, the guard passes, and `request.json()` buffers the entire body into memory with no bound. The documented limit is bypassed by *omitting* a header, which is fully under the caller's control. This is the edge/Workers transport, so the ceiling is the isolate's memory.

Same shape as the unbounded-buffer fix you merged in `mcp-proxy#88`: fail at a bound instead of growing.

## Fix

Read the body through `request.body.getReader()`, accumulate `byteLength`, and `cancel()` + return 413 the moment the running total exceeds the cap. The `Content-Length` fast-path check is untouched, and a `parsedBody` supplied by the host framework keeps its existing short-circuit.

If you'd prefer a smaller diff, the alternative is to keep `await request.json()` whenever `Content-Length` is present and only stream-count when the header is absent — happy to switch.

## Test

Drives an 8 MiB (double the cap) JSON-RPC notification through a `ReadableStream` body; the test first asserts `content-length` really is `null`, so it is not hypothetical.

```
# without the fix:
× rejects an oversized body that arrives without a Content-Length header
  AssertionError: expected 202 to be 413 // Object.is equality
    - 413
    + 202

# with the fix:
✓ src/edge/WebStreamableHTTPServerTransport.body-cap.test.ts (1 test) 97ms

 Test Files  3 passed (3)
      Tests  46 passed (46)
```

`npx vitest run src/edge`. `npx tsc --noEmit` clean.

## Scope

One helper plus the parse branch in `src/edge/`, and its test. No change to the Node transports.

**What I did not verify:** I did not measure the throughput cost of decoding via reader + `TextDecoder` versus native `request.json()` on a real Workers runtime; I only tested under Node/vitest.
