### PR TITLE
fix(auth): reject userinfo in redirect URIs (loopback-default open-redirect bypass)

### DIFF
--- a/src/auth/OAuthProxy.open-redirect.test.ts
+++ b/src/auth/OAuthProxy.open-redirect.test.ts
@@ -447,5 +447,30 @@ describe("OAuthProxy CWE-601 open-redirect regression", () => {
       ).resolves.toBeDefined();
       loose.destroy();
     });
+
+    it("rejects a redirect URI that smuggles a foreign host via userinfo under the default", async () => {
+      // `http://localhost:80@evil.com/cb` matches the loopback-only default
+      // pattern `http://localhost:*`, but its real host (per `new URL`) is
+      // `evil.com`, so accepting it would 302 the authorization code offsite.
+      const defaultProxy = new OAuthProxy({
+        ...baseConfig,
+        allowedRedirectUriPatterns: undefined,
+      });
+
+      await expect(
+        defaultProxy.registerClient({
+          redirect_uris: ["http://localhost:80@evil.com/cb"],
+        }),
+      ).rejects.toMatchObject({ code: "invalid_redirect_uri" });
+
+      // A genuine loopback URI (no userinfo) is still accepted.
+      await expect(
+        defaultProxy.registerClient({
+          redirect_uris: ["http://localhost:54321/callback"],
+        }),
+      ).resolves.toBeDefined();
+
+      defaultProxy.destroy();
+    });
   });
 });

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -1566,9 +1566,23 @@ export class OAuthProxy {
    * theft. Do not loosen the default beyond loopback addresses.
    */
   private validateRedirectUri(uri: string): boolean {
+    let parsed: URL;
+
     try {
-      new URL(uri); // syntactic check only — throws on malformed input
+      parsed = new URL(uri); // syntactic check — throws on malformed input
     } catch {
+      return false;
+    }
+
+    // Reject any userinfo (`user:pass@`) in the redirect URI. Patterns are
+    // matched against the raw URI string, but the callback is later resolved
+    // with `new URL(...)`, whose authority is the part after the last `@`.
+    // A URI such as `http://localhost:80@evil.com/cb` therefore matches the
+    // loopback-only default pattern `http://localhost:*` yet redirects the
+    // authorization code to `evil.com`. A legitimate redirect URI never
+    // carries credentials, so dropping them here closes that bypass without
+    // affecting the port/path wildcards the patterns rely on.
+    if (parsed.username !== "" || parsed.password !== "") {
       return false;
     }
 


### PR DESCRIPTION
### Summary (security hardening)

`OAuthProxy.validateRedirectUri` matches the **raw** redirect-URI string against the allow-list glob patterns, but the authorization code is later delivered by resolving `new URL(clientCallbackUrl)`, whose host is the part **after the last `@`**. So `http://localhost:80@evil.com/cb`:

- matches the loopback-only **default** pattern `http://localhost:*` (regex `^http://localhost:.*$`),
- passes DCR registration and the `authorize()` registered-URI check,
- and `handleCallback()` then 302s the fresh code+state to `evil.com` — defeating the loopback-only guarantee the default is documented to provide.

Verified: `matchesPattern("http://localhost:80@evil.com/cb", "http://localhost:*")` → `true`, while `new URL("http://localhost:80@evil.com/cb").host` → `evil.com`.

### Why this fix

The default's legitimate semantics require the `*` glob to cross `/` (`http://localhost:*` must match `http://localhost:54321/callback`), so the wildcard can't be narrowed without breaking the loopback default. The clean, non-breaking fix is to **reject any redirect URI carrying userinfo** (`username`/`password`) right after the syntactic `new URL` check — a legitimate redirect URI never carries credentials. This closes the default-guarantee bypass without touching the port/path wildcards.

### Test

Adds a regression test to `OAuthProxy.open-redirect.test.ts` asserting the userinfo form is rejected under the default while a genuine loopback URI is still accepted (RED before, GREEN after). All 23 auth suites pass; `tsc`/`eslint`/`prettier` clean.

This is in the same spirit as recent redirect-URI hardening here (escaping regex metacharacters in patterns, DiskStore permissions). Happy to coordinate on disclosure if you'd prefer.
