### PR TITLE
fix(oauth): mark token and registration responses as non-storable

### DIFF
--- a/src/FastMCP.oauth-no-store.test.ts
+++ b/src/FastMCP.oauth-no-store.test.ts
@@ -1,0 +1,75 @@
+/**
+ * The token and dynamic-registration endpoints hand back credentials, so their
+ * responses must not be storable. RFC 6749 §5.1 requires `Cache-Control:
+ * no-store` and `Pragma: no-cache` on token responses, and RFC 7591 §3.2.1
+ * requires the same for a registration response carrying `client_secret`.
+ */
+
+import { getRandomPort } from "get-port-please";
+import { describe, expect, it } from "vitest";
+
+import { OAuthProxy } from "./auth/OAuthProxy.js";
+import { FastMCP } from "./FastMCP.js";
+
+describe("OAuth credential responses are not storable", () => {
+  it("sets no-store on the registration and token endpoints", async () => {
+    const port = await getRandomPort();
+
+    const authProxy = new OAuthProxy({
+      allowedRedirectUriPatterns: ["https://client.example.com/*"],
+      baseUrl: `http://localhost:${port}`,
+      scopes: ["openid", "profile"],
+      upstreamAuthorizationEndpoint: "https://example.com/oauth/authorize",
+      upstreamClientId: "test-client-id",
+      upstreamClientSecret: "test-client-secret",
+      upstreamTokenEndpoint: "https://example.com/oauth/token",
+    });
+
+    const server = new FastMCP({
+      name: "Test Server",
+      oauth: {
+        authorizationServer: authProxy.getAuthorizationServerMetadata(),
+        enabled: true,
+        proxy: authProxy,
+      },
+      version: "1.0.0",
+    });
+
+    await server.start({
+      httpStream: { port },
+      transportType: "httpStream",
+    });
+
+    try {
+      // Dynamic client registration returns client_secret.
+      const dcr = await fetch(`http://localhost:${port}/oauth/register`, {
+        body: JSON.stringify({
+          redirect_uris: ["https://client.example.com/callback"],
+        }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      });
+
+      expect(dcr.headers.get("cache-control")).toBe("no-store");
+      expect(dcr.headers.get("pragma")).toBe("no-cache");
+
+      // The token endpoint returns access_token and refresh_token. This request
+      // is rejected, and that is the point: an error response from the token
+      // endpoint must not be the one an intermediary caches either.
+      const token = await fetch(`http://localhost:${port}/oauth/token`, {
+        body: new URLSearchParams({
+          client_id: "unknown-client",
+          code: "irrelevant",
+          grant_type: "authorization_code",
+        }).toString(),
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      });
+
+      expect(token.headers.get("cache-control")).toBe("no-store");
+      expect(token.headers.get("pragma")).toBe("no-cache");
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2874,6 +2874,18 @@ function parseBasicAuthHeader(
  */
 const OAUTH_PROXY_MAX_BODY_SIZE = 1024 * 1024; // 1 MiB
 
+/**
+ * RFC 6749 §5.1 requires `Cache-Control: no-store` and `Pragma: no-cache` on
+ * token endpoint responses, and RFC 7591 §3.2.1 requires the same for a
+ * registration response carrying `client_secret`. Without them an intermediary
+ * proxy or the browser may retain the credential.
+ */
+const OAUTH_CREDENTIAL_RESPONSE_HEADERS = {
+  "Cache-Control": "no-store",
+  "Content-Type": "application/json",
+  Pragma: "no-cache",
+} as const;
+
 function stripBasePath(
   path: string,
   basePath: "" | `/${string}`,
@@ -3967,13 +3979,13 @@ export class FastMCP<
                 );
                 const response = await oauthProxy.registerClient(request);
                 res
-                  .writeHead(201, { "Content-Type": "application/json" })
+                  .writeHead(201, OAUTH_CREDENTIAL_RESPONSE_HEADERS)
                   .end(JSON.stringify(response));
               } catch (error) {
                 const statusCode =
                   (error as { statusCode?: number }).statusCode || 400;
                 res
-                  .writeHead(statusCode, { "Content-Type": "application/json" })
+                  .writeHead(statusCode, OAUTH_CREDENTIAL_RESPONSE_HEADERS)
                   .end(
                     JSON.stringify(
                       (error as { toJSON?: () => unknown }).toJSON?.() || {
@@ -4217,13 +4229,13 @@ export class FastMCP<
                 }
 
                 res
-                  .writeHead(200, { "Content-Type": "application/json" })
+                  .writeHead(200, OAUTH_CREDENTIAL_RESPONSE_HEADERS)
                   .end(JSON.stringify(response));
               } catch (error) {
                 const statusCode =
                   (error as { statusCode?: number }).statusCode || 400;
                 res
-                  .writeHead(statusCode, { "Content-Type": "application/json" })
+                  .writeHead(statusCode, OAUTH_CREDENTIAL_RESPONSE_HEADERS)
                   .end(
                     JSON.stringify(
                       (error as { toJSON?: () => unknown }).toJSON?.() || {


### PR DESCRIPTION
## Problem

`/oauth/token` returns `access_token` and `refresh_token`, and `/oauth/register` returns `client_secret`, but both responses carried only `Content-Type: application/json`. An intermediary proxy, a CDN or the browser may therefore retain the credential.

RFC 6749 §5.1 requires `Cache-Control: no-store` and `Pragma: no-cache` on token endpoint responses. RFC 7591 §3.2.1 requires the same for a registration response containing `client_secret`.

`grep -rn 'no-store' src/` returns nothing on `main`.

## Fix

One constant beside the existing `OAUTH_PROXY_MAX_BODY_SIZE`, applied to all four responses of those two endpoints — error paths included, since an error response from the token endpoint must not be the cached one either.

```ts
const OAUTH_CREDENTIAL_RESPONSE_HEADERS = {
  "Cache-Control": "no-store",
  "Content-Type": "application/json",
  Pragma: "no-cache",
} as const;
```

The `authorize`, `callback` and `consent` handlers are deliberately left untouched: they redirect and carry no credential in the body.

## Test

`src/FastMCP.oauth-no-store.test.ts` starts a server with `OAuthProxy`, performs dynamic client registration and a token request, and asserts both headers on each response.

Verified failing before the fix:

```
AssertionError: expected null to be 'no-store' // Object.is equality
```

After the fix the full suite passes, and `npm run build` and `npm run lint` are both clean.
