### PR TITLE
fix: serialize session pings

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -1952,6 +1952,58 @@ test("session sends pings to the client", async () => {
   });
 });
 
+test("session does not overlap pings when the client is slow", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      let activePings = 0;
+      let maxActivePings = 0;
+      let pingCalls = 0;
+      let releaseFirstPing!: () => void;
+      const firstPingBlocked = new Promise<void>((resolve) => {
+        releaseFirstPing = resolve;
+      });
+
+      client.setRequestHandler(PingRequestSchema, async () => {
+        pingCalls += 1;
+        activePings += 1;
+        maxActivePings = Math.max(maxActivePings, activePings);
+
+        if (pingCalls === 1) {
+          await firstPingBlocked;
+        }
+
+        activePings -= 1;
+
+        return {};
+      });
+
+      await vi.waitFor(() => {
+        expect(pingCalls).toBe(1);
+      });
+      await delay(50);
+      const callsWhileFirstPingWasBlocked = pingCalls;
+
+      releaseFirstPing();
+
+      expect(callsWhileFirstPingWasBlocked).toBe(1);
+      await vi.waitFor(() => {
+        expect(pingCalls).toBeGreaterThanOrEqual(2);
+      });
+      expect(maxActivePings).toBe(1);
+    },
+    server: async () => {
+      return new FastMCP({
+        name: "Test",
+        ping: {
+          enabled: true,
+          intervalMs: 10,
+        },
+        version: "1.0.0",
+      });
+    },
+  });
+});
+
 test("completes prompt arguments", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1410,6 +1410,7 @@ export class FastMCPSession<
   #onToolCall?: ServerOptions<T>["onToolCall"];
   #pingConfig?: ServerOptions<T>["ping"];
 
+  #pingInFlight = false;
   #pingInterval: null | ReturnType<typeof setInterval> = null;
 
   #prompts: Map<string, Prompt<T>> = new Map();
@@ -1650,6 +1651,12 @@ export class FastMCPSession<
 
         if (pingConfig.enabled) {
           this.#pingInterval = setInterval(async () => {
+            if (this.#pingInFlight) {
+              return;
+            }
+
+            this.#pingInFlight = true;
+
             try {
               await this.#server.ping();
             } catch {
@@ -1671,6 +1678,8 @@ export class FastMCPSession<
               } else {
                 this.#logger.info("[FastMCP info] server ping failed");
               }
+            } finally {
+              this.#pingInFlight = false;
             }
           }, pingConfig.intervalMs);
         }


### PR DESCRIPTION
## What is wrong

`FastMCPSession` schedules `ping()` from an async interval callback. When a client takes longer than `intervalMs`, later ticks start additional requests. A controlled slow-client reproduction reached eight concurrent pings with a 10 ms interval.

The existing catch handles eventual failures, but does not bound how many ping requests are in flight.

## Fix

Track one in-flight ping per session. Ticks are skipped while it is pending, and `finally` releases the guard after either success or failure.

## Regression coverage

The new controlled-promise test:

- blocks the first ping;
- proves no second ping starts while it remains blocked;
- releases it and proves later scheduling resumes;
- verifies maximum concurrency stays at one.

## Verification

- Prettier
- ESLint
- TypeScript `--noEmit`
- focused ping regression: 2/2
- full suite: 51 files, 602/602 tests
- ESM/CJS/DTS build