### PR TITLE
fix: complete all enum values when the prompt argument value is empty

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -6037,3 +6037,43 @@ test("exports SessionError and FastMCPError from the package root", () => {
   // so the base class can serve as a catch-all for all fastmcp errors.
   expect(new UserError("u")).toBeInstanceOf(FastMCPError);
 });
+
+test("offers all enum values when the completion value is empty", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const response = await client.complete({
+        argument: {
+          name: "name",
+          value: "",
+        },
+        ref: {
+          name: "countryPoem",
+          type: "ref/prompt",
+        },
+      });
+
+      expect(response.completion.values).toEqual([
+        "Germany",
+        "France",
+        "Italy",
+      ]);
+    },
+    server: async () => {
+      const server = new FastMCP({ name: "Test", version: "1.0.0" });
+      server.addPrompt({
+        arguments: [
+          {
+            description: "Name of the country",
+            enum: ["Germany", "France", "Italy"],
+            name: "name",
+            required: true,
+          },
+        ],
+        description: "Writes a poem about a country",
+        load: async ({ name }) => `Hello, ${name}!`,
+        name: "countryPoem",
+      });
+      return server;
+    },
+  });
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2053,6 +2053,19 @@ export class FastMCPSession<
         }
 
         if (fuseInstances[name]) {
+          // An empty query yields no fuzzy matches, so a client asking for
+          // completions before the user has typed anything would see nothing.
+          // Offer the full enum instead — it is the set of valid values, and
+          // the central cap trims it to the MCP limit if it is large.
+          if (value === "") {
+            const values = enums[name];
+
+            return {
+              total: values.length,
+              values,
+            };
+          }
+
           const result = fuseInstances[name].search(value);
 
           return {


### PR DESCRIPTION
### Summary

When a prompt argument declares `enum`, FastMCP auto-completes it with a fuzzy `Fuse` index. `Fuse.search("")` returns zero matches, so when a client requests completions with an **empty value** — the standard way editors surface the valid values before the user has typed anything — the response is an empty list, even though the server declared the full valid set.

### Change

In the `addPrompt` completion handler, when the requested value is `""`, return the full `enums[name]` list. The existing central `capCompletionValues` still trims to the MCP 100-item cap and sets `hasMore`, so large enums stay spec-compliant. Non-empty values keep the existing fuzzy path unchanged.

### Test

Adds `"offers all enum values when the completion value is empty"` to `src/FastMCP.test.ts` (RED before the change, GREEN after); the existing non-empty enum test still passes. Full suite green (`pnpm test`), `tsc`/`eslint`/`prettier` clean.
