### PR TITLE
fix: stop pumping a custom route stream once the client is gone

### DIFF
--- a/src/FastMCP.routes.test.ts
+++ b/src/FastMCP.routes.test.ts
@@ -1038,3 +1038,67 @@ test("custom route stream stops when the client disconnects", async () => {
     await server.stop();
   }
 });
+
+test("custom route stream stops when a quiet client disconnects", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  const app = server.getApp();
+
+  let cancelled = false;
+
+  app.get("/quiet-events", () => {
+    const encoder = new TextEncoder();
+    let sent = false;
+
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+      async pull(controller) {
+        if (!sent) {
+          sent = true;
+          controller.enqueue(encoder.encode(": ping\n\n"));
+          return;
+        }
+        // An SSE route between heartbeats: open, but with nothing to say.
+        // Nothing here can observe the disconnect, so the pump must.
+        await new Promise(() => {});
+      },
+    });
+
+    return new Response(body, {
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  });
+
+  await server.start({
+    httpStream: {
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const abortController = new AbortController();
+
+    const response = await fetch(`http://localhost:${port}/quiet-events`, {
+      signal: abortController.signal,
+    });
+
+    expect(response.status).toBe(200);
+
+    const reader = response.body!.getReader();
+    await reader.read();
+
+    abortController.abort();
+
+    await vi.waitFor(() => expect(cancelled).toBe(true), { timeout: 3000 });
+  } finally {
+    await server.stop();
+  }
+});

--- a/src/FastMCP.routes.test.ts
+++ b/src/FastMCP.routes.test.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { getRandomPort } from "get-port-please";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { z } from "zod";
 
 import { FastMCP, FastMCPSession } from "./FastMCP.js";
@@ -978,4 +978,63 @@ test("route options validation", async () => {
       return c.json({ test: 4 });
     });
   }).not.toThrow();
+});
+
+test("custom route stream stops when the client disconnects", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  const app = server.getApp();
+
+  let cancelled = false;
+
+  app.get("/events", () => {
+    const encoder = new TextEncoder();
+
+    const body = new ReadableStream<Uint8Array>({
+      cancel() {
+        cancelled = true;
+      },
+      async pull(controller) {
+        // Never ends, like an SSE route. Throttled so the assertion below
+        // observes the pump rather than a busy loop.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        controller.enqueue(encoder.encode(": ping\n\n"));
+      },
+    });
+
+    return new Response(body, {
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  });
+
+  await server.start({
+    httpStream: {
+      port,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const abortController = new AbortController();
+
+    const response = await fetch(`http://localhost:${port}/events`, {
+      signal: abortController.signal,
+    });
+
+    expect(response.status).toBe(200);
+
+    const reader = response.body!.getReader();
+    await reader.read();
+
+    abortController.abort();
+
+    await vi.waitFor(() => expect(cancelled).toBe(true), { timeout: 3000 });
+  } finally {
+    await server.stop();
+  }
 });

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3751,18 +3751,34 @@ export class FastMCP<
 
           if (honoResponse.body) {
             const reader = honoResponse.body.getReader();
+
+            // A custom route is free to return a stream that never ends on its
+            // own (SSE, a proxied upstream). The client going away is then the
+            // only thing that ends it, and such a stream may well be quiet at
+            // that moment, so waiting on `read()` alone would keep pumping
+            // until a chunk that may never arrive. Race every read against the
+            // response closing instead.
+            let resolveClosed!: () => void;
+            const closed = new Promise<undefined>((resolve) => {
+              resolveClosed = () => resolve(undefined);
+            });
+            res.once("close", resolveClosed);
+            if (res.writableEnded || res.destroyed) {
+              resolveClosed();
+            }
+
             try {
-              // A custom route is free to return a stream that never ends on
-              // its own (SSE, a proxied upstream). The client going away is
-              // then the only thing that ends it, so stop pumping once the
-              // response can no longer be written to instead of reading
-              // forever into a socket nobody is listening on.
               while (!res.writableEnded && !res.destroyed) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                res.write(value);
+                const read = reader.read();
+                // `closed` may win the race, leaving this promise to settle
+                // with nobody observing it.
+                read.catch(() => {});
+                const result = await Promise.race([read, closed]);
+                if (!result || result.done) break;
+                res.write(result.value);
               }
             } finally {
+              res.off("close", resolveClosed);
               // `releaseLock` detaches this reader but leaves the body itself
               // unread and its source running; only `cancel` tells the route
               // to stop producing and release what it holds.

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3752,12 +3752,21 @@ export class FastMCP<
           if (honoResponse.body) {
             const reader = honoResponse.body.getReader();
             try {
-              while (true) {
+              // A custom route is free to return a stream that never ends on
+              // its own (SSE, a proxied upstream). The client going away is
+              // then the only thing that ends it, so stop pumping once the
+              // response can no longer be written to instead of reading
+              // forever into a socket nobody is listening on.
+              while (!res.writableEnded && !res.destroyed) {
                 const { done, value } = await reader.read();
                 if (done) break;
                 res.write(value);
               }
             } finally {
+              // `releaseLock` detaches this reader but leaves the body itself
+              // unread and its source running; only `cancel` tells the route
+              // to stop producing and release what it holds.
+              await reader.cancel().catch(() => {});
               reader.releaseLock();
             }
           }


### PR DESCRIPTION
A route added via `getApp()` may return a body that never ends on its own — an SSE stream, or a proxied upstream. The pump that copies that body into the Node response loops until the source says `done`, which for such a route only happens if the source itself stops.

When the client disconnects, the loop therefore keeps reading forever into a response nobody can receive. The `finally` block releases the reader lock without cancelling the body, so the route is never told to stop producing and keeps holding whatever it holds — an upstream connection, a timer, a subscription.

Stop when the response can no longer be written to, and cancel the body on the way out.

The added test registers a route whose stream never completes, reads one chunk, aborts the request, and asserts the stream's `cancel()` runs. Without the change it never does.

Suite on the branch: 47 files / 593 passed (592 on a clean `main`). Two pre-existing failures were verified to be identical on `main` and are untouched here: `tsc --noEmit` on `src/edge/WebStreamableHTTPServerTransport.ts` (TS2345), and `prettier --check src/FastMCP.ts` (version drift reformats unrelated unions — I deliberately kept only my own hunk rather than reformatting them).
