### PR TITLE
fix(edge): reject reinitializing active sessions

### DIFF
--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -46,7 +46,7 @@ const createPostRequest = (body: unknown, accept: string, sessionId?: string) =>
     method: "POST",
   });
 
-const createInitializeRequest = (accept: string) =>
+const createInitializeRequest = (accept: string, sessionId?: string) =>
   createPostRequest(
     {
       id: 1,
@@ -59,6 +59,7 @@ const createInitializeRequest = (accept: string) =>
       },
     },
     accept,
+    sessionId,
   );
 
 const createServer = () =>
@@ -220,6 +221,52 @@ describe("WebStreamableHTTPServerTransport", () => {
     expect(body.jsonrpc).toBe("2.0");
     expect(body.id).toBe(1);
     expect(body.result.serverInfo.name).toBe("TestServer");
+  });
+
+  it("rejects reinitializing an active session", async () => {
+    const sessionIdGenerator = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("first-session")
+      .mockReturnValueOnce("second-session");
+    const onsessioninitialized = vi.fn();
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      onsessioninitialized,
+      sessionIdGenerator,
+    });
+    await createServer().connect(transport);
+
+    const first = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    expect(first.status).toBe(200);
+    await first.json();
+    expect(transport.sessionId).toBe("first-session");
+
+    const second = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    const error: JsonResponse = await second.json();
+
+    expect(second.status).toBe(400);
+    expect(second.headers.get("mcp-session-id")).toBeNull();
+    expect(error.error).toEqual({
+      code: -32600,
+      message: "Invalid Request: Server already initialized",
+    });
+    expect(transport.sessionId).toBe("first-session");
+    expect(sessionIdGenerator).toHaveBeenCalledTimes(1);
+    expect(onsessioninitialized).toHaveBeenCalledTimes(1);
+
+    const withHeader = await transport.handleRequest(
+      createInitializeRequest("application/json", "attacker-session"),
+    );
+
+    expect(withHeader.status).toBe(400);
+    expect(withHeader.headers.get("mcp-session-id")).toBeNull();
+    expect(transport.sessionId).toBe("first-session");
+    expect(sessionIdGenerator).toHaveBeenCalledTimes(1);
+    expect(onsessioninitialized).toHaveBeenCalledTimes(1);
   });
 
   it("should release the standalone SSE stream when the client cancels", async () => {

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -284,6 +284,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
     status: number,
     code: number,
     message: string,
+    includeSessionId = true,
   ): Response {
     return new Response(
       JSON.stringify({
@@ -293,7 +294,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
       }),
       {
         headers: {
-          ...this.getResponseHeaders(),
+          ...(includeSessionId ? this.getResponseHeaders() : {}),
           "Content-Type": "application/json",
         },
         status,
@@ -509,6 +510,20 @@ export class WebStreamableHTTPServerTransport implements Transport {
         400,
         -32600,
         "Invalid Request: Initialization requests must not include a sessionId",
+        false,
+      );
+    }
+
+    if (
+      hasInitRequest &&
+      this.sessionIdGenerator &&
+      this.sessionId !== undefined
+    ) {
+      return this.createErrorResponse(
+        400,
+        -32600,
+        "Invalid Request: Server already initialized",
+        false,
       );
     }
 


### PR DESCRIPTION
## Summary

- reject repeated `initialize` requests while a stateful session is active
- preserve the original session ID and initialization callback
- avoid returning the active `mcp-session-id` on rejected initialization requests
- keep stateless mode and reinitialization after `DELETE` unchanged

## Problem

A second headerless `initialize` generated a new session ID and replaced the active session. An `initialize` carrying an arbitrary session header was rejected, but its error response exposed the active session ID.

The new guard rejects both forms without mutating or disclosing the current session.

## Verification

- red: repeated initialization returned HTTP 200 instead of 400
- red: an attacker-supplied session header received the active `mcp-session-id`
- `pnpm exec vitest run src/edge/WebStreamableHTTPServerTransport.test.ts src/edge/WebStreamableHTTPServerTransport.body-cap.test.ts` - 30 passed
- `pnpm test` - 51 files, 602 tests passed
- `pnpm lint` - Prettier, ESLint, TypeScript and JSR publish dry-run passed
