### PR TITLE
fix(auth): protect the issued scope claim from upstream passthrough

### DIFF
--- a/src/auth/utils/claimsExtractor.test.ts
+++ b/src/auth/utils/claimsExtractor.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { ClaimsExtractor } from "./claimsExtractor.js";
+
+/** Build a JWT-format token whose payload carries the given claims. */
+function jwtWith(claims: Record<string, unknown>): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "none", typ: "JWT" }),
+  ).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+describe("ClaimsExtractor custom-claims passthrough", () => {
+  it("passes an ordinary custom claim through", async () => {
+    const extractor = new ClaimsExtractor(true);
+    const claims = await extractor.extract(
+      jwtWith({ department: "eng" }),
+      "access",
+    );
+    expect(claims).toEqual({ department: "eng" });
+  });
+
+  it("never copies the proxy-issued `scope` claim from upstream", async () => {
+    // `scope` is a first-class claim the proxy issues itself as an
+    // authorization decision (see JWTClaims). Letting an upstream token
+    // overwrite it would silently replace the scope embedded in the signed
+    // FastMCP JWT, diverging from the mapping and the token response.
+    const extractor = new ClaimsExtractor(true);
+    const claims = await extractor.extract(
+      jwtWith({ department: "eng", scope: "admin superuser" }),
+      "access",
+    );
+    expect(claims).not.toHaveProperty("scope");
+    expect(claims).toEqual({ department: "eng" });
+  });
+});

--- a/src/auth/utils/claimsExtractor.ts
+++ b/src/auth/utils/claimsExtractor.ts
@@ -8,7 +8,10 @@ import type { CustomClaimsPassthroughConfig } from "../types.js";
 export class ClaimsExtractor {
   private config: CustomClaimsPassthroughConfig;
 
-  // Claims that MUST NOT be copied from upstream (protect proxy's JWT integrity)
+  // Claims that MUST NOT be copied from upstream (protect proxy's JWT integrity).
+  // "scope" is included because the proxy issues it itself as an authorization
+  // decision (see JWTClaims); a passthrough "scope" would otherwise overwrite the
+  // scope embedded in the signed FastMCP JWT, diverging from the stored mapping.
   private readonly PROTECTED_CLAIMS = new Set([
     "aud",
     "client_id",
@@ -17,6 +20,7 @@ export class ClaimsExtractor {
     "iss",
     "jti",
     "nbf",
+    "scope",
   ]);
 
   constructor(config: boolean | CustomClaimsPassthroughConfig) {


### PR DESCRIPTION
## What

`ClaimsExtractor` is documented to strip upstream claims that would compromise the proxy-issued JWT, and its `PROTECTED_CLAIMS` set already covers `aud`, `client_id`, `exp`, `iat`, `iss`, `jti`, and `nbf`. `scope` was missing from that set even though it is a first-class claim the proxy issues itself as an authorization decision (`JWTClaims.scope`).

## Why it matters

`JWTIssuer.issueAccessToken`/`issueRefreshToken` merge the passthrough claims **after** the standard ones:

```ts
const claims = { aud, client_id, exp, iat, iss, jti, scope, ...(additionalClaims || {}) };
```

So when `customClaimsPassthrough` is enabled (a documented opt-in) and an upstream access/ID token contains a `scope` claim — a registered JWT access-token claim (RFC 9068) that many IdPs emit, e.g. Keycloak and Auth0 — it silently overwrites the scope the proxy embeds in the signed token.

The JWT's `scope` then diverges from the value stored in the `mapping:${jti}` record and from the `scope` field returned in the token response — three sources that are meant to agree, silently disagreeing. Any resource server that reads scope from the token is misled.

Reachability: operator enables `customClaimsPassthrough` → `OAuthProxy.issueSwappedTokens` → `extractUpstreamClaims` → `issueAccessToken(clientId, upstreamTokens.scope, customClaims, ...)`. If the upstream token carries `scope`, it survives the filter.

## Fix

Add `scope` to `PROTECTED_CLAIMS`. One line, plus a focused test covering an ordinary custom claim (still passes through) and a `scope` claim (now filtered).

## Test

`src/auth/utils/claimsExtractor.test.ts` (new). Fails before the change:

```
AssertionError: expected { department: 'eng', … } to not have property "scope"
+ Received: "admin superuser"
```

Passes after. Full auth suite green (264 tests), `tsc --noEmit` clean.
