### PR TITLE
fix(edge): make session teardown fail-safe

### DIFF
--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -680,6 +680,126 @@ describe("WebStreamableHTTPServerTransport", () => {
     expect(stored.slice(before)).toEqual([]);
   });
 
+  it.each([
+    [
+      "throws",
+      () => {
+        throw new Error("session close failed");
+      },
+    ],
+    [
+      "rejects",
+      async () => {
+        throw new Error("session close failed");
+      },
+    ],
+  ])(
+    "clears the session when onsessionclosed %s",
+    async (_mode, closeHandler) => {
+      const onSessionClosed = vi.fn(closeHandler);
+      const transport = new WebStreamableHTTPServerTransport({
+        onsessionclosed: onSessionClosed,
+        sessionIdGenerator: () => "test-session",
+      });
+      await createServer().connect(transport);
+      await transport.handleRequest(
+        createInitializeRequest("application/json"),
+      );
+
+      await expect(
+        transport.handleRequest(createDeleteRequest()),
+      ).rejects.toThrow("session close failed");
+      expect(onSessionClosed).toHaveBeenCalledTimes(1);
+      expect(onSessionClosed).toHaveBeenCalledWith("test-session");
+
+      const staleSession = await transport.handleRequest(createGetRequest());
+      expect(staleSession.status).toBe(404);
+
+      const reinitialized = await transport.handleRequest(
+        createInitializeRequest("application/json"),
+      );
+      expect(reinitialized.status).toBe(200);
+
+      // A second DELETE belongs to the newly initialized session, proving the
+      // failed callback did not leave the original session active.
+      await expect(
+        transport.handleRequest(createDeleteRequest()),
+      ).rejects.toThrow("session close failed");
+      expect(onSessionClosed).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("rejects initialization until session teardown finishes", async () => {
+    let releaseStreamClose: (() => void) | undefined;
+    let markStreamCloseStarted: (() => void) | undefined;
+    const streamCloseStarted = new Promise<void>((resolve) => {
+      markStreamCloseStarted = resolve;
+    });
+    const streamCloseGate = new Promise<void>((resolve) => {
+      releaseStreamClose = resolve;
+    });
+    let rejectClose: ((reason: Error) => void) | undefined;
+    let markCloseStarted: (() => void) | undefined;
+    const closeStarted = new Promise<void>((resolve) => {
+      markCloseStarted = resolve;
+    });
+    const closeGate = new Promise<void>((_resolve, reject) => {
+      rejectClose = reject;
+    });
+
+    const onSessionClosed = vi.fn(async () => {
+      markCloseStarted?.();
+      await closeGate;
+    });
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      onsessionclosed: onSessionClosed,
+      sessionIdGenerator: () => "test-session",
+    });
+    await createServer().connect(transport);
+    const initialized = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    expect(initialized.status).toBe(200);
+
+    const internals = transport as unknown as TransportInternals;
+    internals._streamMapping.set("old-stream", {
+      close: vi.fn(async () => {
+        markStreamCloseStarted?.();
+        await streamCloseGate;
+      }),
+    } as unknown as WritableStreamDefaultWriter<Uint8Array>);
+
+    const deleting = transport.handleRequest(createDeleteRequest());
+    await streamCloseStarted;
+
+    const staleSession = await transport.handleRequest(createGetRequest());
+    expect(staleSession.status).toBe(404);
+    const initializeDuringTeardown = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+
+    releaseStreamClose?.();
+    await closeStarted;
+    const initializeDuringCallback = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+
+    rejectClose?.(new Error("session close failed"));
+    await expect(deleting).rejects.toThrow("session close failed");
+    expect(onSessionClosed).toHaveBeenCalledOnce();
+    expect(onSessionClosed).toHaveBeenCalledWith("test-session");
+    expect(initializeDuringTeardown.status).toBe(400);
+    expect(initializeDuringCallback.status).toBe(400);
+    expect(internals._streamMapping.size).toBe(0);
+
+    const reinitialized = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    expect(reinitialized.status).toBe(200);
+    expect(internals._streamMapping.size).toBe(0);
+  });
+
   it("stores a standalone event sent while a replay is still resolving", async () => {
     // `replayEventsAfter` only reveals which stream it replayed once it
     // settles, so during the await the stream is neither in `_streamMapping`

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -105,6 +105,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
 
   private _requestToStreamMapping = new Map<RequestId, StreamId>();
 
+  private _sessionClosing = false;
   private _standaloneSseStreamId = "_GET_stream";
   /**
    * Whether a client has held the standalone GET stream during this session.
@@ -332,10 +333,15 @@ export class WebStreamableHTTPServerTransport implements Transport {
       }
     }
 
-    await this.teardownStreams();
-
-    await this._onsessionclosed?.(this.sessionId ?? "");
+    this._sessionClosing = true;
+    const closedSessionId = this.sessionId ?? "";
     this.sessionId = undefined;
+    try {
+      await this.teardownStreams();
+      await this._onsessionclosed?.(closedSessionId);
+    } finally {
+      this._sessionClosing = false;
+    }
 
     return new Response(null, {
       headers: this.getResponseHeaders(),
@@ -509,6 +515,14 @@ export class WebStreamableHTTPServerTransport implements Transport {
         400,
         -32600,
         "Invalid Request: Initialization requests must not include a sessionId",
+      );
+    }
+
+    if (hasInitRequest && this.sessionIdGenerator && this._sessionClosing) {
+      return this.createErrorResponse(
+        400,
+        -32600,
+        "Invalid Request: Session is closing",
       );
     }
 


### PR DESCRIPTION
## Summary

- invalidate a managed session before asynchronous teardown starts
- reject initialization while stream cleanup and `onsessionclosed` are still running
- release the closing guard in `finally` while preserving the callback error and original session ID

## Why

A failing or slow `onsessionclosed` callback could leave the old session usable during teardown. Concurrent GET or initialize requests could then attach state that the old teardown later clears, or leak routing state into the next session.

The transport now fails closed for managed sessions until teardown settles. Stateless behavior is unchanged.

## Tests

- synchronous throw and asynchronous rejection from `onsessionclosed`
- deterministic gated writer close and callback windows
- stale session GET returns 404 during close
- initialize returns 400 during teardown and callback execution
- reinitialization succeeds after close settles
- `pnpm test`: 51 files, 604 tests
- `pnpm lint`: Prettier, ESLint, TypeScript, and JSR dry-run

Related to #339: the guards are complementary (closing session vs. active session), and the combined merge tree is clean.