### PR TITLE
fix: preserve non-canonical numeric JSON Pointer paths

### DIFF
--- a/src/jsonSchemaAdapter.test.ts
+++ b/src/jsonSchemaAdapter.test.ts
@@ -75,6 +75,25 @@ test("reports paths into nested objects and arrays", async () => {
   ]);
 });
 
+test("preserves non-canonical numeric object keys in issue paths", async () => {
+  const numericObjectKeys = ["01", "-1", "1.0", "9007199254740993"];
+  const schema = jsonSchemaAdapter({
+    properties: Object.fromEntries(
+      numericObjectKeys.map((key) => [key, { type: "number" }]),
+    ),
+    required: numericObjectKeys,
+    type: "object",
+  });
+
+  const result = await schema["~standard"].validate(
+    Object.fromEntries(numericObjectKeys.map((key) => [key, "not a number"])),
+  );
+
+  expect(result.issues?.map((issue) => issue.path)).toEqual(
+    numericObjectKeys.map((key) => [key]),
+  );
+});
+
 test("validates nested objects", async () => {
   const schema = jsonSchemaAdapter({
     properties: {

--- a/src/jsonSchemaAdapter.ts
+++ b/src/jsonSchemaAdapter.ts
@@ -165,7 +165,9 @@ function toIssue(error: AjvErrorObject): StandardSchemaV1.Issue {
     .map((segment) => segment.replaceAll("~1", "/").replaceAll("~0", "~"))
     .map((segment): number | string => {
       const index = Number(segment);
-      return Number.isInteger(index) && segment !== "" ? index : segment;
+      return /^(?:0|[1-9]\d*)$/.test(segment) && Number.isSafeInteger(index)
+        ? index
+        : segment;
     });
 
   // AJV reports a missing property against its parent object, with the name in


### PR DESCRIPTION
## Summary

- preserve leading-zero and other non-canonical numeric JSON Pointer tokens as string property keys
- keep canonical non-negative array indexes numeric
- avoid unsafe integer coercion that loses lexical identity

## Tests

- added end-to-end AJV regressions for leading-zero, negative, decimal, and unsafe-integer keys
- pnpm lint
- pnpm test (610 passed)

This keeps validation issue paths faithful to the original object keys while preserving existing array-index behavior.