### PR TITLE
fix(edge): hide the session id from rejections and invalidate it on close

### DIFF
--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -20,18 +20,18 @@ type TransportInternals = {
 /** Let a settled `writer.closed` run its cleanup before asserting on it. */
 const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
 
-const createGetRequest = (lastEventId?: string) =>
+const createGetRequest = (lastEventId?: string, sessionId = "test-session") =>
   new Request("http://localhost/mcp", {
     headers: {
       Accept: "text/event-stream",
-      "mcp-session-id": "test-session",
+      "mcp-session-id": sessionId,
       ...(lastEventId ? { "last-event-id": lastEventId } : {}),
     },
   });
 
-const createDeleteRequest = () =>
+const createDeleteRequest = (sessionId = "test-session") =>
   new Request("http://localhost/mcp", {
-    headers: { "mcp-session-id": "test-session" },
+    headers: { "mcp-session-id": sessionId },
     method: "DELETE",
   });
 
@@ -267,6 +267,127 @@ describe("WebStreamableHTTPServerTransport", () => {
     expect(transport.sessionId).toBe("first-session");
     expect(sessionIdGenerator).toHaveBeenCalledTimes(1);
     expect(onsessioninitialized).toHaveBeenCalledTimes(1);
+  });
+
+  it("never echoes the active session id on a rejected request", async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: () => "secret-session",
+    });
+    await createServer().connect(transport);
+    const initialized = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    await initialized.json();
+    expect(initialized.headers.get("mcp-session-id")).toBe("secret-session");
+
+    // Every path that turns an unusable session id away. Each one is reachable
+    // by a caller holding nothing but a guess, so none of them may answer with
+    // the real id.
+    const rejected = [
+      await transport.handleRequest(
+        createPostRequest(
+          { jsonrpc: "2.0", method: "notifications/initialized" },
+          "application/json",
+          "guessed-session",
+        ),
+      ),
+      await transport.handleRequest(
+        createGetRequest(undefined, "guessed-session"),
+      ),
+      await transport.handleRequest(createDeleteRequest("guessed-session")),
+      await transport.handleRequest(
+        createInitializeRequest("application/json", "guessed-session"),
+      ),
+      await transport.handleRequest(
+        createInitializeRequest("application/json"),
+      ),
+    ];
+
+    for (const response of rejected) {
+      expect(response.ok).toBe(false);
+      expect(response.headers.get("mcp-session-id")).toBeNull();
+    }
+
+    // The rejections left the session itself untouched.
+    expect(transport.sessionId).toBe("secret-session");
+  });
+
+  it("stops resolving its session once closed", async () => {
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: () => "test-session",
+    });
+    let sessionIdSeenByOnclose: string | undefined;
+    transport.onclose = () => {
+      sessionIdSeenByOnclose = transport.sessionId;
+    };
+    await createServer().connect(transport);
+    await (
+      await transport.handleRequest(createInitializeRequest("application/json"))
+    ).json();
+
+    await transport.close();
+
+    // `onclose` is the only close notification this path emits, so it has to
+    // still be able to say which session it was for.
+    expect(sessionIdSeenByOnclose).toBe("test-session");
+    expect(transport.sessionId).toBeUndefined();
+
+    const afterClose = await transport.handleRequest(createGetRequest());
+    expect(afterClose.status).toBe(404);
+    const internals = transport as unknown as TransportInternals;
+    expect(internals._streamMapping.size).toBe(0);
+    expect(internals._standaloneStreamOpened).toBe(false);
+  });
+
+  it("refuses to attach a stream while close is tearing down", async () => {
+    let releaseStreamClose: (() => void) | undefined;
+    let markStreamCloseStarted: (() => void) | undefined;
+    const streamCloseStarted = new Promise<void>((resolve) => {
+      markStreamCloseStarted = resolve;
+    });
+    const streamCloseGate = new Promise<void>((resolve) => {
+      releaseStreamClose = resolve;
+    });
+
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      sessionIdGenerator: () => "test-session",
+    });
+    await createServer().connect(transport);
+    await (
+      await transport.handleRequest(createInitializeRequest("application/json"))
+    ).json();
+
+    const internals = transport as unknown as TransportInternals;
+    internals._streamMapping.set("old-stream", {
+      close: vi.fn(async () => {
+        markStreamCloseStarted?.();
+        await streamCloseGate;
+      }),
+    } as unknown as WritableStreamDefaultWriter<Uint8Array>);
+
+    const closing = transport.close();
+    await streamCloseStarted;
+
+    // `sessionId` still reads as set for `onclose`, so the guard — not the id —
+    // is what has to turn these away.
+    expect(transport.sessionId).toBe("test-session");
+    const duringClose = await transport.handleRequest(createGetRequest());
+    expect(duringClose.status).toBe(404);
+    const initializeDuringClose = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    expect(initializeDuringClose.status).toBe(400);
+
+    releaseStreamClose?.();
+    await closing;
+
+    // Nothing attached during the window, so teardown left nothing behind.
+    expect(internals._streamMapping.size).toBe(0);
+    expect(internals._standaloneStreamOpened).toBe(false);
+    expect(transport.sessionId).toBeUndefined();
   });
 
   it("should release the standalone SSE stream when the client cancels", async () => {

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -132,6 +132,19 @@ export class WebStreamableHTTPServerTransport implements Transport {
   >();
   private sessionIdGenerator: (() => string) | undefined;
 
+  /**
+   * The session id an incoming request may be matched against.
+   *
+   * A session that is tearing down is already gone as far as routing is
+   * concerned, even while `sessionId` still reads as set for the benefit of an
+   * `onclose` handler. Attaching to it during that window opens a stream that
+   * teardown has already stopped accounting for, leaving it with nothing to
+   * write to it and nobody to close it.
+   */
+  private get activeSessionId(): string | undefined {
+    return this._sessionClosing ? undefined : this.sessionId;
+  }
+
   constructor(options: WebStreamableHTTPServerTransportOptions) {
     this.sessionIdGenerator = options.sessionIdGenerator;
     this._enableJsonResponse = options.enableJsonResponse ?? false;
@@ -144,9 +157,19 @@ export class WebStreamableHTTPServerTransport implements Transport {
    * Close the transport
    */
   async close(): Promise<void> {
-    await this.teardownStreams();
+    // The DELETE path invalidates by clearing `sessionId` outright; `close()`
+    // cannot, because it carries no `onsessionclosed` and reading the id in
+    // `onclose` is the only way a handler can tell which session ended. Flag
+    // the teardown instead and clear the id once `onclose` has had it.
+    this._sessionClosing = true;
+    try {
+      await this.teardownStreams();
+    } finally {
+      this._sessionClosing = false;
+    }
     this._started = false;
     this.onclose?.();
+    this.sessionId = undefined;
   }
 
   /**
@@ -279,13 +302,19 @@ export class WebStreamableHTTPServerTransport implements Transport {
   }
 
   /**
-   * Create an error response
+   * Create an error response.
+   *
+   * Never carries `mcp-session-id`. A caller that reaches an error either
+   * already knows the id it sent or has no claim to one, and the paths that
+   * reject an unusable id — `Session not found`, and initialization against a
+   * live or closing session — are exactly the ones someone probing for the
+   * active id would use, so echoing it there hands over the only value that
+   * identifies the session.
    */
   private createErrorResponse(
     status: number,
     code: number,
     message: string,
-    includeSessionId = true,
   ): Response {
     return new Response(
       JSON.stringify({
@@ -294,10 +323,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
         jsonrpc: "2.0",
       }),
       {
-        headers: {
-          ...(includeSessionId ? this.getResponseHeaders() : {}),
-          "Content-Type": "application/json",
-        },
+        headers: { "Content-Type": "application/json" },
         status,
       },
     );
@@ -329,7 +355,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
         );
       }
 
-      if (this.sessionId !== sessionId) {
+      if (this.activeSessionId !== sessionId) {
         return this.createErrorResponse(404, -32001, "Session not found");
       }
     }
@@ -373,7 +399,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
       );
     }
 
-    if (this.sessionIdGenerator && this.sessionId !== sessionId) {
+    if (this.sessionIdGenerator && this.activeSessionId !== sessionId) {
       return this.createErrorResponse(404, -32001, "Session not found");
     }
 
@@ -516,7 +542,17 @@ export class WebStreamableHTTPServerTransport implements Transport {
         400,
         -32600,
         "Invalid Request: Initialization requests must not include a sessionId",
-        false,
+      );
+    }
+
+    // Ordered before the "already initialized" guard: `close()` leaves
+    // `sessionId` set until `onclose` has read it, so a teardown in progress
+    // satisfies both, and "is closing" is the one that describes it.
+    if (hasInitRequest && this.sessionIdGenerator && this._sessionClosing) {
+      return this.createErrorResponse(
+        400,
+        -32600,
+        "Invalid Request: Session is closing",
       );
     }
 
@@ -529,15 +565,6 @@ export class WebStreamableHTTPServerTransport implements Transport {
         400,
         -32600,
         "Invalid Request: Server already initialized",
-        false,
-      );
-    }
-
-    if (hasInitRequest && this.sessionIdGenerator && this._sessionClosing) {
-      return this.createErrorResponse(
-        400,
-        -32600,
-        "Invalid Request: Session is closing",
       );
     }
 
@@ -562,7 +589,10 @@ export class WebStreamableHTTPServerTransport implements Transport {
       this.sessionId = this.sessionIdGenerator();
       await this._onsessioninitialized?.(this.sessionId);
     } else if (requestSessionId) {
-      if (this.sessionIdGenerator && this.sessionId !== requestSessionId) {
+      if (
+        this.sessionIdGenerator &&
+        this.activeSessionId !== requestSessionId
+      ) {
         return this.createErrorResponse(404, -32001, "Session not found");
       }
     }
@@ -962,18 +992,25 @@ export class WebStreamableHTTPServerTransport implements Transport {
    */
   private async teardownStreams(): Promise<void> {
     this._streamGeneration += 1;
-    for (const writer of this._streamMapping.values()) {
-      try {
-        await writer.close();
-      } catch {
-        // Ignore close errors
-      }
-    }
+    // Snapshot and reset before awaiting anything. `writer.close()` yields, so
+    // a stream registered during that window would otherwise be wiped by a
+    // clear() belonging to the session that preceded it — routed to but never
+    // closed, or closed out from under the client that just opened it,
+    // depending on where in the loop it landed.
+    const writers = [...this._streamMapping.values()];
     this._streamMapping.clear();
     // Per-session, like the session id: this instance stays usable, and the
     // next session starts having opened no standalone stream of its own.
     this._standaloneStreamOpened = false;
     this.releasePendingRequests();
+
+    for (const writer of writers) {
+      try {
+        await writer.close();
+      } catch {
+        // Already closed, errored, or cancelled by the client.
+      }
+    }
   }
 
   private trackStream(


### PR DESCRIPTION
Follow-up to #339 and #340, closing two gaps that surfaced while reviewing them.

## 1. Rejected requests still echoed the active session id

#339 stopped the two `initialize` rejections from returning `mcp-session-id`, but the three `Session not found` paths kept doing it. Against a transport with an active session, a caller holding nothing but a guess got the real id back:

```
POST (non-init) mcp-session-id: guessed  -> 404, mcp-session-id: secret-session
GET             mcp-session-id: guessed  -> 404, mcp-session-id: secret-session
DELETE          mcp-session-id: guessed  -> 404, mcp-session-id: secret-session
```

Those are precisely the paths someone probing for the id would use, so the disclosure was worse there than on the path #339 fixed.

`createErrorResponse` now never attaches the header, which also drops the `includeSessionId` positional boolean #339 had to thread through. This matches the upstream SDK, whose error responses carry no session header either.

## 2. `close()` left the session resolvable

`close()` is the other teardown path and it did not invalidate anything. After it returned, the transport still matched its old session id, so a GET passed validation and opened a fresh standalone stream on a dead transport — nothing left to write to it, nobody left to close it:

```
after close(): sessionId = test-session
GET after close: status = 200, streamMapping size = 1, standaloneStreamOpened = true
```

`close()` cannot simply clear `sessionId` the way the DELETE path does: it carries no `onsessionclosed`, so reading the id in `onclose` is the only way a handler can tell which session ended. It now sets the `_sessionClosing` flag #340 introduced, and clears the id once `onclose` has had it. Session matching goes through a new `activeSessionId` getter that reads as `undefined` while closing, so GET, POST and DELETE all fail closed during the window.

The `initialize` guards are reordered so `Session is closing` wins over `Server already initialized`, since a `close()` in progress now satisfies both and the former is the one that describes it.

## 3. `teardownStreams` mutated its state after awaiting

`writer.close()` yields, and the `clear()` / flag reset / `releasePendingRequests()` all ran after the loop. A stream registered during that window was wiped by the preceding session's teardown. It now snapshots the writers and resets synchronously, then awaits the closes — the alternative design raised in the #340 review, which removes the race rather than only guarding against it. Safe to reorder: the deferred `writer.closed` cleanup only touches the two maps teardown clears anyway.

## Tests

Three regression tests, each verified red against `main` before the fix:

- `never echoes the active session id on a rejected request` — all five rejection paths
- `stops resolving its session once closed` — plus `onclose` can still read the id
- `refuses to attach a stream while close is tearing down` — gated writer holds teardown open

`pnpm test`: 51 files, 609 tests. `pnpm lint`: prettier, eslint, tsc, jsr dry-run all clean.