### PR TITLE
feat(oauth): add Client ID Metadata Document (CIMD) support to OAuthProxy

### DIFF
--- a/docs/oauth-proxy-guide.md
+++ b/docs/oauth-proxy-guide.md
@@ -267,6 +267,7 @@ interface OAuthProxyConfig {
   consentRequired?: boolean; // default: true
   consentSigningKey?: string; // auto-generated if not provided
   allowedRedirectUriPatterns?: string[];
+  enableCimd?: boolean; // default: false — accept Client ID Metadata Documents
   extraAuthorizationParams?: Record<string, string>; // provider-specific params
   transactionTtl?: number; // seconds, default: 600
   authorizationCodeTtl?: number; // seconds, default: 300
@@ -319,6 +320,40 @@ const authProxy = new OAuthProxy({
   ],
 });
 ```
+
+### Client ID Metadata Documents (CIMD)
+
+Some MCP clients — VS Code among them — identify themselves with an HTTPS URL
+instead of registering through DCR, and do not fall back to `POST
+/oauth/register`. Set `enableCimd: true` to accept them:
+
+```typescript
+const authProxy = new OAuthProxy({
+  // ... other config
+  enableCimd: true,
+});
+```
+
+An unregistered `client_id` that is an HTTPS URL is then fetched as a [Client
+ID Metadata Document](https://modelcontextprotocol.io/specification/draft/basic/authorization)
+(SEP-991) and accepted only if it:
+
+- self-identifies with the exact URL it was fetched from,
+- lists the `redirect_uri` being requested, and
+- lists only redirect URIs that pass `allowedRedirectUriPatterns` — CIMD does
+  not widen the allow-list.
+
+Documents are fetched over HTTPS with no redirects followed, a 5s timeout and a
+64 KB cap, and hosts that are literal loopback or private-range addresses are
+refused (a layer against SSRF, though not a defence against DNS rebinding —
+keep the proxy's egress restricted if that matters to you). A resolved document
+is cached for 15 minutes and then re-read, so a client that rotates its
+redirect URIs is picked up without a restart.
+
+When enabled, `/.well-known/oauth-authorization-server` advertises
+`client_id_metadata_document_supported: true`.
+
+Off by default: leaving it off means only DCR-registered clients are accepted.
 
 ### TTL Configuration
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -868,6 +868,8 @@ type ServerOptions<T extends FastMCPSessionAuth> = {
      */
     authorizationServer?: {
       authorizationEndpoint: string;
+      // Client ID Metadata Documents (SEP-991) accepted in place of DCR
+      clientIdMetadataDocumentSupported?: boolean;
       codeChallengeMethodsSupported?: string[];
       // DPoP support
       dpopSigningAlgValuesSupported?: string[];

--- a/src/auth/OAuthProxy.cimd.test.ts
+++ b/src/auth/OAuthProxy.cimd.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Client ID Metadata Document (CIMD) support in OAuthProxy.
+ *
+ * CIMD (MCP authorization spec SEP-991) lets a client identify itself with
+ * an HTTPS URL instead of calling POST /oauth/register. These tests cover
+ * the feature end-to-end through authorize() and exchangeAuthorizationCode(),
+ * that it is off unless explicitly enabled, and that it does not weaken the
+ * existing redirect-URI allow-list.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthorizationParams, UpstreamTokenSet } from "./types.js";
+
+import { OAuthProxy, OAuthProxyError } from "./OAuthProxy.js";
+
+const CLIENT_METADATA_URL = "https://client.example.com/client-metadata.json";
+const REDIRECT_URI = "http://127.0.0.1:33418/";
+
+const baseConfig = {
+  allowedRedirectUriPatterns: ["http://127.0.0.1:*"],
+  baseUrl: "http://localhost:4200",
+  consentRequired: false,
+  // Pass-through mode, so the token-exchange assertions below can check the
+  // mocked upstream token directly — token swap itself is covered by
+  // OAuthProxy.token-swap.test.ts and is orthogonal to CIMD identity resolution.
+  enableTokenSwap: false,
+  encryptionKey: false as const,
+  redirectPath: "/oauth/callback",
+  upstreamAuthorizationEndpoint: "https://provider.com/oauth/authorize",
+  upstreamClientId: "legit-upstream-id",
+  upstreamClientSecret: "legit-upstream-secret",
+  upstreamTokenEndpoint: "https://provider.com/oauth/token",
+};
+
+function buildAuthParams(
+  overrides: Partial<AuthorizationParams> = {},
+): AuthorizationParams {
+  return {
+    client_id: CLIENT_METADATA_URL,
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    state: "test-state",
+    ...overrides,
+  } as AuthorizationParams;
+}
+
+function clientMetadataResponse(
+  overrides: Record<string, unknown> = {},
+): Response {
+  return new Response(
+    JSON.stringify({
+      client_id: CLIENT_METADATA_URL,
+      client_name: "Example MCP Client",
+      redirect_uris: [REDIRECT_URI],
+      ...overrides,
+    }),
+    { headers: { "Content-Type": "application/json" }, status: 200 },
+  );
+}
+
+/**
+ * Routes the client-metadata URL to one handler and everything else (the
+ * upstream token endpoint) to another, so a single mock can drive a full
+ * authorize -> callback -> token flow.
+ */
+function mockFetchRouting(clientMetadataHandler: () => Response) {
+  const fetchMock = vi.fn(async (input: Request | string | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url === CLIENT_METADATA_URL) {
+      return clientMetadataHandler();
+    }
+    return upstreamTokenResponse();
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function upstreamTokenResponse(): Response {
+  const upstream: UpstreamTokenSet = {
+    accessToken: "UP_ACCESS_TOKEN",
+    expiresIn: 3600,
+    issuedAt: new Date(),
+    scope: ["read"],
+    tokenType: "Bearer",
+  };
+  return new Response(
+    JSON.stringify({
+      access_token: upstream.accessToken,
+      expires_in: upstream.expiresIn,
+      scope: upstream.scope.join(" "),
+      token_type: upstream.tokenType,
+    }),
+    { headers: { "Content-Type": "application/json" }, status: 200 },
+  );
+}
+
+describe("OAuthProxy CIMD support", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("is off by default: a CIMD-shaped client_id is still an unknown client", async () => {
+    const proxy = new OAuthProxy(baseConfig);
+    mockFetchRouting(clientMetadataResponse);
+
+    await expect(proxy.authorize(buildAuthParams())).rejects.toMatchObject({
+      code: "invalid_client",
+    });
+
+    proxy.destroy();
+  });
+
+  it("does not advertise client_id_metadata_document_supported when disabled", () => {
+    const proxy = new OAuthProxy(baseConfig);
+    expect(
+      proxy.getAuthorizationServerMetadata().clientIdMetadataDocumentSupported,
+    ).toBeUndefined();
+    proxy.destroy();
+  });
+
+  it("advertises client_id_metadata_document_supported when enabled", () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    expect(
+      proxy.getAuthorizationServerMetadata().clientIdMetadataDocumentSupported,
+    ).toBe(true);
+    proxy.destroy();
+  });
+
+  it("resolves a valid CIMD client_id and completes the full authorize -> callback -> token flow", async () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    mockFetchRouting(clientMetadataResponse);
+
+    const authResp = await proxy.authorize(buildAuthParams());
+    expect(authResp.status).toBe(302);
+
+    const upstreamUrl = new URL(authResp.headers.get("Location")!);
+    const transactionId = upstreamUrl.searchParams.get("state")!;
+
+    const cbReq = new Request(
+      `${baseConfig.baseUrl}${baseConfig.redirectPath}?code=UP_CODE&state=${encodeURIComponent(transactionId)}`,
+    );
+    const cbResp = await proxy.handleCallback(cbReq);
+    expect(cbResp.status).toBe(302);
+
+    const finalLocation = new URL(cbResp.headers.get("Location")!);
+    expect(finalLocation.origin + finalLocation.pathname).toBe(REDIRECT_URI);
+    const code = finalLocation.searchParams.get("code")!;
+    expect(code).toBeTruthy();
+
+    const tokenResp = await proxy.exchangeAuthorizationCode({
+      client_id: CLIENT_METADATA_URL,
+      code,
+      grant_type: "authorization_code",
+      redirect_uri: REDIRECT_URI,
+    });
+    expect(tokenResp.access_token).toBe("UP_ACCESS_TOKEN");
+
+    proxy.destroy();
+  });
+
+  it("caches the resolved client: the metadata document is fetched only once across authorize + token exchange", async () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    const fetchMock = mockFetchRouting(clientMetadataResponse);
+
+    const authResp = await proxy.authorize(buildAuthParams());
+    const upstreamUrl = new URL(authResp.headers.get("Location")!);
+    const transactionId = upstreamUrl.searchParams.get("state")!;
+
+    const cbReq = new Request(
+      `${baseConfig.baseUrl}${baseConfig.redirectPath}?code=UP_CODE&state=${encodeURIComponent(transactionId)}`,
+    );
+    const cbResp = await proxy.handleCallback(cbReq);
+    const finalLocation = new URL(cbResp.headers.get("Location")!);
+    const code = finalLocation.searchParams.get("code")!;
+
+    await proxy.exchangeAuthorizationCode({
+      client_id: CLIENT_METADATA_URL,
+      code,
+      grant_type: "authorization_code",
+      redirect_uri: REDIRECT_URI,
+    });
+
+    const clientMetadataFetches = fetchMock.mock.calls.filter(
+      ([input]) =>
+        (typeof input === "string" ? input : input.toString()) ===
+        CLIENT_METADATA_URL,
+    );
+    expect(clientMetadataFetches).toHaveLength(1);
+
+    proxy.destroy();
+  });
+
+  it("rejects a CIMD document whose redirect_uris fall outside allowedRedirectUriPatterns", async () => {
+    const proxy = new OAuthProxy({
+      ...baseConfig,
+      allowedRedirectUriPatterns: ["https://only-this-host.example.com/*"],
+      enableCimd: true,
+    });
+    mockFetchRouting(clientMetadataResponse);
+
+    await expect(proxy.authorize(buildAuthParams())).rejects.toMatchObject({
+      code: "invalid_client",
+    });
+
+    proxy.destroy();
+  });
+
+  it("rejects a CIMD document that does not vouch for the requested redirect_uri", async () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    mockFetchRouting(() =>
+      clientMetadataResponse({ redirect_uris: ["http://127.0.0.1:9999/"] }),
+    );
+
+    await expect(proxy.authorize(buildAuthParams())).rejects.toMatchObject({
+      code: "invalid_client",
+    });
+
+    proxy.destroy();
+  });
+
+  it("rejects a non-HTTPS client_id even when CIMD is enabled", async () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    const fetchMock = mockFetchRouting(clientMetadataResponse);
+
+    await expect(
+      proxy.authorize(
+        buildAuthParams({
+          client_id: "http://client.example.com/client-metadata.json",
+        }),
+      ),
+    ).rejects.toBeInstanceOf(OAuthProxyError);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    proxy.destroy();
+  });
+
+  it("exchangeAuthorizationCode() independently rejects an unresolved CIMD client_id when disabled", async () => {
+    const proxy = new OAuthProxy(baseConfig);
+
+    await expect(
+      proxy.exchangeAuthorizationCode({
+        client_id: CLIENT_METADATA_URL,
+        code: "irrelevant",
+        grant_type: "authorization_code",
+        redirect_uri: REDIRECT_URI,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_client" });
+
+    proxy.destroy();
+  });
+});

--- a/src/auth/OAuthProxy.cimd.test.ts
+++ b/src/auth/OAuthProxy.cimd.test.ts
@@ -45,6 +45,16 @@ function buildAuthParams(
   } as AuthorizationParams;
 }
 
+function clientMetadataFetchCount(
+  fetchMock: ReturnType<typeof mockFetchRouting>,
+): number {
+  return fetchMock.mock.calls.filter(
+    ([input]) =>
+      (typeof input === "string" ? input : input.toString()) ===
+      CLIENT_METADATA_URL,
+  ).length;
+}
+
 function clientMetadataResponse(
   overrides: Record<string, unknown> = {},
 ): Response {
@@ -189,6 +199,58 @@ describe("OAuthProxy CIMD support", () => {
     expect(clientMetadataFetches).toHaveLength(1);
 
     proxy.destroy();
+  });
+
+  it("re-reads the metadata document once the cached resolution lapses", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+      const fetchMock = mockFetchRouting(clientMetadataResponse);
+
+      await proxy.authorize(buildAuthParams());
+      expect(clientMetadataFetchCount(fetchMock)).toBe(1);
+
+      // Still inside the cache window: served from the cached resolution.
+      vi.advanceTimersByTime(60_000);
+      await proxy.authorize(buildAuthParams());
+      expect(clientMetadataFetchCount(fetchMock)).toBe(1);
+
+      // Past it: the document is authoritative again, not the snapshot.
+      vi.advanceTimersByTime(15 * 60 * 1000);
+      await proxy.authorize(buildAuthParams());
+      expect(clientMetadataFetchCount(fetchMock)).toBe(2);
+
+      proxy.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops honouring a client whose document dropped the redirect URI, once the resolution lapses", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+      let currentRedirectUris = [REDIRECT_URI];
+      mockFetchRouting(() =>
+        clientMetadataResponse({ redirect_uris: currentRedirectUris }),
+      );
+
+      await expect(proxy.authorize(buildAuthParams())).resolves.toBeDefined();
+
+      // The client rotates the URI away — a revocation the proxy must observe.
+      currentRedirectUris = ["http://127.0.0.1:9999/"];
+
+      vi.advanceTimersByTime(16 * 60 * 1000);
+      await expect(proxy.authorize(buildAuthParams())).rejects.toMatchObject({
+        code: "invalid_client",
+      });
+
+      proxy.destroy();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects a CIMD document whose redirect_uris fall outside allowedRedirectUriPatterns", async () => {

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -182,10 +182,8 @@ export class OAuthProxy {
       params.client_id,
     );
 
-    // Not a DCR (or previously-resolved CIMD) client — if this deployment
-    // opted in to CIMD and client_id looks like one, resolve and cache it so
-    // it is found the ordinary way on every subsequent request, including
-    // the token exchange for this same flow.
+    // Unknown client_id: if CIMD is enabled, try resolving and caching it
+    // as one so later lookups (including token exchange) find it normally.
     if (!registeredClient && this.config.enableCimd) {
       registeredClient = await resolveCimdClient(
         params.client_id,
@@ -287,10 +285,8 @@ export class OAuthProxy {
       request.client_id,
     );
 
-    // Defence in depth: authorize() already resolves and caches a CIMD
-    // client before issuing a code for it, so this normally finds it above.
-    // Falling back here too means a cache eviction between authorize and
-    // token exchange degrades to an extra fetch rather than a hard failure.
+    // Defence in depth: authorize() already caches a resolved CIMD client,
+    // so this only matters if it was evicted between authorize and exchange.
     if (!registeredClient && this.config.enableCimd) {
       registeredClient = await resolveCimdClient(
         request.client_id,

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_TRANSACTION_TTL,
   DEFAULT_UPSTREAM_REQUEST_TIMEOUT_MS,
 } from "./types.js";
+import { resolveCimdClient } from "./utils/cimd.js";
 import { ClaimsExtractor } from "./utils/claimsExtractor.js";
 import { ConsentManager } from "./utils/consent.js";
 import { JWTIssuer } from "./utils/jwtIssuer.js";
@@ -88,6 +89,7 @@ export class OAuthProxy {
       allowPlainPkce: true,
       authorizationCodeTtl: DEFAULT_AUTHORIZATION_CODE_TTL,
       consentRequired: true,
+      enableCimd: false,
       enableTokenSwap: true, // Enabled by default for security
       redirectPath: "/oauth/callback",
       transactionTtl: DEFAULT_TRANSACTION_TTL,
@@ -176,8 +178,27 @@ export class OAuthProxy {
     // RFC 6749 §5.2 - reject unknown clients with invalid_client.
     // MCP clients receive a proxy-issued client_id during DCR (not the upstream
     // provider's credentials), so we look up by that proxy client_id.
-    const registeredClient =
-      await this.stateStore.getRegisteredClientByClientId(params.client_id);
+    let registeredClient = await this.stateStore.getRegisteredClientByClientId(
+      params.client_id,
+    );
+
+    // Not a DCR (or previously-resolved CIMD) client — if this deployment
+    // opted in to CIMD and client_id looks like one, resolve and cache it so
+    // it is found the ordinary way on every subsequent request, including
+    // the token exchange for this same flow.
+    if (!registeredClient && this.config.enableCimd) {
+      registeredClient = await resolveCimdClient(
+        params.client_id,
+        params.redirect_uri,
+        (uri) => this.validateRedirectUri(uri),
+      );
+
+      if (registeredClient) {
+        this.stateStore.cacheRegisteredClient(registeredClient);
+        await this.stateStore.saveRegisteredClient(registeredClient);
+      }
+    }
+
     if (!registeredClient) {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
     }
@@ -260,10 +281,29 @@ export class OAuthProxy {
     }
 
     // RFC 6749 §5.2 - reject unknown clients. Only proxy-issued client_ids
-    // (obtained via DCR) are accepted, so stolen codes cannot be exchanged by
-    // arbitrary callers.
-    const registeredClient =
-      await this.stateStore.getRegisteredClientByClientId(request.client_id);
+    // (obtained via DCR) and, when enabled, resolved CIMD clients are
+    // accepted, so stolen codes cannot be exchanged by arbitrary callers.
+    let registeredClient = await this.stateStore.getRegisteredClientByClientId(
+      request.client_id,
+    );
+
+    // Defence in depth: authorize() already resolves and caches a CIMD
+    // client before issuing a code for it, so this normally finds it above.
+    // Falling back here too means a cache eviction between authorize and
+    // token exchange degrades to an extra fetch rather than a hard failure.
+    if (!registeredClient && this.config.enableCimd) {
+      registeredClient = await resolveCimdClient(
+        request.client_id,
+        undefined,
+        (uri) => this.validateRedirectUri(uri),
+      );
+
+      if (registeredClient) {
+        this.stateStore.cacheRegisteredClient(registeredClient);
+        await this.stateStore.saveRegisteredClient(registeredClient);
+      }
+    }
+
     if (!registeredClient) {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
     }
@@ -389,6 +429,7 @@ export class OAuthProxy {
    */
   getAuthorizationServerMetadata(): {
     authorizationEndpoint: string;
+    clientIdMetadataDocumentSupported?: boolean;
     codeChallengeMethodsSupported?: string[];
     dpopSigningAlgValuesSupported?: string[];
     grantTypesSupported?: string[];
@@ -410,6 +451,9 @@ export class OAuthProxy {
   } {
     return {
       authorizationEndpoint: `${this.config.baseUrl}/oauth/authorize`,
+      ...(this.config.enableCimd
+        ? { clientIdMetadataDocumentSupported: true as const }
+        : {}),
       codeChallengeMethodsSupported: this.config.allowPlainPkce
         ? ["S256", "plain"]
         : ["S256"],

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -76,9 +76,13 @@ export class OAuthProxy {
   private ownedTokenStorage: MemoryTokenStorage | null = null;
   /**
    * Keyed by proxy-issued client_id for authorize/token-exchange lookups and
-   * for the defence-in-depth callback checks. A registration never changes
+   * for the defence-in-depth callback checks. A DCR registration never changes
    * after it is written, so caching it locally cannot go stale; it is also
    * persisted, so another instance can hydrate it.
+   *
+   * A CIMD client is not a registration but a snapshot of a document that can
+   * change under us, so it is cached with an `expiresAt` and re-resolved once
+   * that passes.
    */
   private registeredClientsByClientId: Map<string, ProxyDCRClient> = new Map();
   private stateStore: OAuthProxyStateStore;
@@ -178,24 +182,10 @@ export class OAuthProxy {
     // RFC 6749 §5.2 - reject unknown clients with invalid_client.
     // MCP clients receive a proxy-issued client_id during DCR (not the upstream
     // provider's credentials), so we look up by that proxy client_id.
-    let registeredClient = await this.stateStore.getRegisteredClientByClientId(
+    const registeredClient = await this.resolveClient(
       params.client_id,
+      params.redirect_uri,
     );
-
-    // Unknown client_id: if CIMD is enabled, try resolving and caching it
-    // as one so later lookups (including token exchange) find it normally.
-    if (!registeredClient && this.config.enableCimd) {
-      registeredClient = await resolveCimdClient(
-        params.client_id,
-        params.redirect_uri,
-        (uri) => this.validateRedirectUri(uri),
-      );
-
-      if (registeredClient) {
-        this.stateStore.cacheRegisteredClient(registeredClient);
-        await this.stateStore.saveRegisteredClient(registeredClient);
-      }
-    }
 
     if (!registeredClient) {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
@@ -281,24 +271,7 @@ export class OAuthProxy {
     // RFC 6749 §5.2 - reject unknown clients. Only proxy-issued client_ids
     // (obtained via DCR) and, when enabled, resolved CIMD clients are
     // accepted, so stolen codes cannot be exchanged by arbitrary callers.
-    let registeredClient = await this.stateStore.getRegisteredClientByClientId(
-      request.client_id,
-    );
-
-    // Defence in depth: authorize() already caches a resolved CIMD client,
-    // so this only matters if it was evicted between authorize and exchange.
-    if (!registeredClient && this.config.enableCimd) {
-      registeredClient = await resolveCimdClient(
-        request.client_id,
-        undefined,
-        (uri) => this.validateRedirectUri(uri),
-      );
-
-      if (registeredClient) {
-        this.stateStore.cacheRegisteredClient(registeredClient);
-        await this.stateStore.saveRegisteredClient(registeredClient);
-      }
-    }
+    const registeredClient = await this.resolveClient(request.client_id);
 
     if (!registeredClient) {
       throw new OAuthProxyError("invalid_client", "Unknown client_id");
@@ -499,7 +472,7 @@ export class OAuthProxy {
     // Defense-in-depth: the transaction's stored callback URL must still be
     // registered. Guards against any code path that could persist an
     // unvalidated URI, and against registration being revoked mid-flow.
-    if (!(await this.stateStore.isTransactionCallbackRegistered(transaction))) {
+    if (!(await this.isTransactionCallbackRegistered(transaction))) {
       throw new OAuthProxyError(
         "invalid_request",
         "Transaction callback URL is not registered",
@@ -562,9 +535,7 @@ export class OAuthProxy {
       // User denied consent
       await this.stateStore.deleteTransaction(transactionId);
       // Defense-in-depth: never redirect to an unregistered URI.
-      if (
-        !(await this.stateStore.isTransactionCallbackRegistered(transaction))
-      ) {
+      if (!(await this.isTransactionCallbackRegistered(transaction))) {
         throw new OAuthProxyError(
           "invalid_request",
           "Transaction callback URL is not registered",
@@ -1344,6 +1315,28 @@ export class OAuthProxy {
   }
 
   /**
+   * Defence in depth for the callback and consent-denial redirects: the
+   * transaction's stored callback URL must still be registered for its client.
+   *
+   * Resolution goes through {@link resolveClient}, so a CIMD registration whose
+   * cached copy lapsed mid-flow is re-fetched rather than mistaken for one that
+   * was revoked.
+   */
+  private async isTransactionCallbackRegistered(
+    transaction: OAuthTransaction,
+  ): Promise<boolean> {
+    const registeredClient = await this.resolveClient(
+      transaction.clientId,
+      transaction.clientCallbackUrl,
+    );
+
+    return (
+      registeredClient?.redirectUris.includes(transaction.clientCallbackUrl) ??
+      false
+    );
+  }
+
+  /**
    * Match URI against pattern (supports wildcards)
    */
   private matchesPattern(uri: string, pattern: string): boolean {
@@ -1523,6 +1516,41 @@ export class OAuthProxy {
       scope: tokens.scope ? tokens.scope.split(" ") : [],
       tokenType: tokens.token_type || "Bearer",
     };
+  }
+
+  /**
+   * Resolve the client behind a `client_id`: a stored registration if there is
+   * one, otherwise — when CIMD is enabled — the client's metadata document.
+   *
+   * A resolved CIMD client is cached like a DCR registration but carries the
+   * `expiresAt` the resolver stamped on it, so the store drops it once it
+   * lapses and the next call re-fetches the document. Every lookup goes
+   * through here, so a lapse always means "re-resolve", never "unknown
+   * client" mid-flow.
+   */
+  private async resolveClient(
+    clientId: string,
+    requestedRedirectUri?: string,
+  ): Promise<null | ProxyDCRClient> {
+    const registeredClient =
+      await this.stateStore.getRegisteredClientByClientId(clientId);
+
+    if (registeredClient || !this.config.enableCimd) {
+      return registeredClient;
+    }
+
+    const resolved = await resolveCimdClient(
+      clientId,
+      requestedRedirectUri,
+      (uri) => this.validateRedirectUri(uri),
+    );
+
+    if (resolved) {
+      this.stateStore.cacheRegisteredClient(resolved);
+      await this.stateStore.saveRegisteredClient(resolved);
+    }
+
+    return resolved;
   }
 
   /**

--- a/src/auth/OAuthProxyStateStore.ts
+++ b/src/auth/OAuthProxyStateStore.ts
@@ -48,6 +48,7 @@ const proxyDcrClientStorageSchema: z.ZodType<ProxyDCRClient> = z.object({
   callbackUrl: z.string(),
   clientId: z.string(),
   clientSecret: z.string().optional(),
+  expiresAt: storedDateSchema.optional(),
   metadata: dcrClientMetadataSchema.optional(),
   redirectUris: z.array(z.string()),
   registeredAt: storedDateSchema,
@@ -124,7 +125,9 @@ interface OAuthProxyStateStoreConfig {
  * Backs OAuth proxy state with the configured TokenStorage so that several
  * proxy instances can serve one flow.
  *
- * Client registrations are immutable once written, so they are cached locally.
+ * Client registrations are immutable once written, so they are cached locally —
+ * except a CIMD resolution, which carries an `expiresAt` and is dropped once it
+ * lapses so the document behind it can be re-read.
  * Transactions and authorization codes are *not* cached: they are single-use
  * and mutated by whichever instance handles the next leg of the flow, so a
  * local copy would go stale and let a consumed code or transaction be redeemed
@@ -203,12 +206,21 @@ export class OAuthProxyStateStore {
     );
   }
 
+  /**
+   * A client carrying `expiresAt` is a cached resolution rather than a
+   * permanent registration (CIMD), so a lapsed copy is dropped and reported as
+   * a miss — the caller re-resolves it from the source of truth.
+   */
   async getRegisteredClientByClientId(
     clientId: string,
   ): Promise<null | ProxyDCRClient> {
     const cached = this.registeredClientsByClientId.get(clientId);
     if (cached) {
-      return cached;
+      if (!cached.expiresAt || !this.isExpired(cached.expiresAt)) {
+        return cached;
+      }
+
+      this.registeredClientsByClientId.delete(clientId);
     }
 
     const stored = await this.tokenStorage.get(
@@ -217,6 +229,11 @@ export class OAuthProxyStateStore {
     const parsed = proxyDcrClientStorageSchema.safeParse(stored);
 
     if (!parsed.success) {
+      return null;
+    }
+
+    if (parsed.data.expiresAt && this.isExpired(parsed.data.expiresAt)) {
+      await this.tokenStorage.delete(`${STORAGE_KEY_PREFIX.client}${clientId}`);
       return null;
     }
 
@@ -248,19 +265,6 @@ export class OAuthProxyStateStore {
     return parsed.data;
   }
 
-  async isTransactionCallbackRegistered(
-    transaction: OAuthTransaction,
-  ): Promise<boolean> {
-    const registeredClient = await this.getRegisteredClientByClientId(
-      transaction.clientId,
-    );
-
-    return (
-      registeredClient?.redirectUris.includes(transaction.clientCallbackUrl) ??
-      false
-    );
-  }
-
   /**
    * Record that an authorization code has been redeemed, so a later attempt
    * gets "already used" rather than looking like an unknown code. Keyed and
@@ -286,6 +290,7 @@ export class OAuthProxyStateStore {
     await this.tokenStorage.save(
       `${STORAGE_KEY_PREFIX.client}${client.clientId}`,
       client,
+      client.expiresAt ? this.getTtlSeconds(client.expiresAt) : undefined,
     );
   }
 

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -367,6 +367,12 @@ export interface ProxyDCRClient {
   clientId: string;
   /** Proxy-issued client secret (not the upstream provider's client_secret) */
   clientSecret?: string;
+  /**
+   * When set, this is a cached resolution of a live document (CIMD) rather
+   * than a permanent registration: past this instant the copy is dropped and
+   * the document is fetched again.
+   */
+  expiresAt?: Date;
   /** Client metadata from registration request */
   metadata?: DCRClientMetadata;
   /** All redirect URIs registered by this client */

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -262,30 +262,11 @@ export interface OAuthProxyConfig {
    * Accept Client ID Metadata Documents (CIMD) as an alternative to Dynamic
    * Client Registration (default: false).
    *
-   * When enabled, a `client_id` that is not already a registered client —
-   * via DCR or a prior CIMD resolution — and that is an HTTPS URL is treated
-   * as a CIMD client: the proxy fetches that URL, expects a JSON document
-   * whose own `client_id` field matches the URL it was fetched from, and
-   * reads `redirect_uris` from it. This lets clients that publish a stable
-   * metadata document (e.g. a first-party IDE) identify themselves without
-   * ever calling POST /oauth/register — see the MCP authorization spec's
-   * Client ID Metadata Document mechanism (SEP-991), which newer MCP clients
-   * increasingly prefer, or require, over classic DCR.
-   *
-   * The fetched document's `redirect_uris` are checked against
-   * `allowedRedirectUriPatterns` exactly as DCR's are — a CIMD document
-   * cannot claim a redirect URI this deployment wouldn't otherwise accept.
-   * The proxy also refuses non-HTTPS URLs and literal loopback/private-range
-   * hosts before fetching (defence against CWE-918 SSRF), and caps both the
-   * fetch timeout and response size.
-   *
-   * When enabled, `client_id_metadata_document_supported: true` is added to
-   * `getAuthorizationServerMetadata()` so compliant clients know to try this
-   * before falling back to DCR or manual client registration.
-   *
-   * Off by default: this adds a new, network-reaching code path triggered by
-   * client-supplied input, so existing deployments upgrading this package
-   * are unaffected until they opt in.
+   * When enabled, an unregistered `client_id` that is an HTTPS URL is
+   * resolved by fetching it as a CIMD document (see `resolveCimdClient` in
+   * `utils/cimd.ts` for validation details) and advertised via
+   * `client_id_metadata_document_supported` in the AS metadata. See the MCP
+   * authorization spec's CIMD mechanism (SEP-991).
    */
   enableCimd?: boolean;
   /** Enable token swap pattern (default: true) - issues short-lived JWTs instead of passing through upstream tokens */

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -258,6 +258,36 @@ export interface OAuthProxyConfig {
    * Default: true (enabled with default settings)
    */
   customClaimsPassthrough?: boolean | CustomClaimsPassthroughConfig;
+  /**
+   * Accept Client ID Metadata Documents (CIMD) as an alternative to Dynamic
+   * Client Registration (default: false).
+   *
+   * When enabled, a `client_id` that is not already a registered client —
+   * via DCR or a prior CIMD resolution — and that is an HTTPS URL is treated
+   * as a CIMD client: the proxy fetches that URL, expects a JSON document
+   * whose own `client_id` field matches the URL it was fetched from, and
+   * reads `redirect_uris` from it. This lets clients that publish a stable
+   * metadata document (e.g. a first-party IDE) identify themselves without
+   * ever calling POST /oauth/register — see the MCP authorization spec's
+   * Client ID Metadata Document mechanism (SEP-991), which newer MCP clients
+   * increasingly prefer, or require, over classic DCR.
+   *
+   * The fetched document's `redirect_uris` are checked against
+   * `allowedRedirectUriPatterns` exactly as DCR's are — a CIMD document
+   * cannot claim a redirect URI this deployment wouldn't otherwise accept.
+   * The proxy also refuses non-HTTPS URLs and literal loopback/private-range
+   * hosts before fetching (defence against CWE-918 SSRF), and caps both the
+   * fetch timeout and response size.
+   *
+   * When enabled, `client_id_metadata_document_supported: true` is added to
+   * `getAuthorizationServerMetadata()` so compliant clients know to try this
+   * before falling back to DCR or manual client registration.
+   *
+   * Off by default: this adds a new, network-reaching code path triggered by
+   * client-supplied input, so existing deployments upgrading this package
+   * are unaffected until they opt in.
+   */
+  enableCimd?: boolean;
   /** Enable token swap pattern (default: true) - issues short-lived JWTs instead of passing through upstream tokens */
   enableTokenSwap?: boolean;
   /** Encryption key for token storage (default: auto-generated). Set to false to disable encryption. */

--- a/src/auth/utils/cimd.test.ts
+++ b/src/auth/utils/cimd.test.ts
@@ -109,6 +109,13 @@ describe("resolveCimdClient", () => {
     "https://10.0.0.5/client.json",
     "https://192.168.1.5/client.json",
     "https://172.16.0.5/client.json",
+    "https://[::1]/client.json",
+    "https://[::]/client.json",
+    "https://[fe80::1]/client.json",
+    "https://[fc00::1]/client.json",
+    "https://[fd12:3456::1]/client.json",
+    "https://[::ffff:127.0.0.1]/client.json",
+    "https://[::ffff:169.254.169.254]/client.json",
   ])(
     "rejects a loopback or private-range host without fetching it (%s)",
     async (loopbackClientId) => {
@@ -173,6 +180,62 @@ describe("resolveCimdClient", () => {
       alwaysAllow,
     );
     expect(client).toBeNull();
+  });
+
+  it("rejects via the Content-Length header without reading the body", async () => {
+    const body = new ReadableStream({
+      pull() {
+        throw new Error("body should not be read");
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, {
+            headers: { "content-length": "999999" },
+            status: 200,
+          }),
+      ),
+    );
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("cancels the stream once the size cap is exceeded, instead of buffering the full body", async () => {
+    const chunk = new TextEncoder().encode("x".repeat(40_000));
+    let pullCount = 0;
+    let cancelled = false;
+    const body = new ReadableStream({
+      cancel() {
+        cancelled = true;
+      },
+      pull(controller) {
+        pullCount += 1;
+        controller.enqueue(chunk);
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+
+    expect(client).toBeNull();
+    expect(cancelled).toBe(true);
+    // 40_000 then 80_000 > CIMD_MAX_RESPONSE_BYTES: stops within a couple of
+    // chunks rather than continuing to buffer an effectively unbounded body.
+    expect(pullCount).toBeLessThanOrEqual(3);
   });
 
   it("rejects a document whose client_id does not match the fetch URL", async () => {

--- a/src/auth/utils/cimd.test.ts
+++ b/src/auth/utils/cimd.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Client ID Metadata Document (CIMD) resolver tests
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveCimdClient } from "./cimd.js";
+
+const CLIENT_ID = "https://client.example.com/oauth/client-metadata.json";
+const REDIRECT_URI = "http://127.0.0.1:33418/";
+
+const alwaysAllow = () => true;
+const alwaysDeny = () => false;
+
+function mockFetchOnce(body: unknown, init: ResponseInit = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(typeof body === "string" ? body : JSON.stringify(body), {
+          headers: { "Content-Type": "application/json" },
+          status: 200,
+          ...init,
+        }),
+    ),
+  );
+}
+
+function validDocument(overrides: Record<string, unknown> = {}) {
+  return {
+    client_id: CLIENT_ID,
+    client_name: "Example Client",
+    redirect_uris: [REDIRECT_URI],
+    ...overrides,
+  };
+}
+
+describe("resolveCimdClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves a valid document into a ProxyDCRClient", async () => {
+    mockFetchOnce(validDocument());
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+
+    expect(client).not.toBeNull();
+    expect(client?.clientId).toBe(CLIENT_ID);
+    expect(client?.callbackUrl).toBe(REDIRECT_URI);
+    expect(client?.redirectUris).toEqual([REDIRECT_URI]);
+    expect(client?.clientSecret).toBeUndefined();
+    expect(client?.metadata?.client_name).toBe("Example Client");
+  });
+
+  it("only reads recognised metadata fields, ignoring unknown ones", async () => {
+    mockFetchOnce(
+      validDocument({
+        application_type: "native",
+        token_endpoint_auth_method: "none",
+      }),
+    );
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+
+    expect(client?.metadata).not.toHaveProperty("application_type");
+    expect(client?.metadata).not.toHaveProperty("token_endpoint_auth_method");
+  });
+
+  it("rejects a client_id that is not a URL at all", async () => {
+    const client = await resolveCimdClient(
+      "not-a-url",
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("rejects a non-HTTPS client_id", async () => {
+    const client = await resolveCimdClient(
+      "http://client.example.com/client-metadata.json",
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("rejects a client_id with a query string", async () => {
+    const client = await resolveCimdClient(
+      `${CLIENT_ID}?x=1`,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it.each([
+    "https://localhost/client.json",
+    "https://127.0.0.1/client.json",
+    "https://169.254.169.254/client.json",
+    "https://10.0.0.5/client.json",
+    "https://192.168.1.5/client.json",
+    "https://172.16.0.5/client.json",
+  ])(
+    "rejects a loopback or private-range host without fetching it (%s)",
+    async (loopbackClientId) => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const client = await resolveCimdClient(
+        loopbackClientId,
+        REDIRECT_URI,
+        alwaysAllow,
+      );
+
+      expect(client).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects when the fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network error");
+      }),
+    );
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("rejects a non-2xx response", async () => {
+    mockFetchOnce(validDocument(), { status: 404 });
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("rejects a response body that is not valid JSON", async () => {
+    mockFetchOnce("not json");
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("rejects a response larger than the size cap", async () => {
+    mockFetchOnce(validDocument({ client_name: "x".repeat(100_000) }));
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("rejects a document whose client_id does not match the fetch URL", async () => {
+    mockFetchOnce(
+      validDocument({ client_id: "https://attacker.example.com/client.json" }),
+    );
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("rejects a document with no redirect_uris", async () => {
+    mockFetchOnce(validDocument({ redirect_uris: [] }));
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("rejects a document whose redirect_uris does not include the requested redirect_uri", async () => {
+    mockFetchOnce(validDocument({ redirect_uris: ["http://127.0.0.1:9999/"] }));
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+    expect(client).toBeNull();
+  });
+
+  it("accepts a document when requestedRedirectUri is omitted (token-exchange call sites)", async () => {
+    mockFetchOnce(validDocument());
+
+    const client = await resolveCimdClient(CLIENT_ID, undefined, alwaysAllow);
+    expect(client).not.toBeNull();
+  });
+
+  it("rejects every redirect_uri that fails the caller's allow-list check", async () => {
+    mockFetchOnce(validDocument());
+
+    const client = await resolveCimdClient(CLIENT_ID, REDIRECT_URI, alwaysDeny);
+    expect(client).toBeNull();
+  });
+
+  it("never throws — resolves to null even for a malformed URL constructor edge case", async () => {
+    await expect(
+      resolveCimdClient("https://", REDIRECT_URI, alwaysAllow),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/auth/utils/cimd.ts
+++ b/src/auth/utils/cimd.ts
@@ -10,13 +10,23 @@ import type { DCRClientMetadata, ProxyDCRClient } from "../types.js";
 
 const CIMD_FETCH_TIMEOUT_MS = 5000;
 
+/**
+ * How long a resolved document may be reused before it is fetched again.
+ * A CIMD document is live — the client can rotate its redirect URIs or stop
+ * publishing altogether — so a resolution is a short-lived snapshot, not a
+ * registration.
+ */
+const CIMD_CLIENT_TTL_MS = 15 * 60 * 1000;
+
 /** Max response size accepted, enforced while streaming (not after buffering). */
 const CIMD_MAX_RESPONSE_BYTES = 65536;
 
 /**
  * Resolves a CIMD `client_id` into the same shape Dynamic Client
- * Registration produces. Callers should look up `client_id` in their
- * existing client registry first and only call this on a miss.
+ * Registration produces, stamped with an `expiresAt` so callers re-read the
+ * document instead of trusting the snapshot forever. Callers should look up
+ * `client_id` in their existing client registry first and only call this on
+ * a miss.
  *
  * Never throws — anything that isn't a valid, fetchable, self-consistent
  * CIMD document resolves to `null` so callers can fall through to the
@@ -119,6 +129,7 @@ export async function resolveCimdClient(
     clientId,
     // CIMD is a public-client mechanism secured by PKCE; there is no secret.
     clientSecret: undefined,
+    expiresAt: new Date(Date.now() + CIMD_CLIENT_TTL_MS),
     metadata,
     redirectUris,
     registeredAt: new Date(),

--- a/src/auth/utils/cimd.ts
+++ b/src/auth/utils/cimd.ts
@@ -1,0 +1,196 @@
+/**
+ * Client ID Metadata Documents (CIMD)
+ *
+ * Implements the client-identification mechanism introduced to the MCP
+ * authorization spec by SEP-991, positioned as the successor to Dynamic
+ * Client Registration: instead of calling POST /oauth/register, a client
+ * presents an HTTPS URL as its `client_id`, and the authorization server
+ * fetches that URL on demand to read the client's metadata. Nothing is
+ * written on the server side ahead of time, so there is no registration
+ * database to grow, no client to expire, and no unauthenticated /register
+ * endpoint to abuse.
+ */
+
+import type { DCRClientMetadata, ProxyDCRClient } from "../types.js";
+
+const CIMD_FETCH_TIMEOUT_MS = 5000;
+
+/** Refuses documents larger than this before attempting to parse them. */
+const CIMD_MAX_RESPONSE_BYTES = 65536;
+
+/**
+ * Resolves a CIMD `client_id` into the same shape Dynamic Client
+ * Registration produces, so every downstream consumer — authorize, token
+ * exchange, storage — can treat a CIMD client and a DCR client identically
+ * once this returns.
+ *
+ * Callers are expected to try `client_id` against their existing client
+ * registry first and only reach this function on a miss: a `client_id` a
+ * previous CIMD or DCR call already registered is found there and should
+ * never reach here again.
+ *
+ * Never throws. Anything that isn't a valid, fetchable, self-consistent CIMD
+ * document resolves to `null`, so callers can fall through to the ordinary
+ * "Unknown client_id" error rather than distinguish "not CIMD" from "invalid
+ * CIMD" — RFC 6749 §5.2 gives an attacker no more information from one
+ * outcome than the other anyway.
+ *
+ * @param clientId The `client_id` presented by the client.
+ * @param requestedRedirectUri The `redirect_uri` from the current request,
+ *   if any. When present, the resolved document's `redirect_uris` must
+ *   include it. Token-exchange call sites that don't carry a `redirect_uri`
+ *   may omit this and rely on `validateRedirectUri` plus the fact that
+ *   `authorize()` already validated the pairing for this transaction.
+ * @param validateRedirectUri The proxy's own redirect-URI allow-list check
+ *   (`OAuthProxy.validateRedirectUri`) — every URI in the document must pass
+ *   it, exactly as DCR's `registerClient` already requires. A CIMD document
+ *   cannot claim a redirect URI this deployment wouldn't otherwise accept.
+ */
+export async function resolveCimdClient(
+  clientId: string,
+  requestedRedirectUri: string | undefined,
+  validateRedirectUri: (uri: string) => boolean,
+): Promise<null | ProxyDCRClient> {
+  let url: URL;
+
+  try {
+    url = new URL(clientId);
+  } catch {
+    return null;
+  }
+
+  // CIMD requires an HTTPS URL with no query string.
+  if (url.protocol !== "https:" || url.search) {
+    return null;
+  }
+
+  if (isPrivateOrLoopbackHost(url.hostname)) {
+    return null;
+  }
+
+  let response: Response;
+
+  try {
+    response = await fetch(clientId, {
+      redirect: "error",
+      signal: AbortSignal.timeout(CIMD_FETCH_TIMEOUT_MS),
+    });
+  } catch {
+    return null;
+  }
+
+  if (!response.ok) {
+    return null;
+  }
+
+  let text: string;
+
+  try {
+    text = await response.text();
+  } catch {
+    return null;
+  }
+
+  if (text.length > CIMD_MAX_RESPONSE_BYTES) {
+    return null;
+  }
+
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+
+  const doc = parsed as Record<string, unknown>;
+
+  // The document must identify itself by the exact URL it was fetched from —
+  // otherwise it says nothing about who actually controls `clientId`, and any
+  // HTTPS host could vouch for any other client_id.
+  if (doc.client_id !== clientId) {
+    return null;
+  }
+
+  if (!isStringArray(doc.redirect_uris) || doc.redirect_uris.length === 0) {
+    return null;
+  }
+
+  const redirectUris = doc.redirect_uris;
+
+  if (requestedRedirectUri && !redirectUris.includes(requestedRedirectUri)) {
+    return null;
+  }
+
+  if (!redirectUris.every((uri) => validateRedirectUri(uri))) {
+    return null;
+  }
+
+  const metadata: DCRClientMetadata = {
+    client_name: optionalString(doc.client_name),
+    client_uri: optionalString(doc.client_uri),
+    logo_uri: optionalString(doc.logo_uri),
+    policy_uri: optionalString(doc.policy_uri),
+    scope: optionalString(doc.scope),
+    tos_uri: optionalString(doc.tos_uri),
+  };
+
+  return {
+    callbackUrl: redirectUris[0],
+    clientId,
+    // CIMD is a public-client mechanism: the URL is the identity, and there
+    // is no secret-issuance step for a downstream check to rely on. The flow
+    // is secured by PKCE instead, exactly as for a DCR client that requested
+    // `token_endpoint_auth_method: "none"`.
+    clientSecret: undefined,
+    metadata,
+    redirectUris,
+    registeredAt: new Date(),
+  };
+}
+
+/**
+ * Rejects hosts that are, by their literal form, loopback or link-local/
+ * private-range addresses. This defends against a CIMD `client_id` pointing
+ * the proxy's own outbound fetch at internal infrastructure — e.g. a cloud
+ * metadata endpoint on 169.254.169.254 — which is CWE-918 Server-Side
+ * Request Forgery.
+ *
+ * This is a literal-form check only, not DNS-resolution-based, so it does
+ * not defend against DNS rebinding (a hostname that resolves to a private
+ * address only after this check runs). Treat it as one layer of defence,
+ * not a complete SSRF mitigation.
+ */
+function isPrivateOrLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+
+  if (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "0.0.0.0"
+  ) {
+    return true;
+  }
+
+  return (
+    /^169\.254\./.test(host) || // link-local, includes cloud metadata endpoints
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host)
+  );
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === "string")
+  );
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/auth/utils/cimd.ts
+++ b/src/auth/utils/cimd.ts
@@ -1,50 +1,32 @@
 /**
- * Client ID Metadata Documents (CIMD)
+ * Client ID Metadata Documents (CIMD) — MCP authorization spec SEP-991.
  *
- * Implements the client-identification mechanism introduced to the MCP
- * authorization spec by SEP-991, positioned as the successor to Dynamic
- * Client Registration: instead of calling POST /oauth/register, a client
- * presents an HTTPS URL as its `client_id`, and the authorization server
- * fetches that URL on demand to read the client's metadata. Nothing is
- * written on the server side ahead of time, so there is no registration
- * database to grow, no client to expire, and no unauthenticated /register
- * endpoint to abuse.
+ * A client presents an HTTPS URL as its `client_id`; the authorization
+ * server fetches that URL on demand to read the client's metadata instead
+ * of requiring a prior POST /oauth/register call.
  */
 
 import type { DCRClientMetadata, ProxyDCRClient } from "../types.js";
 
 const CIMD_FETCH_TIMEOUT_MS = 5000;
 
-/** Refuses documents larger than this before attempting to parse them. */
+/** Max response size accepted, enforced while streaming (not after buffering). */
 const CIMD_MAX_RESPONSE_BYTES = 65536;
 
 /**
  * Resolves a CIMD `client_id` into the same shape Dynamic Client
- * Registration produces, so every downstream consumer — authorize, token
- * exchange, storage — can treat a CIMD client and a DCR client identically
- * once this returns.
+ * Registration produces. Callers should look up `client_id` in their
+ * existing client registry first and only call this on a miss.
  *
- * Callers are expected to try `client_id` against their existing client
- * registry first and only reach this function on a miss: a `client_id` a
- * previous CIMD or DCR call already registered is found there and should
- * never reach here again.
- *
- * Never throws. Anything that isn't a valid, fetchable, self-consistent CIMD
- * document resolves to `null`, so callers can fall through to the ordinary
- * "Unknown client_id" error rather than distinguish "not CIMD" from "invalid
- * CIMD" — RFC 6749 §5.2 gives an attacker no more information from one
- * outcome than the other anyway.
+ * Never throws — anything that isn't a valid, fetchable, self-consistent
+ * CIMD document resolves to `null` so callers can fall through to the
+ * ordinary "Unknown client_id" error.
  *
  * @param clientId The `client_id` presented by the client.
  * @param requestedRedirectUri The `redirect_uri` from the current request,
- *   if any. When present, the resolved document's `redirect_uris` must
- *   include it. Token-exchange call sites that don't carry a `redirect_uri`
- *   may omit this and rely on `validateRedirectUri` plus the fact that
- *   `authorize()` already validated the pairing for this transaction.
- * @param validateRedirectUri The proxy's own redirect-URI allow-list check
- *   (`OAuthProxy.validateRedirectUri`) — every URI in the document must pass
- *   it, exactly as DCR's `registerClient` already requires. A CIMD document
- *   cannot claim a redirect URI this deployment wouldn't otherwise accept.
+ *   if any; when present it must appear in the document's `redirect_uris`.
+ * @param validateRedirectUri The proxy's redirect-URI allow-list check —
+ *   every URI in the document must pass it, exactly as DCR requires.
  */
 export async function resolveCimdClient(
   clientId: string,
@@ -83,15 +65,9 @@ export async function resolveCimdClient(
     return null;
   }
 
-  let text: string;
+  const text = await readBoundedText(response);
 
-  try {
-    text = await response.text();
-  } catch {
-    return null;
-  }
-
-  if (text.length > CIMD_MAX_RESPONSE_BYTES) {
+  if (text === null) {
     return null;
   }
 
@@ -109,9 +85,8 @@ export async function resolveCimdClient(
 
   const doc = parsed as Record<string, unknown>;
 
-  // The document must identify itself by the exact URL it was fetched from —
-  // otherwise it says nothing about who actually controls `clientId`, and any
-  // HTTPS host could vouch for any other client_id.
+  // The document must self-identify by the exact URL it was fetched from,
+  // or any HTTPS host could vouch for any other client_id.
   if (doc.client_id !== clientId) {
     return null;
   }
@@ -142,10 +117,7 @@ export async function resolveCimdClient(
   return {
     callbackUrl: redirectUris[0],
     clientId,
-    // CIMD is a public-client mechanism: the URL is the identity, and there
-    // is no secret-issuance step for a downstream check to rely on. The flow
-    // is secured by PKCE instead, exactly as for a DCR client that requested
-    // `token_endpoint_auth_method: "none"`.
+    // CIMD is a public-client mechanism secured by PKCE; there is no secret.
     clientSecret: undefined,
     metadata,
     redirectUris,
@@ -153,36 +125,106 @@ export async function resolveCimdClient(
   };
 }
 
+/** Expands a (possibly `::`-abbreviated) IPv6 address into 8 16-bit groups. */
+function expandIPv6(host: string): null | number[] {
+  const sides = host.split("::");
+
+  if (sides.length > 2) {
+    return null;
+  }
+
+  const head = sides[0] ? sides[0].split(":") : [];
+  const tail = sides.length === 2 && sides[1] ? sides[1].split(":") : [];
+
+  if (sides.length === 1 && head.length !== 8) {
+    return null;
+  }
+
+  const missing = 8 - head.length - tail.length;
+
+  if (missing < 0) {
+    return null;
+  }
+
+  const parts = [...head, ...Array<string>(missing).fill("0"), ...tail];
+
+  if (parts.length !== 8) {
+    return null;
+  }
+
+  const groups = parts.map((g) => Number.parseInt(g || "0", 16));
+  return groups.every((g) => !Number.isNaN(g)) ? groups : null;
+}
+
 /**
- * Rejects hosts that are, by their literal form, loopback or link-local/
- * private-range addresses. This defends against a CIMD `client_id` pointing
- * the proxy's own outbound fetch at internal infrastructure — e.g. a cloud
- * metadata endpoint on 169.254.169.254 — which is CWE-918 Server-Side
- * Request Forgery.
+ * Rejects hosts that are, by literal form, loopback/link-local/private-range
+ * addresses (IPv4 and IPv6, including IPv4-mapped IPv6). Defends against a
+ * CIMD `client_id` pointing the proxy's outbound fetch at internal
+ * infrastructure (CWE-918 SSRF) — e.g. a cloud metadata endpoint.
  *
- * This is a literal-form check only, not DNS-resolution-based, so it does
- * not defend against DNS rebinding (a hostname that resolves to a private
- * address only after this check runs). Treat it as one layer of defence,
- * not a complete SSRF mitigation.
+ * Literal-form only, not DNS-resolution-based: one layer of defence, not a
+ * complete SSRF mitigation (does not defend against DNS rebinding).
  */
 function isPrivateOrLoopbackHost(hostname: string): boolean {
-  const host = hostname.toLowerCase();
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
 
-  if (
-    host === "localhost" ||
-    host === "127.0.0.1" ||
-    host === "::1" ||
-    host === "0.0.0.0"
-  ) {
+  if (host === "localhost" || host === "0.0.0.0") {
     return true;
   }
 
+  if (host.includes(":")) {
+    return isPrivateOrLoopbackIPv6(host);
+  }
+
   return (
-    /^169\.254\./.test(host) || // link-local, includes cloud metadata endpoints
+    host === "127.0.0.1" ||
+    /^169\.254\./.test(host) ||
     /^10\./.test(host) ||
     /^192\.168\./.test(host) ||
     /^172\.(1[6-9]|2\d|3[01])\./.test(host)
   );
+}
+
+function isPrivateOrLoopbackIPv6(host: string): boolean {
+  const groups = expandIPv6(host);
+
+  if (!groups) {
+    return false;
+  }
+
+  if (groups.every((g) => g === 0)) {
+    return true; // :: (unspecified)
+  }
+
+  if (groups.slice(0, 7).every((g) => g === 0) && groups[7] === 1) {
+    return true; // ::1 (loopback)
+  }
+
+  const [first] = groups;
+
+  if ((first & 0xffc0) === 0xfe80) {
+    return true; // fe80::/10 (link-local)
+  }
+
+  if ((first & 0xfe00) === 0xfc00) {
+    return true; // fc00::/7 (unique-local)
+  }
+
+  // IPv4-mapped/-compatible (::ffff:a.b.c.d or ::a.b.c.d): check the
+  // embedded IPv4 address against the same rules.
+  if (
+    groups[0] === 0 &&
+    groups[1] === 0 &&
+    groups[2] === 0 &&
+    groups[3] === 0 &&
+    groups[4] === 0 &&
+    (groups[5] === 0 || groups[5] === 0xffff)
+  ) {
+    const ipv4 = `${groups[6] >> 8}.${groups[6] & 0xff}.${groups[7] >> 8}.${groups[7] & 0xff}`;
+    return isPrivateOrLoopbackHost(ipv4);
+  }
+
+  return false;
 }
 
 function isStringArray(value: unknown): value is string[] {
@@ -193,4 +235,49 @@ function isStringArray(value: unknown): value is string[] {
 
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Reads a fetch `Response` body up to `CIMD_MAX_RESPONSE_BYTES`, aborting
+ * the stream (rather than buffering it fully first) once the cap is
+ * exceeded. Returns `null` on any error or if the cap is hit.
+ */
+async function readBoundedText(response: Response): Promise<null | string> {
+  const contentLength = response.headers.get("content-length");
+
+  if (contentLength && Number(contentLength) > CIMD_MAX_RESPONSE_BYTES) {
+    return null;
+  }
+
+  const reader = response.body?.getReader();
+
+  if (!reader) {
+    return null;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+
+      if (done) {
+        break;
+      }
+
+      totalBytes += value.byteLength;
+
+      if (totalBytes > CIMD_MAX_RESPONSE_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+
+      chunks.push(value);
+    }
+  } catch {
+    return null;
+  }
+
+  return Buffer.concat(chunks).toString("utf-8");
 }


### PR DESCRIPTION
Adds enableCimd (default: false) to OAuthProxyConfig. When enabled,
authorize() and exchangeAuthorizationCode() resolve a client_id that
is an HTTPS URL by fetching it (SEP-991), instead of requiring a prior
POST /oauth/register — the fetched document is validated (self-referential
client_id, redirect_uris checked against the existing
allowedRedirectUriPatterns allow-list, no-loopback/private-host guard)
and cached through the existing state store exactly like a DCR client.
getAuthorizationServerMetadata() advertises
client_id_metadata_document_supported when enabled.

Fixes MCP clients (VS Code among them) that require CIMD and don't
fall back to DCR. Off by default; no behavior change otherwise.

Adds src/auth/utils/cimd.ts + unit tests, and
src/auth/OAuthProxy.cimd.test.ts integration tests.