### PR TITLE
fix: prevent cleared discovery fetches from recaching

### DIFF
--- a/src/DiscoveryDocumentCache.test.ts
+++ b/src/DiscoveryDocumentCache.test.ts
@@ -146,6 +146,98 @@ test("clears all cached documents", async () => {
   fetchSpy.mockRestore();
 });
 
+test("clear(url) prevents an in-flight fetch from repopulating the cache", async () => {
+  const cache = new DiscoveryDocumentCache();
+  const testUrl = "https://auth.example.com/.well-known/openid-configuration";
+  const staleDocument = { issuer: "https://stale.example.com" };
+  const freshDocument = { issuer: "https://fresh.example.com" };
+  let resolveFirstFetch!: (response: Response) => void;
+  let resolveSecondFetch!: (response: Response) => void;
+  const firstFetch = new Promise<Response>((resolve) => {
+    resolveFirstFetch = resolve;
+  });
+  const secondFetch = new Promise<Response>((resolve) => {
+    resolveSecondFetch = resolve;
+  });
+  const fetchSpy = vi
+    .spyOn(global, "fetch")
+    .mockReturnValueOnce(firstFetch)
+    .mockReturnValueOnce(secondFetch);
+
+  const staleRequest = cache.get(testUrl);
+
+  cache.clear(testUrl);
+  const freshRequest = cache.get(testUrl);
+  resolveFirstFetch({
+    json: async () => staleDocument,
+    ok: true,
+  } as Response);
+
+  await expect(staleRequest).resolves.toEqual(staleDocument);
+  const coalescedRequest = cache.get(testUrl);
+
+  expect(fetchSpy).toHaveBeenCalledTimes(2);
+  resolveSecondFetch({
+    json: async () => freshDocument,
+    ok: true,
+  } as Response);
+  await expect(freshRequest).resolves.toEqual(freshDocument);
+  await expect(coalescedRequest).resolves.toEqual(freshDocument);
+  expect(await cache.get(testUrl)).toEqual(freshDocument);
+  expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+  fetchSpy.mockRestore();
+});
+
+test("clear() prevents in-flight fetches from repopulating the cache", async () => {
+  const cache = new DiscoveryDocumentCache();
+  const url1 = "https://auth1.example.com/.well-known/openid-configuration";
+  const url2 = "https://auth2.example.com/.well-known/openid-configuration";
+  const resolvers = new Map<string, Array<(response: Response) => void>>();
+  const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(
+    (input) =>
+      new Promise<Response>((resolve) => {
+        const url = String(input);
+        resolvers.set(url, [...(resolvers.get(url) ?? []), resolve]);
+      }),
+  );
+
+  const staleRequest1 = cache.get(url1);
+  const staleRequest2 = cache.get(url2);
+
+  cache.clear();
+  const freshRequest1 = cache.get(url1);
+  const freshRequest2 = cache.get(url2);
+  resolvers.get(url1)?.[0]?.({
+    json: async () => ({ issuer: "https://auth1.example.com" }),
+    ok: true,
+  } as Response);
+  resolvers.get(url2)?.[0]?.({
+    json: async () => ({ issuer: "https://auth2.example.com" }),
+    ok: true,
+  } as Response);
+  resolvers.get(url1)?.[1]?.({
+    json: async () => ({ issuer: "https://fresh-auth1.example.com" }),
+    ok: true,
+  } as Response);
+  resolvers.get(url2)?.[1]?.({
+    json: async () => ({ issuer: "https://fresh-auth2.example.com" }),
+    ok: true,
+  } as Response);
+
+  await Promise.all([staleRequest1, staleRequest2]);
+  await expect(freshRequest1).resolves.toEqual({
+    issuer: "https://fresh-auth1.example.com",
+  });
+  await expect(freshRequest2).resolves.toEqual({
+    issuer: "https://fresh-auth2.example.com",
+  });
+  expect(fetchSpy).toHaveBeenCalledTimes(4);
+  expect(cache.size).toBe(2);
+
+  fetchSpy.mockRestore();
+});
+
 test("has() returns false for expired entries", async () => {
   const cache = new DiscoveryDocumentCache({ ttl: 100 }); // 100ms TTL
   const testUrl = "https://auth.example.com/.well-known/openid-configuration";

--- a/src/DiscoveryDocumentCache.ts
+++ b/src/DiscoveryDocumentCache.ts
@@ -13,11 +13,15 @@ export class DiscoveryDocumentCache {
     }
   > = new Map();
 
+  #generation = 0;
+
   #inFlight: Map<string, Promise<unknown>> = new Map();
 
   #timeoutMs: number;
 
   #ttl: number;
+
+  #urlGenerations: Map<string, number> = new Map();
 
   /**
    * @param options - configuration options
@@ -35,8 +39,13 @@ export class DiscoveryDocumentCache {
   public clear(url?: string): void {
     if (url) {
       this.#cache.delete(url);
+      this.#inFlight.delete(url);
+      this.#urlGenerations.set(url, (this.#urlGenerations.get(url) ?? 0) + 1);
     } else {
       this.#cache.clear();
+      this.#inFlight.clear();
+      this.#urlGenerations.clear();
+      this.#generation++;
     }
   }
 
@@ -66,7 +75,11 @@ export class DiscoveryDocumentCache {
     }
 
     // create a new fetch promise and store it
-    const fetchPromise = this.#fetchAndCache(url);
+    const fetchPromise = this.#fetchAndCache(
+      url,
+      this.#generation,
+      this.#urlGenerations.get(url) ?? 0,
+    );
 
     this.#inFlight.set(url, fetchPromise);
 
@@ -76,7 +89,9 @@ export class DiscoveryDocumentCache {
     } finally {
       // clean up in-flight promise after completion
       // (success or failure)
-      this.#inFlight.delete(url);
+      if (this.#inFlight.get(url) === fetchPromise) {
+        this.#inFlight.delete(url);
+      }
     }
   }
 
@@ -102,7 +117,11 @@ export class DiscoveryDocumentCache {
     return true;
   }
 
-  async #fetchAndCache(url: string): Promise<unknown> {
+  async #fetchAndCache(
+    url: string,
+    generation: number,
+    urlGeneration: number,
+  ): Promise<unknown> {
     // fetch fresh document, bounded by the configured timeout
     let res: Response;
     try {
@@ -132,11 +151,16 @@ export class DiscoveryDocumentCache {
     // calculate expiration time AFTER fetch completes
     const expiresAt = Date.now() + this.#ttl;
 
-    // store in cache with expiration
-    this.#cache.set(url, {
-      data,
-      expiresAt,
-    });
+    // A clear that occurred while the fetch was pending invalidates its result.
+    if (
+      this.#generation === generation &&
+      (this.#urlGenerations.get(url) ?? 0) === urlGeneration
+    ) {
+      this.#cache.set(url, {
+        data,
+        expiresAt,
+      });
+    }
 
     return data;
   }


### PR DESCRIPTION
Summary:
- invalidate pending discovery fetch results when a URL or the whole cache is cleared
- let post-clear callers start a fresh fetch without aborting existing callers
- preserve coalescing when an older fetch settles after the replacement fetch starts

Verification:
- pnpm vitest run src/DiscoveryDocumentCache.test.ts (17/17)
- pnpm test (611/611)
- pnpm lint (Prettier, ESLint, TypeScript, JSR dry-run)

The regression tests use deferred fetches for both clear(url) and clear() and cover the old-finally/new-inflight interleaving.