### PR TITLE
fix(oauth): require S256 PKCE from CIMD clients

### DIFF
--- a/docs/oauth-proxy-guide.md
+++ b/docs/oauth-proxy-guide.md
@@ -343,6 +343,13 @@ ID Metadata Document](https://modelcontextprotocol.io/specification/draft/basic/
 - lists only redirect URIs that pass `allowedRedirectUriPatterns` — CIMD does
   not widen the allow-list.
 
+A CIMD client is a public client: it holds no secret, and its identity is a URL
+anyone can name. PKCE is therefore the only thing binding an authorization code
+to whoever asked for it, so the proxy **requires `code_challenge` with
+`code_challenge_method=S256`** from these clients and rejects the authorization
+request otherwise. This holds regardless of `allowPlainPkce`, which only
+relaxes the rule for DCR clients that predate it.
+
 Documents are fetched over HTTPS with no redirects followed, a 5s timeout and a
 64 KB cap, and hosts that are literal loopback or private-range addresses are
 refused (a layer against SSRF, though not a defence against DNS rebinding —

--- a/src/auth/OAuthProxy.cimd.test.ts
+++ b/src/auth/OAuthProxy.cimd.test.ts
@@ -13,9 +13,16 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AuthorizationParams, UpstreamTokenSet } from "./types.js";
 
 import { OAuthProxy, OAuthProxyError } from "./OAuthProxy.js";
+import { PKCEUtils } from "./utils/pkce.js";
 
 const CLIENT_METADATA_URL = "https://client.example.com/client-metadata.json";
 const REDIRECT_URI = "http://127.0.0.1:33418/";
+
+/**
+ * A CIMD client is a public client, so the proxy requires S256 PKCE from it.
+ * One pair is reused across the suite; nothing here depends on it being fresh.
+ */
+const PKCE = PKCEUtils.generatePair("S256");
 
 const baseConfig = {
   allowedRedirectUriPatterns: ["http://127.0.0.1:*"],
@@ -38,6 +45,8 @@ function buildAuthParams(
 ): AuthorizationParams {
   return {
     client_id: CLIENT_METADATA_URL,
+    code_challenge: PKCE.challenge,
+    code_challenge_method: "S256",
     redirect_uri: REDIRECT_URI,
     response_type: "code",
     state: "test-state",
@@ -161,6 +170,7 @@ describe("OAuthProxy CIMD support", () => {
     const tokenResp = await proxy.exchangeAuthorizationCode({
       client_id: CLIENT_METADATA_URL,
       code,
+      code_verifier: PKCE.verifier,
       grant_type: "authorization_code",
       redirect_uri: REDIRECT_URI,
     });
@@ -187,6 +197,7 @@ describe("OAuthProxy CIMD support", () => {
     await proxy.exchangeAuthorizationCode({
       client_id: CLIENT_METADATA_URL,
       code,
+      code_verifier: PKCE.verifier,
       grant_type: "authorization_code",
       redirect_uri: REDIRECT_URI,
     });
@@ -251,6 +262,88 @@ describe("OAuthProxy CIMD support", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("refuses to issue a code to a CIMD client that sent no code_challenge", async () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    mockFetchRouting(clientMetadataResponse);
+
+    await expect(
+      proxy.authorize(
+        buildAuthParams({
+          code_challenge: undefined,
+          code_challenge_method: undefined,
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+
+    proxy.destroy();
+  });
+
+  it("refuses `plain` PKCE from a CIMD client even where allowPlainPkce permits it", async () => {
+    // allowPlainPkce defaults to true, and this proxy leaves it there: the
+    // stricter rule has to come from the client being CIMD, not from config.
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    mockFetchRouting(clientMetadataResponse);
+
+    await expect(
+      proxy.authorize(
+        buildAuthParams({
+          code_challenge: "a-verifier-doubling-as-its-own-challenge",
+          code_challenge_method: "plain",
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "invalid_request" });
+
+    proxy.destroy();
+  });
+
+  it("still lets a DCR client authorize without PKCE — the requirement is CIMD-only", async () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    const registration = await proxy.registerClient({
+      redirect_uris: [REDIRECT_URI],
+    });
+
+    await expect(
+      proxy.authorize({
+        client_id: registration.client_id,
+        redirect_uri: REDIRECT_URI,
+        response_type: "code",
+        state: "test-state",
+      } as AuthorizationParams),
+    ).resolves.toBeDefined();
+
+    proxy.destroy();
+  });
+
+  it("rejects a token exchange that presents the wrong verifier", async () => {
+    const proxy = new OAuthProxy({ ...baseConfig, enableCimd: true });
+    mockFetchRouting(clientMetadataResponse);
+
+    const authResp = await proxy.authorize(buildAuthParams());
+    const upstreamUrl = new URL(authResp.headers.get("Location")!);
+    const transactionId = upstreamUrl.searchParams.get("state")!;
+
+    const cbResp = await proxy.handleCallback(
+      new Request(
+        `${baseConfig.baseUrl}${baseConfig.redirectPath}?code=UP_CODE&state=${encodeURIComponent(transactionId)}`,
+      ),
+    );
+    const code = new URL(cbResp.headers.get("Location")!).searchParams.get(
+      "code",
+    )!;
+
+    await expect(
+      proxy.exchangeAuthorizationCode({
+        client_id: CLIENT_METADATA_URL,
+        code,
+        code_verifier: PKCEUtils.generatePair("S256").verifier,
+        grant_type: "authorization_code",
+        redirect_uri: REDIRECT_URI,
+      }),
+    ).rejects.toMatchObject({ code: "invalid_grant" });
+
+    proxy.destroy();
   });
 
   it("rejects a CIMD document whose redirect_uris fall outside allowedRedirectUriPatterns", async () => {

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -224,6 +224,29 @@ export class OAuthProxy {
       );
     }
 
+    // A CIMD client holds no secret and its identity is a URL anyone can name,
+    // so PKCE is the only thing binding the authorization code to whoever
+    // asked for it. `plain` puts the verifier in the same request as the
+    // challenge, binding nothing, so S256 is the only method accepted here —
+    // regardless of `allowPlainPkce`, which exists for legacy DCR clients that
+    // predate this requirement. Both OAuth 2.1 and the MCP authorization spec
+    // require this of public clients.
+    if (registeredClient.source === "cimd") {
+      if (!params.code_challenge) {
+        throw new OAuthProxyError(
+          "invalid_request",
+          "code_challenge is required for Client ID Metadata Document clients",
+        );
+      }
+
+      if (params.code_challenge_method !== "S256") {
+        throw new OAuthProxyError(
+          "invalid_request",
+          "code_challenge_method must be S256 for Client ID Metadata Document clients",
+        );
+      }
+    }
+
     // Create transaction
     const transaction = await this.createTransaction(params);
 
@@ -307,6 +330,17 @@ export class OAuthProxy {
     // Validate client
     if (clientCode.clientId !== request.client_id) {
       throw new OAuthProxyError("invalid_client", "Client ID mismatch");
+    }
+
+    // Defence in depth: authorize() refuses to issue a code to a CIMD client
+    // without S256 PKCE, so an unbound one here was issued under different
+    // rules — by an older version, or before the client_id resolved to a CIMD
+    // document. Refuse it rather than fall through to the no-PKCE path.
+    if (registeredClient.source === "cimd" && !clientCode.codeChallenge) {
+      throw new OAuthProxyError(
+        "invalid_grant",
+        "PKCE is required for Client ID Metadata Document clients",
+      );
     }
 
     // Validate PKCE if used

--- a/src/auth/OAuthProxyStateStore.ts
+++ b/src/auth/OAuthProxyStateStore.ts
@@ -52,6 +52,7 @@ const proxyDcrClientStorageSchema: z.ZodType<ProxyDCRClient> = z.object({
   metadata: dcrClientMetadataSchema.optional(),
   redirectUris: z.array(z.string()),
   registeredAt: storedDateSchema,
+  source: z.literal("cimd").optional(),
 });
 
 const upstreamTokenSetStorageSchema: z.ZodType<UpstreamTokenSet> = z.object({

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -379,6 +379,13 @@ export interface ProxyDCRClient {
   redirectUris: string[];
   /** Client registration timestamp */
   registeredAt: Date;
+  /**
+   * How this client came to be known, when that changes the rules applied to
+   * it. `"cimd"` marks a public client whose identity is a URL anyone can
+   * name and which holds no secret, so the proxy requires S256 PKCE from it.
+   * Absent for a Dynamic Client Registration.
+   */
+  source?: "cimd";
 }
 
 /**

--- a/src/auth/utils/cimd.test.ts
+++ b/src/auth/utils/cimd.test.ts
@@ -55,6 +55,9 @@ describe("resolveCimdClient", () => {
     expect(client?.redirectUris).toEqual([REDIRECT_URI]);
     expect(client?.clientSecret).toBeUndefined();
     expect(client?.metadata?.client_name).toBe("Example Client");
+    // Marks it as a public client, which the proxy holds to S256 PKCE.
+    expect(client?.source).toBe("cimd");
+    expect(client?.expiresAt).toBeInstanceOf(Date);
   });
 
   it("only reads recognised metadata fields, ignoring unknown ones", async () => {

--- a/src/auth/utils/cimd.ts
+++ b/src/auth/utils/cimd.ts
@@ -133,6 +133,7 @@ export async function resolveCimdClient(
     metadata,
     redirectUris,
     registeredAt: new Date(),
+    source: "cimd",
   };
 }
 


### PR DESCRIPTION
Follow-up to #347.

A CIMD client holds no secret and its identity is an HTTPS URL anyone can name, so PKCE is the only thing binding an authorization code to whoever asked for it. The proxy did not require it: `createTransaction` stores `params.code_challenge || ""`, and `exchangeAuthorizationCode` only validates when `clientCode.codeChallenge` is truthy — so a CIMD client that simply omitted `code_challenge` got a code any interceptor could redeem.

## Change

- `ProxyDCRClient.source?: "cimd"` marks a client resolved from a metadata document, so the rule keys off what the client *is* rather than off `expiresAt` as a proxy for it.
- `authorize()` rejects a CIMD client with no `code_challenge`, or with any method other than `S256`. This ignores `allowPlainPkce` — that option exists to keep legacy DCR clients working, and `plain` carries the verifier in the same request as the challenge, so it binds nothing.
- `exchangeAuthorizationCode()` refuses an unbound code from a CIMD client, so one issued under older rules cannot fall through to the no-PKCE path.
- DCR clients are untouched; a test pins that they can still authorize without PKCE.

Both OAuth 2.1 and the MCP authorization spec require this of public clients.

## Scope

Technically a behaviour change for CIMD, which shipped in v4.17.0 — but it is opt-in (`enableCimd` defaults to false), roughly an hour old, and any client modern enough to use CIMD already sends S256. Not marked breaking.

## Test

Four tests in `OAuthProxy.cimd.test.ts` (missing challenge, `plain` under permissive config, DCR still works, wrong verifier rejected); the first two are red without the change. Existing CIMD tests updated to carry a real S256 pair. Full suite green (659), `tsc`/`eslint`/`prettier` clean.

https://claude.ai/code/session_01Qa2kBssnRrQDcxLvgfFTnA