### PR TITLE
fix(auth): restrict DiskStore file and directory permissions

### DIFF
--- a/src/auth/utils/diskStore.test.ts
+++ b/src/auth/utils/diskStore.test.ts
@@ -1,4 +1,5 @@
-import { readdir, rm } from "fs/promises";
+import { mkdtemp, readdir, rm, stat } from "fs/promises";
+import { tmpdir } from "os";
 import { join } from "path";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
@@ -247,6 +248,35 @@ describe("DiskStore", () => {
       expect(files.filter((file) => file.includes(".claim"))).toHaveLength(0);
 
       store.destroy();
+    });
+  });
+
+  // Node ignores the `mode` option on Windows, so these assertions are
+  // POSIX-only.
+  describe.skipIf(process.platform === "win32")("file permissions", () => {
+    it("should not expose stored credentials to group or other", async () => {
+      const directory = join(
+        await mkdtemp(join(tmpdir(), "fastmcp-diskstore-perms-")),
+        "oauth",
+      );
+      const store = new DiskStore({ directory });
+
+      try {
+        await store.save("token-key", {
+          access_token: "at-secret",
+          proxyCodeVerifier: "pkce-secret",
+          refresh_token: "rt-secret",
+        });
+
+        const directoryStats = await stat(directory);
+        const fileStats = await stat(join(directory, "token-key.json"));
+
+        expect(directoryStats.mode & 0o077).toBe(0);
+        expect(fileStats.mode & 0o077).toBe(0);
+      } finally {
+        store.destroy();
+        await rm(directory, { force: true, recursive: true });
+      }
     });
   });
 });

--- a/src/auth/utils/diskStore.ts
+++ b/src/auth/utils/diskStore.ts
@@ -168,7 +168,14 @@ export class DiskStore implements TokenStorage {
     };
 
     try {
-      await writeFile(filePath, JSON.stringify(entry, null, 2), "utf-8");
+      // 0o600: these files hold authorization codes, access/refresh tokens
+      // and PKCE verifiers, so nothing outside the owning user should read
+      // them. `mode` only applies when the file is created; an overwrite
+      // keeps whatever mode the existing file already has.
+      await writeFile(filePath, JSON.stringify(entry, null, 2), {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
     } catch (error) {
       console.error(`Failed to save key ${key}:`, error);
       throw error;
@@ -236,7 +243,9 @@ export class DiskStore implements TokenStorage {
       }
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        await mkdir(this.directory, { recursive: true });
+        // 0o700 so the credential filenames are not even listable by
+        // other users on the host.
+        await mkdir(this.directory, { mode: 0o700, recursive: true });
       } else {
         throw error;
       }


### PR DESCRIPTION
## Problem

`DiskStore` persists OAuth state as plain JSON on disk: authorization codes, access tokens, refresh tokens and the proxy PKCE `proxyCodeVerifier`.

`save()` called `writeFile(filePath, ..., "utf-8")` and `ensureDirectory()` called `mkdir(this.directory, { recursive: true })` — neither passed a `mode`, so Node applied the defaults minus the process umask. On a default host that yields **directory `0755`, files `0644`**: every local user can read live credentials, and replay them.

This is not a niche configuration. `DiskStore` is part of the public API (exported from `src/auth/index.ts`), and `docs/oauth-advanced-features.md` recommends it for production with `directory: "/var/lib/fastmcp/oauth"`, presenting `EncryptedTokenStorage` only as *"For additional security"* — so unencrypted `DiskStore` is a supported production configuration.

## Fix

- `mkdir(..., { mode: 0o700, recursive: true })`
- `writeFile(..., { encoding: "utf-8", mode: 0o600 })`

`take()` needs no change: it uses `rename()`, which preserves the mode of the source file.

## Caveats

Both are deliberate and noted in code comments:

1. **`mode` only applies at creation time.** Overwriting an existing file keeps whatever mode that file already has, and `mkdir` does not chmod an existing directory. Deployments already running with `0755`/`0644` therefore keep those modes until the files are recreated. This PR intentionally does not `chmod` existing paths — silently tightening permissions on a directory the operator may have configured on purpose (for example a shared group) is a behavioural change beyond the scope of a hardening fix. Operators upgrading should `chmod 700` the directory and `chmod 600` its contents once.

2. **Windows ignores `mode`,** so the new test is guarded with `describe.skipIf(process.platform === "win32")`.

## Test

Added `DiskStore > file permissions > should not expose stored credentials to group or other`: it creates a store under `mkdtemp()`, saves an entry containing token-shaped fields, then `stat()`s both the directory and the entry file and asserts `(mode & 0o077) === 0`.

Verified failing before the fix:

```
AssertionError: expected 45 to be +0 // Object.is equality
 ❯ src/auth/utils/diskStore.test.ts:274:45
       expect(directoryStats.mode & 0o077).toBe(0);
```

`45` is `0o055`, i.e. the directory's `0755`.

After the fix: 47 test files / 593 tests passing. `npm run build` and `npm run lint` both clean.
