### PR TITLE
feat(openapi): fix form-urlencoded request bodies, add GET-to-resource mapping

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -6,6 +6,7 @@
 
 - [Basic Usage](#basic-usage)
 - [Choosing which operations become tools](#choosing-which-operations-become-tools)
+- [GET → resources](#get--resources)
 - [Options](#options)
 - [Authentication](#authentication)
 - [Adding to an existing server](#adding-to-an-existing-server)
@@ -42,21 +43,45 @@ const server = await fromOpenAPI({
 
 If neither `include`/`exclude` nor `maxTools` is given and the spec still produces more than 40 operations, `fromOpenAPI` throws instead of silently generating a wall of tools. Pass `maxTools` to raise that limit explicitly once you've decided that's really what you want.
 
+## GET → resources
+
+Pass `resources: true` to map an eligible `GET` operation to an MCP resource (no parameters) or resource template (path and/or query parameters) instead of a tool:
+
+```typescript
+const server = await fromOpenAPI({
+  spec: "https://petstore3.swagger.io/api/v3/openapi.json",
+  include: (operation) => operation.tags.includes("pet"),
+  resources: true,
+});
+```
+
+`getPetById` (`GET /pet/{petId}`) becomes a resource template at `openapi://getPetById/pet/{petId}`, readable via `client.readResource({ uri: "openapi://getPetById/pet/10" })`. A `GET` with no parameters at all becomes a static resource.
+
+A `GET` stays a tool instead — even with `resources: true` — when:
+
+- it has any `header` or `cookie` parameter (these can't be expressed in a resource URI, and resource reads have no per-call side channel for them), or
+- any of its path/query parameters is array-typed (OpenAPI's array query serialization and RFC 6570's don't match).
+
+This means a "get by ID" style endpoint typically becomes a resource template, while a "search/filter" endpoint with array-valued query parameters typically stays a tool — which tends to match how each is actually used.
+
+There's no per-operation override for this — an eligible `GET` always maps to a resource when `resources: true`; use `exclude` if you want a specific one to stay a tool instead of being generated at all.
+
 ## Options
 
-| Option     | Type                                                       | Description                                                                                |
-| ---------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `spec`     | `string \| object`                                         | Required. A URL, file path, or parsed OpenAPI document.                                    |
-| `name`     | `string`                                                   | Name for a newly-created server. Defaults to the spec's `info.title`, or "OpenAPI Server". |
-| `version`  | `` `${number}.${number}.${number}` ``                      | Version for a newly-created server. Defaults to `"1.0.0"`.                                 |
-| `server`   | `FastMCP`                                                  | Register the generated tools onto an existing server instead of creating one.              |
-| `include`  | `(operation: OperationSummary) => boolean`                 | Only keep matching operations.                                                             |
-| `exclude`  | `(operation: OperationSummary) => boolean`                 | Drop matching operations, applied after `include`.                                         |
-| `maxTools` | `number`                                                   | Hard cap; throws if the selected operation count exceeds it.                               |
-| `mcpNames` | `Record<string, string>`                                   | Override the generated tool name for a given `operationId`.                                |
-| `baseUrl`  | `string`                                                   | Overrides the resolved `servers[0].url`.                                                   |
-| `headers`  | `Record<string, string> \| (() => Record<string, string>)` | Static or dynamically-resolved headers sent with every generated tool call.                |
-| `fetch`    | `typeof fetch`                                             | HTTP client used to execute tool calls. Defaults to the global `fetch`.                    |
+| Option      | Type                                                       | Description                                                                                |
+| ----------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `spec`      | `string \| object`                                         | Required. A URL, file path, or parsed OpenAPI document.                                    |
+| `name`      | `string`                                                   | Name for a newly-created server. Defaults to the spec's `info.title`, or "OpenAPI Server". |
+| `version`   | `` `${number}.${number}.${number}` ``                      | Version for a newly-created server. Defaults to `"1.0.0"`.                                 |
+| `server`    | `FastMCP`                                                  | Register the generated tools onto an existing server instead of creating one.              |
+| `include`   | `(operation: OperationSummary) => boolean`                 | Only keep matching operations.                                                             |
+| `exclude`   | `(operation: OperationSummary) => boolean`                 | Drop matching operations, applied after `include`.                                         |
+| `maxTools`  | `number`                                                   | Hard cap; throws if the selected operation count exceeds it.                               |
+| `mcpNames`  | `Record<string, string>`                                   | Override the generated tool name for a given `operationId`.                                |
+| `resources` | `boolean`                                                  | Map eligible `GET`s to resources/resource templates instead of tools. Default `false`.     |
+| `baseUrl`   | `string`                                                   | Overrides the resolved `servers[0].url`.                                                   |
+| `headers`   | `Record<string, string> \| (() => Record<string, string>)` | Static or dynamically-resolved headers sent with every generated tool call.                |
+| `fetch`     | `typeof fetch`                                             | HTTP client used to execute tool calls. Defaults to the global `fetch`.                    |
 
 ## Authentication
 
@@ -84,10 +109,10 @@ await fromOpenAPI({ spec: "https://api.example.com/openapi.json", server });
 
 ## Known limitations
 
-This is a v1 scope, deliberately kept tight:
+This scope is deliberately kept tight:
 
-- **Tools only.** Every operation becomes a tool, including `GET`s — there is no resource/resource-template mapping yet.
-- **`application/json` request bodies only.** Multipart and form-urlencoded bodies are not supported.
+- **Tools by default.** Every operation becomes a tool unless you opt into [`resources: true`](#get--resources), and even then only an eligible `GET` is affected.
+- **`application/json` and `application/x-www-form-urlencoded` request bodies.** A nested object/array _value_ inside a form-urlencoded body property is JSON-stringified into a single form value rather than expanded with bracket notation (e.g. Stripe's own `metadata[key]=value` style) — correct for flat scalar properties, which cover the large majority of real-world form-encoded APIs (Stripe, Twilio), not a full form-encoding implementation. Other content types (`multipart/form-data`, `application/json-patch+json`, `application/octet-stream`, ...) are skipped, not silently turned into a tool with no way to carry its payload — `fromOpenAPI` logs one `console.warn` listing every operation it skipped this way.
 - **Common query parameter styles only.** Array query parameters are sent as repeated keys (the OpenAPI default `style: form, explode: true`). `deepObject`, `spaceDelimited`, and `pipeDelimited` are not implemented.
 - **OpenAPI 3.x only.** Swagger 2.0 documents are rejected with a clear error.
 - **No response/`outputSchema` validation.** A tool's result is the raw response body (pretty-printed if JSON), not validated against the spec's response schemas.

--- a/src/openapi/__fixtures__/benchmark-specs/sources.json
+++ b/src/openapi/__fixtures__/benchmark-specs/sources.json
@@ -6,7 +6,7 @@
       "url": "https://raw.githubusercontent.com/box/box-openapi/main/openapi.json"
     },
     "posthog.yaml": {
-      "sha256": "bf1d3c3b018ed5c8e22774c4f2452a664351e4a0d5889853526685bb55f068ea",
+      "sha256": "0d814511997cd8f975869d93b26f19abc5844d744fa44375d7974ca60281986d",
       "url": "https://app.posthog.com/api/schema/"
     },
     "slack.json": {

--- a/src/openapi/fromOpenAPI.benchmark.test.ts
+++ b/src/openapi/fromOpenAPI.benchmark.test.ts
@@ -15,7 +15,7 @@ import { fromOpenAPI } from "./fromOpenAPI.js";
 import { loadSpec } from "./loadSpec.js";
 import { generateNames } from "./naming.js";
 import { extractRoutes } from "./routes.js";
-import { SUPPORTED_BODY_CONTENT_TYPES } from "./schemas.js";
+import { buildFlatSchema, SUPPORTED_BODY_CONTENT_TYPES } from "./schemas.js";
 import { selectRoutes } from "./selection.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -51,18 +51,18 @@ const SPECS = [
   { file: "multi-file-spec/root.yaml", name: "Multi-file YAML spec" },
 ];
 
-/** A route whose only declared content type(s) this module can't flatten at all. */
-function hasUnsupportedOnlyBody(route: HttpRoute): boolean {
-  if (route.method === "get") {
-    return false;
-  }
-
-  const contentTypes = Object.keys(route.requestBody?.content ?? {});
-
-  return (
-    contentTypes.length > 0 &&
-    !contentTypes.some((ct) => SUPPORTED_BODY_CONTENT_TYPE_SET.has(ct))
-  );
+/**
+ * Whether `fromOpenAPI` skips this route entirely rather than turning it
+ * into a tool — reuses `buildFlatSchema` itself (the actual production
+ * logic) instead of re-deriving "which content types are unsupported" as a
+ * second, parallel heuristic here. A prior version of this check only
+ * looked at the declared content-type string, which drifted out of sync
+ * with `extractBodyProperties` (schemas.ts) treating a non-object body
+ * declared as form-urlencoded as unsupported too — silently over-counting
+ * `expectedToolCount` against real specs that hit that case.
+ */
+function isSkipped(route: HttpRoute): boolean {
+  return !!buildFlatSchema(route, undefined).unsupportedBodyContentType;
 }
 
 describe.each(SPECS)("fromOpenAPI benchmark: $name", ({ file }) => {
@@ -76,7 +76,7 @@ describe.each(SPECS)("fromOpenAPI benchmark: $name", ({ file }) => {
       const routes = extractRoutes(document);
       const nonDeprecated = routes.filter((route) => !route.deprecated);
       const expectedToolCount = nonDeprecated.filter(
-        (route) => !hasUnsupportedOnlyBody(route),
+        (route) => !isSkipped(route),
       ).length;
 
       // Mirrors fromOpenAPI's own internal selection/naming so a tool's name
@@ -172,7 +172,7 @@ describe.each(SPECS)("fromOpenAPI benchmark: $name", ({ file }) => {
       const specPath = path.join(FIXTURES_DIR, file);
       const { document } = await loadSpec(specPath);
       const expectedCount = extractRoutes(document).filter(
-        (route) => !route.deprecated && !hasUnsupportedOnlyBody(route),
+        (route) => !route.deprecated && !isSkipped(route),
       ).length;
 
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/openapi/fromOpenAPI.benchmark.test.ts
+++ b/src/openapi/fromOpenAPI.benchmark.test.ts
@@ -6,16 +6,23 @@ import { beforeAll, describe, expect, test, vi } from "vitest";
 
 import type { FastMCP } from "../FastMCP.js";
 import type { JsonSchemaObject } from "../jsonSchemaAdapter.js";
+import type { HttpRoute } from "./types.js";
 
 import { jsonSchemaAdapter } from "../jsonSchemaAdapter.js";
 // @ts-expect-error -- plain .mjs helper, shared with the refresh script
 import { ensureBenchmarkSpecs } from "./__fixtures__/ensureBenchmarkSpecs.mjs";
 import { fromOpenAPI } from "./fromOpenAPI.js";
 import { loadSpec } from "./loadSpec.js";
+import { generateNames } from "./naming.js";
 import { extractRoutes } from "./routes.js";
+import { SUPPORTED_BODY_CONTENT_TYPES } from "./schemas.js";
+import { selectRoutes } from "./selection.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = path.join(__dirname, "__fixtures__");
+const SUPPORTED_BODY_CONTENT_TYPE_SET = new Set<string>(
+  SUPPORTED_BODY_CONTENT_TYPES,
+);
 
 /**
  * The five large specs (~20MB combined) are fetched on demand rather than
@@ -32,7 +39,8 @@ beforeAll(async () => {
 /**
  * Real-world OpenAPI 3.x documents covering the shapes that break naive
  * converters: multi-file `$ref`s, `nullable` next to `oneOf`, recursive
- * component schemas, and specs large enough to surface naming collisions.
+ * component schemas, form-urlencoded-only request bodies (Stripe, Twilio),
+ * and specs large enough to surface naming collisions.
  */
 const SPECS = [
   { file: "benchmark-specs/petstore.json", name: "Petstore" },
@@ -43,41 +51,161 @@ const SPECS = [
   { file: "multi-file-spec/root.yaml", name: "Multi-file YAML spec" },
 ];
 
+/** A route whose only declared content type(s) this module can't flatten at all. */
+function hasUnsupportedOnlyBody(route: HttpRoute): boolean {
+  if (route.method === "get") {
+    return false;
+  }
+
+  const contentTypes = Object.keys(route.requestBody?.content ?? {});
+
+  return (
+    contentTypes.length > 0 &&
+    !contentTypes.some((ct) => SUPPORTED_BODY_CONTENT_TYPE_SET.has(ct))
+  );
+}
+
 describe.each(SPECS)("fromOpenAPI benchmark: $name", ({ file }) => {
   test(
-    "converts every non-deprecated operation into a uniquely-named tool with a well-formed JSON Schema",
+    "converts every non-deprecated, encodable operation into a uniquely-named tool with a well-formed JSON Schema — and a body-bearing one actually carries its body",
     { timeout: 60_000 },
     async () => {
       const specPath = path.join(FIXTURES_DIR, file);
 
       const { document } = await loadSpec(specPath);
-      const expectedToolCount = extractRoutes(document).filter(
-        (route) => !route.deprecated,
+      const routes = extractRoutes(document);
+      const nonDeprecated = routes.filter((route) => !route.deprecated);
+      const expectedToolCount = nonDeprecated.filter(
+        (route) => !hasUnsupportedOnlyBody(route),
       ).length;
 
-      const server = await fromOpenAPI({ maxTools: Infinity, spec: specPath });
-      const client = await connect(server);
-      const { tools } = await client.listTools();
-
-      expect(tools).toHaveLength(expectedToolCount);
-      expect(new Set(tools.map((tool) => tool.name)).size).toBe(tools.length);
+      // Mirrors fromOpenAPI's own internal selection/naming so a tool's name
+      // can be matched back to the route it came from below.
+      const selected = selectRoutes(routes, { maxTools: Infinity });
+      const names = generateNames(selected, undefined);
+      const routesByName = new Map(
+        [...names].map(([route, name]) => [name, route]),
+      );
 
       // Compiles each tool's schema through the same AJV path FastMCP uses
       // at runtime (jsonSchemaAdapter) — a malformed schema rejects here
       // instead of resolving to a validation result. AJV (strict: false,
       // matching production) logs a console.warn for every non-standard
       // `format` a real spec uses (e.g. Twilio's "phone-number", Stripe's
-      // "unix-time"/"decimal") — harmless and expected, so it's muted here
-      // rather than left to spam the test run.
+      // "unix-time"/"decimal"), and fromOpenAPI itself warns once for any
+      // operations it skipped (Box has 10, unsupported content types) —
+      // both expected and muted here rather than spamming the test run.
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
       try {
+        const server = await fromOpenAPI({
+          maxTools: Infinity,
+          spec: specPath,
+        });
+        const client = await connect(server);
+        const { tools } = await client.listTools();
+
+        expect(tools).toHaveLength(expectedToolCount);
+        expect(new Set(tools.map((tool) => tool.name)).size).toBe(tools.length);
+
         for (const tool of tools) {
           const schema = jsonSchemaAdapter(
             tool.inputSchema as JsonSchemaObject,
           );
           await expect(schema["~standard"].validate({})).resolves.toBeDefined();
+
+          // The actual regression this benchmark exists to catch: before
+          // form-urlencoded support, every Stripe/Twilio write operation
+          // silently generated a tool with zero body properties. For any
+          // non-GET tool whose route declares a body in a supported
+          // encoding with real properties, the tool's schema must have
+          // *more* properties than the route's own parameter list — i.e.
+          // the body actually contributed something. `buildFlatSchema`
+          // always contributes exactly one property per parameter
+          // occurrence regardless of collision-suffixing, so
+          // `route.parameters.length` is an exact, generic baseline.
+          const route = routesByName.get(tool.name);
+
+          if (!route || route.method === "get") {
+            continue;
+          }
+
+          const contentTypes = Object.keys(route.requestBody?.content ?? {});
+          const supportedType = contentTypes.find((ct) =>
+            SUPPORTED_BODY_CONTENT_TYPE_SET.has(ct),
+          );
+
+          if (!supportedType) {
+            continue;
+          }
+
+          const bodySchema = route.requestBody?.content?.[supportedType]
+            ?.schema as JsonSchemaObject | undefined;
+          const bodyProperties = bodySchema?.properties as
+            | Record<string, unknown>
+            | undefined;
+          const declaresProperties =
+            !!bodySchema &&
+            (bodySchema.type !== "object" ||
+              Object.keys(bodyProperties ?? {}).length > 0);
+
+          if (!declaresProperties) {
+            continue;
+          }
+
+          const toolPropertyCount = Object.keys(
+            (tool.inputSchema as JsonSchemaObject).properties ?? {},
+          ).length;
+
+          expect(toolPropertyCount).toBeGreaterThan(route.parameters.length);
         }
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
+
+  test(
+    "with resources: true, every eligible operation lands in exactly one of tools/resources/resourceTemplates",
+    { timeout: 60_000 },
+    async () => {
+      const specPath = path.join(FIXTURES_DIR, file);
+      const { document } = await loadSpec(specPath);
+      const expectedCount = extractRoutes(document).filter(
+        (route) => !route.deprecated && !hasUnsupportedOnlyBody(route),
+      ).length;
+
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const server = await fromOpenAPI({
+          maxTools: Infinity,
+          resources: true,
+          spec: specPath,
+        });
+        const client = await connect(server);
+
+        const [{ tools }, { resources }, { resourceTemplates }] =
+          await Promise.all([
+            client.listTools(),
+            hasResourcesCapability(client)
+              ? client.listResources()
+              : Promise.resolve({ resources: [] as { name: string }[] }),
+            hasResourcesCapability(client)
+              ? client.listResourceTemplates()
+              : Promise.resolve({
+                  resourceTemplates: [] as { name: string }[],
+                }),
+          ]);
+
+        const allNames = [
+          ...tools.map((t) => t.name),
+          ...resources.map((r) => r.name),
+          ...resourceTemplates.map((t) => t.name),
+        ];
+
+        expect(allNames).toHaveLength(expectedCount);
+        expect(new Set(allNames).size).toBe(allNames.length);
       } finally {
         warn.mockRestore();
       }
@@ -111,4 +239,8 @@ async function connect(server: FastMCP) {
   ]);
 
   return client;
+}
+
+function hasResourcesCapability(client: Client): boolean {
+  return !!client.getServerCapabilities()?.resources;
 }

--- a/src/openapi/fromOpenAPI.benchmark.test.ts
+++ b/src/openapi/fromOpenAPI.benchmark.test.ts
@@ -15,7 +15,11 @@ import { fromOpenAPI } from "./fromOpenAPI.js";
 import { loadSpec } from "./loadSpec.js";
 import { generateNames } from "./naming.js";
 import { extractRoutes } from "./routes.js";
-import { buildFlatSchema, SUPPORTED_BODY_CONTENT_TYPES } from "./schemas.js";
+import {
+  buildFlatSchema,
+  buildSharedDefs,
+  SUPPORTED_BODY_CONTENT_TYPES,
+} from "./schemas.js";
 import { selectRoutes } from "./selection.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -60,9 +64,16 @@ const SPECS = [
  * with `extractBodyProperties` (schemas.ts) treating a non-object body
  * declared as form-urlencoded as unsupported too — silently over-counting
  * `expectedToolCount` against real specs that hit that case.
+ *
+ * The document's real shared definitions have to be passed along, exactly
+ * as `fromOpenAPI` does: a form body declared as a `$ref` (Box's OAuth
+ * operations) is only flattenable once that reference resolves.
  */
-function isSkipped(route: HttpRoute): boolean {
-  return !!buildFlatSchema(route, undefined).unsupportedBodyContentType;
+function isSkipped(
+  route: HttpRoute,
+  sharedDefs: ReturnType<typeof buildSharedDefs>,
+): boolean {
+  return !!buildFlatSchema(route, sharedDefs).unsupportedBodyContentType;
 }
 
 describe.each(SPECS)("fromOpenAPI benchmark: $name", ({ file }) => {
@@ -73,10 +84,11 @@ describe.each(SPECS)("fromOpenAPI benchmark: $name", ({ file }) => {
       const specPath = path.join(FIXTURES_DIR, file);
 
       const { document } = await loadSpec(specPath);
+      const sharedDefs = buildSharedDefs(document);
       const routes = extractRoutes(document);
       const nonDeprecated = routes.filter((route) => !route.deprecated);
       const expectedToolCount = nonDeprecated.filter(
-        (route) => !isSkipped(route),
+        (route) => !isSkipped(route, sharedDefs),
       ).length;
 
       // Mirrors fromOpenAPI's own internal selection/naming so a tool's name
@@ -93,7 +105,7 @@ describe.each(SPECS)("fromOpenAPI benchmark: $name", ({ file }) => {
       // matching production) logs a console.warn for every non-standard
       // `format` a real spec uses (e.g. Twilio's "phone-number", Stripe's
       // "unix-time"/"decimal"), and fromOpenAPI itself warns once for any
-      // operations it skipped (Box has 10, unsupported content types) —
+      // operations it skipped (Box has 11, unsupported content types) —
       // both expected and muted here rather than spamming the test run.
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -171,8 +183,9 @@ describe.each(SPECS)("fromOpenAPI benchmark: $name", ({ file }) => {
     async () => {
       const specPath = path.join(FIXTURES_DIR, file);
       const { document } = await loadSpec(specPath);
+      const sharedDefs = buildSharedDefs(document);
       const expectedCount = extractRoutes(document).filter(
-        (route) => !route.deprecated && !isSkipped(route),
+        (route) => !route.deprecated && !isSkipped(route, sharedDefs),
       ).length;
 
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/openapi/fromOpenAPI.live.test.ts
+++ b/src/openapi/fromOpenAPI.live.test.ts
@@ -87,7 +87,13 @@ test(
         return;
       }
 
-      expect(JSON.parse(content.text)).toMatchObject({ id: 10 });
+      // Deliberately not asserting on pet 10's actual data: Petstore is a
+      // shared, publicly-writable demo, so its contents can be mutated by
+      // any other caller at any time. Valid JSON back from the real host is
+      // what proves the relative servers[0].url ("/api/v3") resolved and
+      // the request round-tripped; the payload itself isn't ours to depend
+      // on.
+      expect(() => JSON.parse(content.text)).not.toThrow();
     } finally {
       await server.stop();
     }

--- a/src/openapi/fromOpenAPI.offline.test.ts
+++ b/src/openapi/fromOpenAPI.offline.test.ts
@@ -30,6 +30,34 @@ const WIDGETS_SPEC = {
   servers: [{ url: "https://api.example.com" }],
 };
 
+const WIDGETS_READ_SPEC = {
+  info: { title: "Widgets API", version: "1.0.0" },
+  openapi: "3.0.3",
+  paths: {
+    "/widgets": {
+      get: {
+        operationId: "listWidgets",
+        responses: { 200: { description: "OK" } },
+      },
+    },
+    "/widgets/{widgetId}": {
+      get: {
+        operationId: "getWidget",
+        parameters: [
+          {
+            in: "path",
+            name: "widgetId",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { 200: { description: "OK" } },
+      },
+    },
+  },
+  servers: [{ url: "https://api.example.com" }],
+};
+
 async function connect(server: FastMCP) {
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
@@ -97,4 +125,64 @@ test("registers onto an existing server (`server` option) instead of always crea
     "createWidget",
     "ping",
   ]);
+});
+
+test("resources: true — a parameterless GET becomes a static resource, readable end-to-end", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(
+    async () => new Response(JSON.stringify({ widgets: [] })),
+  );
+
+  const server = await fromOpenAPI({
+    fetch: fetchImpl,
+    resources: true,
+    spec: WIDGETS_READ_SPEC,
+  });
+  const client = await connect(server);
+
+  const { resources } = await client.listResources();
+  expect(resources.map((r) => r.uri)).toContain(
+    "openapi://listWidgets/widgets",
+  );
+  // The spec has exactly one operation, and it became a resource — no tools
+  // capability is declared at all (not just an empty tools/list).
+  expect(client.getServerCapabilities()?.tools).toBeUndefined();
+
+  const result = await client.readResource({
+    uri: "openapi://listWidgets/widgets",
+  });
+  expect(fetchImpl).toHaveBeenCalledWith(
+    "https://api.example.com/widgets",
+    expect.objectContaining({ method: "GET" }),
+  );
+  expect(result.contents[0].mimeType).toBe("application/json");
+  expect((result.contents[0] as { text: string }).text).toContain("widgets");
+});
+
+test("resources: true — a GET with a path parameter becomes a resource template, readable end-to-end", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(
+    async () => new Response(JSON.stringify({ id: "w1", name: "sprocket" })),
+  );
+
+  const server = await fromOpenAPI({
+    fetch: fetchImpl,
+    resources: true,
+    spec: WIDGETS_READ_SPEC,
+  });
+  const client = await connect(server);
+
+  const { resourceTemplates } = await client.listResourceTemplates();
+  const template = resourceTemplates.find((t) => t.name === "getWidget");
+  expect(template?.uriTemplate).toBe("openapi://getWidget/widgets/{widgetId}");
+
+  const result = await client.readResource({
+    uri: "openapi://getWidget/widgets/w1",
+  });
+  expect(fetchImpl).toHaveBeenCalledWith(
+    "https://api.example.com/widgets/w1",
+    expect.objectContaining({ method: "GET" }),
+  );
+  expect(JSON.parse((result.contents[0] as { text: string }).text)).toEqual({
+    id: "w1",
+    name: "sprocket",
+  });
 });

--- a/src/openapi/fromOpenAPI.offline.test.ts
+++ b/src/openapi/fromOpenAPI.offline.test.ts
@@ -186,3 +186,66 @@ test("resources: true — a GET with a path parameter becomes a resource templat
     name: "sprocket",
   });
 });
+
+test("a FastAPI-style form body (`$ref` to a component schema) becomes a tool with flattened parameters that posts form-encoded", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(
+    async () => new Response(JSON.stringify({ access_token: "t" })),
+  );
+
+  const server = await fromOpenAPI({
+    fetch: fetchImpl,
+    spec: {
+      components: {
+        schemas: {
+          Body_login: {
+            properties: {
+              password: { type: "string" },
+              username: { type: "string" },
+            },
+            required: ["username", "password"],
+            type: "object",
+          },
+        },
+      },
+      info: { title: "Auth API", version: "1.0.0" },
+      openapi: "3.1.0",
+      paths: {
+        "/token": {
+          post: {
+            operationId: "login",
+            requestBody: {
+              content: {
+                "application/x-www-form-urlencoded": {
+                  schema: { $ref: "#/components/schemas/Body_login" },
+                },
+              },
+              required: true,
+            },
+            responses: { 200: { description: "OK" } },
+          },
+        },
+      },
+      servers: [{ url: "https://api.example.com" }],
+    },
+  });
+  const client = await connect(server);
+
+  const { tools } = await client.listTools();
+  expect(tools.map((tool) => tool.name)).toEqual(["login"]);
+  expect(Object.keys(tools[0].inputSchema.properties ?? {}).sort()).toEqual([
+    "password",
+    "username",
+  ]);
+
+  await client.callTool({
+    arguments: { password: "pw", username: "ann" },
+    name: "login",
+  });
+
+  const [url, init] = fetchImpl.mock.calls[0]!;
+  expect(url).toBe("https://api.example.com/token");
+  expect((init!.headers as Headers).get("content-type")).toBe(
+    "application/x-www-form-urlencoded",
+  );
+  expect(new URLSearchParams(init!.body as string).get("username")).toBe("ann");
+});

--- a/src/openapi/fromOpenAPI.ts
+++ b/src/openapi/fromOpenAPI.ts
@@ -1,16 +1,24 @@
+import type { ResourceResult } from "../FastMCP.js";
+import type { ParameterMapping } from "./schemas.js";
+import type { HttpRoute } from "./types.js";
 import type { FromOpenAPIOptions } from "./types.js";
 
 import { FastMCP } from "../FastMCP.js";
 import { jsonSchemaAdapter } from "../jsonSchemaAdapter.js";
 import { loadSpec } from "./loadSpec.js";
-import { generateToolNames } from "./naming.js";
+import { generateNames } from "./naming.js";
 import { executeRequest } from "./requestBuilder.js";
+import {
+  buildResourceMapping,
+  isEligibleForResource,
+} from "./resourceMapping.js";
 import { extractRoutes } from "./routes.js";
 import { buildFlatSchema, buildSharedDefs } from "./schemas.js";
 import { selectRoutes } from "./selection.js";
 
 /**
- * Converts an OpenAPI 3.x document into an MCP server, one tool per
+ * Converts an OpenAPI 3.x document into an MCP server, one tool (or, with
+ * `resources: true`, resource/resource template for an eligible `GET`) per
  * operation.
  *
  * See docs/openapi.md for the full option reference and known limitations.
@@ -21,7 +29,7 @@ export async function fromOpenAPI(
   const { document, origin } = await loadSpec(options.spec);
   const routes = extractRoutes(document);
   const selected = selectRoutes(routes, options);
-  const names = generateToolNames(selected, options.mcpNames);
+  const names = generateNames(selected, options.mcpNames);
   const sharedDefs = buildSharedDefs(document);
 
   const server =
@@ -31,6 +39,12 @@ export async function fromOpenAPI(
       version: options.version ?? "1.0.0",
     });
 
+  const skippedOperations: {
+    contentType: string;
+    method: string;
+    path: string;
+  }[] = [];
+
   for (const route of selected) {
     const name = names.get(route);
 
@@ -38,24 +52,57 @@ export async function fromOpenAPI(
       continue;
     }
 
-    const { flatSchema, parameterMap, wholeBodyKey } = buildFlatSchema(
+    const {
+      bodyEncoding,
+      flatSchema,
+      parameterMap,
+      unsupportedBodyContentType,
+      wholeBodyKey,
+    } = buildFlatSchema(route, sharedDefs);
+
+    const execOptions = {
+      baseUrlOverride: options.baseUrl,
+      fetchImpl: options.fetch ?? fetch,
+      headers: options.headers,
+      origin,
+      parameterMap,
       route,
-      sharedDefs,
-    );
+      servers: document.servers,
+    };
+
+    if (
+      options.resources &&
+      route.method === "get" &&
+      isEligibleForResource(route)
+    ) {
+      registerResource(
+        server,
+        route,
+        name,
+        parameterMap,
+        flatSchema.required,
+        execOptions,
+      );
+      continue;
+    }
+
+    if (unsupportedBodyContentType) {
+      skippedOperations.push({
+        contentType: unsupportedBodyContentType,
+        method: route.method,
+        path: route.path,
+      });
+      continue;
+    }
 
     server.addTool({
       description:
         route.summary ?? `${route.method.toUpperCase()} ${route.path}`,
       execute: async (args) =>
         executeRequest({
+          ...execOptions,
           args: args as Record<string, unknown>,
-          baseUrlOverride: options.baseUrl,
-          fetchImpl: options.fetch ?? fetch,
-          headers: options.headers,
-          origin,
-          parameterMap,
-          route,
-          servers: document.servers,
+          bodyEncoding,
           wholeBodyKey,
         }),
       name,
@@ -63,5 +110,70 @@ export async function fromOpenAPI(
     });
   }
 
+  if (skippedOperations.length > 0) {
+    console.warn(
+      "fromOpenAPI: skipped " +
+        `${skippedOperations.length} operation(s) with a request body content type that isn't supported yet ` +
+        "(only application/json and application/x-www-form-urlencoded are): " +
+        skippedOperations
+          .map(
+            (op) => `${op.method.toUpperCase()} ${op.path} (${op.contentType})`,
+          )
+          .join(", "),
+    );
+  }
+
   return server;
+}
+
+function registerResource(
+  server: FastMCP,
+  route: HttpRoute,
+  name: string,
+  parameterMap: Record<string, ParameterMapping>,
+  requiredKeys: string[] | undefined,
+  execOptions: Omit<
+    Parameters<typeof executeRequest>[0],
+    "args" | "bodyEncoding" | "wholeBodyKey"
+  >,
+): void {
+  const mapping = buildResourceMapping(route, name, parameterMap, requiredKeys);
+  const description = route.summary ?? `GET ${route.path}`;
+
+  if (mapping.kind === "resource") {
+    server.addResource({
+      description,
+      load: async () =>
+        wrapAsResourceResult(
+          await executeRequest({ ...execOptions, args: {} }),
+        ),
+      name,
+      uri: mapping.uri,
+    });
+
+    return;
+  }
+
+  server.addResourceTemplate({
+    arguments: mapping.args,
+    description,
+    load: async (args) =>
+      wrapAsResourceResult(
+        await executeRequest({
+          ...execOptions,
+          args: args as Record<string, unknown>,
+        }),
+      ),
+    name,
+    uriTemplate: mapping.uriTemplate,
+  });
+}
+
+function wrapAsResourceResult(text: string): ResourceResult {
+  try {
+    JSON.parse(text);
+    return { mimeType: "application/json", text };
+  } catch {
+    return { mimeType: "text/plain", text };
+  }
 }

--- a/src/openapi/fromOpenAPI.ts
+++ b/src/openapi/fromOpenAPI.ts
@@ -113,8 +113,8 @@ export async function fromOpenAPI(
   if (skippedOperations.length > 0) {
     console.warn(
       "fromOpenAPI: skipped " +
-        `${skippedOperations.length} operation(s) with a request body content type that isn't supported yet ` +
-        "(only application/json and application/x-www-form-urlencoded are): " +
+        `${skippedOperations.length} operation(s) whose request body can't be turned into tool parameters ` +
+        "(supported: application/json, or application/x-www-form-urlencoded with a flat object schema): " +
         skippedOperations
           .map(
             (op) => `${op.method.toUpperCase()} ${op.path} (${op.contentType})`,

--- a/src/openapi/naming.test.ts
+++ b/src/openapi/naming.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 
 import type { HttpRoute } from "./types.js";
 
-import { generateToolNames } from "./naming.js";
+import { generateNames } from "./naming.js";
 
 function route(overrides: Partial<HttpRoute>): HttpRoute {
   return {
@@ -16,7 +16,7 @@ function route(overrides: Partial<HttpRoute>): HttpRoute {
 }
 
 test("uses operationId, slugified", () => {
-  const names = generateToolNames(
+  const names = generateNames(
     [route({ operationId: "list Pets!" })],
     undefined,
   );
@@ -24,14 +24,14 @@ test("uses operationId, slugified", () => {
 });
 
 test("mcpNames overrides operationId", () => {
-  const names = generateToolNames([route({ operationId: "listPets" })], {
+  const names = generateNames([route({ operationId: "listPets" })], {
     listPets: "getAllPets",
   });
   expect([...names.values()]).toEqual(["getAllPets"]);
 });
 
 test("strips FastAPI-style __ suffixes from operationId", () => {
-  const names = generateToolNames(
+  const names = generateNames(
     [route({ operationId: "get_user__users__get" })],
     undefined,
   );
@@ -39,7 +39,7 @@ test("strips FastAPI-style __ suffixes from operationId", () => {
 });
 
 test("falls back to method_path when there is no operationId or summary", () => {
-  const names = generateToolNames(
+  const names = generateNames(
     [route({ method: "get", path: "/pets/{id}" })],
     undefined,
   );
@@ -52,7 +52,7 @@ test("collisions get a numeric suffix", () => {
     route({ operationId: "listPets", path: "/v2/pets" }),
     route({ operationId: "listPets", path: "/v3/pets" }),
   ];
-  const names = generateToolNames(routes, undefined);
+  const names = generateNames(routes, undefined);
   expect([...names.values()]).toEqual(["listPets", "listPets_2", "listPets_3"]);
 });
 
@@ -62,7 +62,7 @@ test("a collision is checked against the final name, not just the base — a spe
     route({ operationId: "foo_2", path: "/2" }),
     route({ operationId: "foo", path: "/3" }),
   ];
-  const names = [...generateToolNames(routes, undefined).values()];
+  const names = [...generateNames(routes, undefined).values()];
   expect(names).toEqual(["foo", "foo_2", "foo_3"]);
   expect(new Set(names).size).toBe(3);
 });
@@ -74,7 +74,7 @@ test("a collision suffix never pushes the name past 56 characters", () => {
     route({ operationId: longId, path: "/2" }),
     route({ operationId: longId, path: "/3" }),
   ];
-  const names = [...generateToolNames(routes, undefined).values()];
+  const names = [...generateNames(routes, undefined).values()];
   expect(new Set(names).size).toBe(3);
 
   for (const name of names) {

--- a/src/openapi/naming.ts
+++ b/src/openapi/naming.ts
@@ -6,7 +6,10 @@ const MAX_NAME_LENGTH = 56;
 const MAX_BASE_LENGTH = MAX_NAME_LENGTH - 5;
 
 /**
- * Generates a unique tool name per route.
+ * Generates a unique name per route — used both for tools and, when
+ * `resources: true`, for the resources/resource templates a `GET` route
+ * maps to instead. One pass over the whole selected set keeps names unique
+ * regardless of which destination a route ends up at.
  *
  * Ports the Python implementation's naming rule
  * (`server/providers/openapi/provider.py:_generate_default_name`): prefer
@@ -19,7 +22,7 @@ const MAX_BASE_LENGTH = MAX_NAME_LENGTH - 5;
  * (e.g. both "foo" and "foo_2" present) could produce two identically-named
  * tools, one of which `FastMCP.addTool` would silently drop.
  */
-export function generateToolNames(
+export function generateNames(
   routes: HttpRoute[],
   mcpNames: Record<string, string> | undefined,
 ): Map<HttpRoute, string> {

--- a/src/openapi/requestBuilder.test.ts
+++ b/src/openapi/requestBuilder.test.ts
@@ -126,6 +126,72 @@ test("a caller-supplied header overrides the generated content-type, case-insens
   expect(headers.get("content-type")).toBe("application/vnd.api+json");
 });
 
+test("a form-encoded body (bodyEncoding: 'form') is serialized with URLSearchParams and gets the right content-type", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(
+    async () => new Response("{}", { status: 200 }),
+  );
+
+  await executeRequest({
+    args: { amount: 500, description: "a widget & gear" },
+    bodyEncoding: "form",
+    fetchImpl,
+    parameterMap: {
+      amount: { in: "body", name: "amount" },
+      description: { in: "body", name: "description" },
+    },
+    route: route({ method: "post" }),
+    servers: [{ url: "https://api.example.com" }],
+  });
+
+  const [, calledInit] = fetchImpl.mock.calls[0]!;
+  const headers = calledInit!.headers as Headers;
+  expect(headers.get("content-type")).toBe("application/x-www-form-urlencoded");
+
+  const body = new URLSearchParams(calledInit!.body as string);
+  expect(body.get("amount")).toBe("500");
+  expect(body.get("description")).toBe("a widget & gear");
+});
+
+test("a caller-supplied content-type header overrides the generated form-urlencoded one", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(
+    async () => new Response("{}", { status: 200 }),
+  );
+
+  await executeRequest({
+    args: { name: "Rex" },
+    bodyEncoding: "form",
+    fetchImpl,
+    headers: { "Content-Type": "application/vnd.api+json" },
+    parameterMap: { name: { in: "body", name: "name" } },
+    route: route({ method: "post" }),
+    servers: [{ url: "https://api.example.com" }],
+  });
+
+  const [, calledInit] = fetchImpl.mock.calls[0]!;
+  expect((calledInit!.headers as Headers).get("content-type")).toBe(
+    "application/vnd.api+json",
+  );
+});
+
+test("an array-valued form body property is sent as repeated keys", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(
+    async () => new Response("{}", { status: 200 }),
+  );
+
+  await executeRequest({
+    args: { tag: ["a", "b"] },
+    bodyEncoding: "form",
+    fetchImpl,
+    parameterMap: { tag: { in: "body", name: "tag" } },
+    route: route({ method: "post" }),
+    servers: [{ url: "https://api.example.com" }],
+  });
+
+  const [, calledInit] = fetchImpl.mock.calls[0]!;
+  const body = new URLSearchParams(calledInit!.body as string);
+  expect(body.getAll("tag")).toEqual(["a", "b"]);
+});
+
 test("a non-ok response throws with the status and body surfaced", async () => {
   const fetchImpl = vi.fn(
     async () => new Response("not found", { status: 404 }),

--- a/src/openapi/requestBuilder.ts
+++ b/src/openapi/requestBuilder.ts
@@ -6,6 +6,8 @@ import { UserError } from "../FastMCP.js";
 export interface ExecuteRequestOptions {
   args: Record<string, unknown>;
   baseUrlOverride?: string;
+  /** How to serialize a request body, if `args` contains any body-mapped values. */
+  bodyEncoding?: "form" | "json";
   fetchImpl: typeof fetch;
   headers?: FromOpenAPIOptions["headers"];
   origin?: string;
@@ -81,13 +83,23 @@ export async function executeRequest(
   let body: string | undefined;
 
   if (Object.keys(bodyProps).length > 0) {
-    if (!headers.has("content-type")) {
-      headers.set("content-type", "application/json");
-    }
+    const payload = options.wholeBodyKey
+      ? bodyProps[options.wholeBodyKey]
+      : bodyProps;
 
-    body = JSON.stringify(
-      options.wholeBodyKey ? bodyProps[options.wholeBodyKey] : bodyProps,
-    );
+    if (options.bodyEncoding === "form") {
+      if (!headers.has("content-type")) {
+        headers.set("content-type", "application/x-www-form-urlencoded");
+      }
+
+      body = encodeFormBody(payload);
+    } else {
+      if (!headers.has("content-type")) {
+        headers.set("content-type", "application/json");
+      }
+
+      body = JSON.stringify(payload);
+    }
   }
 
   const response = await options.fetchImpl(url.toString(), {
@@ -155,6 +167,41 @@ export function resolveBaseUrl(
 
     return new URL(url, origin).toString().replace(/\/$/, "");
   }
+}
+
+/**
+ * Serializes a flattened body payload as `application/x-www-form-urlencoded`.
+ * Array values become repeated keys, matching the existing query-parameter
+ * convention. A nested object/array *value* is JSON-stringified into a
+ * single form value rather than expanded with bracket notation (e.g.
+ * Stripe's own `metadata[key]=value` style) — correct for the flat scalar
+ * properties that make up the overwhelming majority of real form-encoded
+ * APIs (Stripe, Twilio), not a full form-encoding implementation.
+ * `URLSearchParams` handles percent-encoding for free.
+ */
+function encodeFormBody(payload: unknown): string {
+  const params = new URLSearchParams();
+
+  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+    for (const [key, value] of Object.entries(
+      payload as Record<string, unknown>,
+    )) {
+      if (value === undefined) {
+        continue;
+      }
+
+      for (const item of Array.isArray(value) ? value : [value]) {
+        params.append(
+          key,
+          item !== null && typeof item === "object"
+            ? JSON.stringify(item)
+            : String(item),
+        );
+      }
+    }
+  }
+
+  return params.toString();
 }
 
 async function resolveHeaders(

--- a/src/openapi/resourceMapping.test.ts
+++ b/src/openapi/resourceMapping.test.ts
@@ -1,0 +1,153 @@
+import { expect, test } from "vitest";
+
+import type { HttpRoute } from "./types.js";
+
+import {
+  buildResourceMapping,
+  isEligibleForResource,
+} from "./resourceMapping.js";
+
+function route(overrides: Partial<HttpRoute>): HttpRoute {
+  return {
+    deprecated: false,
+    method: "get",
+    parameters: [],
+    path: "/pets/{petId}",
+    tags: [],
+    ...overrides,
+  };
+}
+
+test("a route with only path/query parameters is eligible", () => {
+  expect(
+    isEligibleForResource(
+      route({
+        parameters: [
+          {
+            in: "path",
+            name: "petId",
+            required: true,
+            schema: { type: "integer" },
+          },
+          { in: "query", name: "verbose", schema: { type: "boolean" } },
+        ],
+      }),
+    ),
+  ).toBe(true);
+});
+
+test("a header parameter makes a route ineligible", () => {
+  expect(
+    isEligibleForResource(
+      route({
+        parameters: [
+          { in: "header", name: "x-api-key", schema: { type: "string" } },
+        ],
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("a cookie parameter makes a route ineligible", () => {
+  expect(
+    isEligibleForResource(
+      route({
+        parameters: [
+          { in: "cookie", name: "session", schema: { type: "string" } },
+        ],
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("an array-typed query parameter makes a route ineligible", () => {
+  expect(
+    isEligibleForResource(
+      route({
+        parameters: [
+          {
+            in: "query",
+            name: "tags",
+            schema: { items: { type: "string" }, type: "array" },
+          },
+        ],
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("an empty parameterMap produces a static resource", () => {
+  const mapping = buildResourceMapping(
+    route({ path: "/pets" }),
+    "listPets",
+    {},
+    undefined,
+  );
+  expect(mapping).toEqual({ kind: "resource", uri: "openapi://listPets/pets" });
+});
+
+test("path-only parameters produce a resource template reusing the OpenAPI path verbatim", () => {
+  const mapping = buildResourceMapping(
+    route({ path: "/pets/{petId}" }),
+    "getPetById",
+    { petId: { in: "path", name: "petId" } },
+    ["petId"],
+  );
+  expect(mapping).toEqual({
+    args: [{ name: "petId", required: true }],
+    kind: "template",
+    uriTemplate: "openapi://getPetById/pets/{petId}",
+  });
+});
+
+test("query-only parameters append an RFC 6570 query-expansion segment", () => {
+  const mapping = buildResourceMapping(
+    route({ path: "/pets" }),
+    "findPets",
+    { status: { in: "query", name: "status" } },
+    undefined,
+  );
+  expect(mapping).toEqual({
+    args: [{ name: "status", required: false }],
+    kind: "template",
+    uriTemplate: "openapi://findPets/pets{?status}",
+  });
+});
+
+test("path and query parameters combine, path substitution first", () => {
+  const mapping = buildResourceMapping(
+    route({ path: "/pets/{petId}/photos" }),
+    "getPetPhotos",
+    {
+      petId: { in: "path", name: "petId" },
+      size: { in: "query", name: "size" },
+    },
+    ["petId"],
+  );
+  expect(mapping).toEqual({
+    args: [
+      { name: "petId", required: true },
+      { name: "size", required: false },
+    ],
+    kind: "template",
+    uriTemplate: "openapi://getPetPhotos/pets/{petId}/photos{?size}",
+  });
+});
+
+test("a collision-suffixed flat key rewrites the specific path variable it replaced", () => {
+  // e.g. a path param "id" colliding with a query param also named "id" —
+  // buildFlatSchema would have suffixed the path one to "id__path".
+  const mapping = buildResourceMapping(
+    route({ path: "/items/{id}" }),
+    "getItem",
+    {
+      id__path: { in: "path", name: "id" },
+      id__query: { in: "query", name: "id" },
+    },
+    ["id__path"],
+  );
+  expect(mapping.kind).toBe("template");
+  expect((mapping as { uriTemplate: string }).uriTemplate).toBe(
+    "openapi://getItem/items/{id__path}{?id__query}",
+  );
+});

--- a/src/openapi/resourceMapping.ts
+++ b/src/openapi/resourceMapping.ts
@@ -1,0 +1,85 @@
+import type { ParameterMapping } from "./schemas.js";
+import type { HttpRoute } from "./types.js";
+
+export type ResourceMapping =
+  | {
+      args: { name: string; required: boolean }[];
+      kind: "template";
+      uriTemplate: string;
+    }
+  | { kind: "resource"; uri: string };
+
+/**
+ * Builds a static resource URI, or a resource template (URI + `arguments`),
+ * for an eligible `GET` route — reusing the `parameterMap` and `required`
+ * list `buildFlatSchema` already produced for it (path-always-required,
+ * collision-suffixed flat keys) rather than re-deriving parameter
+ * flattening from scratch.
+ *
+ * OpenAPI's `{petId}` path-parameter syntax is already valid RFC 6570 simple
+ * string expansion, so the route's own path is reused verbatim except where
+ * a flat key was collision-suffixed. Query parameters are appended as an
+ * RFC 6570 query-expansion segment (`{?a,b}`), which `uri-templates`
+ * (already a FastMCP dependency — see its own resource-template dispatch in
+ * FastMCP.ts) parses and fills the same way it does path variables.
+ */
+export function buildResourceMapping(
+  route: HttpRoute,
+  name: string,
+  parameterMap: Record<string, ParameterMapping>,
+  requiredKeys: string[] | undefined,
+): ResourceMapping {
+  const entries = Object.entries(parameterMap);
+
+  if (entries.length === 0) {
+    return { kind: "resource", uri: `openapi://${name}${route.path}` };
+  }
+
+  const required = new Set(requiredKeys ?? []);
+  const args: { name: string; required: boolean }[] = [];
+  const queryKeys: string[] = [];
+  let path = route.path;
+
+  for (const [flatKey, mapping] of entries) {
+    if (mapping.in === "path") {
+      if (flatKey !== mapping.name) {
+        path = path.replace(`{${mapping.name}}`, `{${flatKey}}`);
+      }
+    } else {
+      queryKeys.push(flatKey);
+    }
+
+    args.push({ name: flatKey, required: required.has(flatKey) });
+  }
+
+  const uriTemplate =
+    `openapi://${name}${path}` +
+    (queryKeys.length > 0 ? `{?${queryKeys.join(",")}}` : "");
+
+  return { args, kind: "template", uriTemplate };
+}
+
+/**
+ * Whether a `GET` route can become an MCP resource/resource template
+ * instead of a tool, when `resources: true` is passed to `fromOpenAPI`. See
+ * docs/openapi.md "GET → resources" for the reasoning behind each carve-out:
+ *
+ * - `header`/`cookie` parameters can't be expressed in a resource URI, and
+ *   MCP resource reads have no per-call side channel for them.
+ * - An array-typed path/query parameter can't be represented consistently
+ *   between OpenAPI's query serialization (repeated keys) and RFC 6570's
+ *   array representation (comma-joined or `*`-exploded).
+ *
+ * A route failing either check falls through to the existing tool path —
+ * this only ever *removes* operations from the tool list in favor of a
+ * resource, never breaks one.
+ */
+export function isEligibleForResource(route: HttpRoute): boolean {
+  return route.parameters.every((param) => {
+    if (param.in === "header" || param.in === "cookie") {
+      return false;
+    }
+
+    return param.schema?.type !== "array";
+  });
+}

--- a/src/openapi/schemas.test.ts
+++ b/src/openapi/schemas.test.ts
@@ -240,6 +240,134 @@ test("GET never contributes a request body — fetch rejects a body on GET, so i
   expect(wholeBodyKey).toBeUndefined();
 });
 
+test("GET's body skip happens before content-type inspection: a multipart-only body on a GET is not flagged unsupported", () => {
+  const { bodyEncoding, unsupportedBodyContentType } = buildFlatSchema(
+    route({
+      method: "get",
+      requestBody: {
+        content: { "multipart/form-data": { schema: { type: "object" } } },
+      },
+    }),
+    undefined,
+  );
+
+  expect(bodyEncoding).toBeUndefined();
+  expect(unsupportedBodyContentType).toBeUndefined();
+});
+
+test("a form-urlencoded body is flattened like a JSON one, with bodyEncoding: 'form'", () => {
+  const { bodyEncoding, flatSchema, parameterMap } = buildFlatSchema(
+    route({
+      requestBody: {
+        content: {
+          "application/x-www-form-urlencoded": {
+            schema: {
+              properties: {
+                amount: { type: "integer" },
+                currency: { type: "string" },
+              },
+              required: ["amount"],
+              type: "object",
+            },
+          },
+        },
+      },
+    }),
+    undefined,
+  );
+
+  expect(bodyEncoding).toBe("form");
+  expect(flatSchema.properties).toEqual({
+    amount: { type: "integer" },
+    currency: { type: "string" },
+  });
+  expect(parameterMap.amount).toEqual({ in: "body", name: "amount" });
+  expect(flatSchema.required).toEqual(["amount"]);
+});
+
+test("application/json is preferred over form-urlencoded when a route declares both", () => {
+  const { bodyEncoding, flatSchema } = buildFlatSchema(
+    route({
+      requestBody: {
+        content: {
+          "application/json": {
+            schema: {
+              properties: { fromJson: { type: "string" } },
+              type: "object",
+            },
+          },
+          "application/x-www-form-urlencoded": {
+            schema: {
+              properties: { fromForm: { type: "string" } },
+              type: "object",
+            },
+          },
+        },
+      },
+    }),
+    undefined,
+  );
+
+  expect(bodyEncoding).toBe("json");
+  expect(flatSchema.properties).toEqual({ fromJson: { type: "string" } });
+});
+
+test("a request body declared only in an unsupported content type is signaled for skipping, not silently emptied", () => {
+  const { flatSchema, unsupportedBodyContentType } = buildFlatSchema(
+    route({
+      requestBody: {
+        content: { "multipart/form-data": { schema: { type: "object" } } },
+      },
+    }),
+    undefined,
+  );
+
+  expect(unsupportedBodyContentType).toBe("multipart/form-data");
+  expect(flatSchema.properties).toEqual({});
+});
+
+test("a requestBody with no content types at all is treated as no body, not unsupported", () => {
+  const { bodyEncoding, unsupportedBodyContentType } = buildFlatSchema(
+    route({ requestBody: { content: {} } }),
+    undefined,
+  );
+
+  expect(bodyEncoding).toBeUndefined();
+  expect(unsupportedBodyContentType).toBeUndefined();
+});
+
+test("a supported content type declared with no schema at all (an unconstrained body) is not flagged unsupported", () => {
+  const { bodyEncoding, flatSchema, unsupportedBodyContentType } =
+    buildFlatSchema(
+      route({ requestBody: { content: { "application/json": {} } } }),
+      undefined,
+    );
+
+  expect(bodyEncoding).toBe("json");
+  expect(unsupportedBodyContentType).toBeUndefined();
+  expect(flatSchema.properties).toEqual({});
+});
+
+test("a non-object form-urlencoded body is reported unsupported, since form encoding can't represent it", () => {
+  const { bodyEncoding, unsupportedBodyContentType, wholeBodyKey } =
+    buildFlatSchema(
+      route({
+        requestBody: {
+          content: {
+            "application/x-www-form-urlencoded": {
+              schema: { items: { type: "string" }, type: "array" },
+            },
+          },
+        },
+      }),
+      undefined,
+    );
+
+  expect(unsupportedBodyContentType).toBe("application/x-www-form-urlencoded");
+  expect(bodyEncoding).toBeUndefined();
+  expect(wholeBodyKey).toBeUndefined();
+});
+
 test("a body property literally named `nullable` is a field name, not the OpenAPI keyword, and survives", () => {
   const { flatSchema } = buildFlatSchema(
     route({

--- a/src/openapi/schemas.test.ts
+++ b/src/openapi/schemas.test.ts
@@ -453,3 +453,129 @@ test("`example`/`default` payloads are instance data, not schemas, and are passe
     type: "object",
   });
 });
+
+test("a form-urlencoded body declared as a `$ref` to a component object schema is resolved and flattened (FastAPI's `Body_<operation>` shape)", () => {
+  const document: BundledOpenApiDocument = {
+    components: {
+      schemas: {
+        Body_login: {
+          properties: {
+            grant_type: { $ref: "#/components/schemas/GrantType" },
+            password: { type: "string" },
+            username: { type: "string" },
+          },
+          required: ["username", "password"],
+          type: "object",
+        },
+        GrantType: { enum: ["password"], type: "string" },
+      },
+    },
+  };
+
+  const { bodyEncoding, flatSchema, parameterMap, unsupportedBodyContentType } =
+    buildFlatSchema(
+      route({
+        requestBody: {
+          content: {
+            "application/x-www-form-urlencoded": {
+              schema: { $ref: "#/components/schemas/Body_login" },
+            },
+          },
+          required: true,
+        },
+      }),
+      buildSharedDefs(document),
+    );
+
+  expect(unsupportedBodyContentType).toBeUndefined();
+  expect(bodyEncoding).toBe("form");
+  expect(Object.keys(flatSchema.properties!).sort()).toEqual([
+    "grant_type",
+    "password",
+    "username",
+  ]);
+  expect([...flatSchema.required!].sort()).toEqual(["password", "username"]);
+  expect(parameterMap.username).toEqual({ in: "body", name: "username" });
+  // A property that itself references a shared schema still travels with
+  // the tool as a filtered $defs entry, exactly as an inline body would —
+  // while the resolved body schema itself is inlined, not carried as a def.
+  expect(flatSchema.properties!.grant_type).toEqual({
+    $ref: "#/$defs/GrantType",
+  });
+  expect(flatSchema.$defs).toEqual({
+    GrantType: { enum: ["password"], type: "string" },
+  });
+});
+
+test("a form-urlencoded `$ref` is followed through an alias chain to the object it ends at", () => {
+  const document: BundledOpenApiDocument = {
+    components: {
+      schemas: {
+        Credentials: { $ref: "#/components/schemas/LoginForm" },
+        LoginForm: {
+          properties: { username: { type: "string" } },
+          type: "object",
+        },
+      },
+    },
+  };
+
+  const { bodyEncoding, flatSchema } = buildFlatSchema(
+    route({
+      requestBody: {
+        content: {
+          "application/x-www-form-urlencoded": {
+            schema: { $ref: "#/components/schemas/Credentials" },
+          },
+        },
+      },
+    }),
+    buildSharedDefs(document),
+  );
+
+  expect(bodyEncoding).toBe("form");
+  expect(flatSchema.properties).toEqual({ username: { type: "string" } });
+});
+
+test("a form-urlencoded `$ref` that resolves to a non-object schema is still reported unsupported", () => {
+  const document: BundledOpenApiDocument = {
+    components: {
+      schemas: { Ids: { items: { type: "string" }, type: "array" } },
+    },
+  };
+
+  const { bodyEncoding, unsupportedBodyContentType, wholeBodyKey } =
+    buildFlatSchema(
+      route({
+        requestBody: {
+          content: {
+            "application/x-www-form-urlencoded": {
+              schema: { $ref: "#/components/schemas/Ids" },
+            },
+          },
+        },
+      }),
+      buildSharedDefs(document),
+    );
+
+  expect(unsupportedBodyContentType).toBe("application/x-www-form-urlencoded");
+  expect(bodyEncoding).toBeUndefined();
+  expect(wholeBodyKey).toBeUndefined();
+});
+
+test("a form-urlencoded `$ref` that can't be resolved is reported unsupported rather than throwing", () => {
+  const { unsupportedBodyContentType } = buildFlatSchema(
+    route({
+      requestBody: {
+        content: {
+          "application/x-www-form-urlencoded": {
+            schema: { $ref: "#/components/schemas/Missing" },
+          },
+        },
+      },
+    }),
+    undefined,
+  );
+
+  expect(unsupportedBodyContentType).toBe("application/x-www-form-urlencoded");
+});

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -41,9 +41,12 @@ export interface FlatSchemaResult {
   flatSchema: JsonSchemaObject;
   parameterMap: Record<string, ParameterMapping>;
   /**
-   * Set when `route.requestBody` declares a body, but only in content
-   * type(s) this module doesn't support (e.g. `multipart/form-data`,
-   * `application/json-patch+json`, `application/octet-stream`). The caller
+   * Set when `route.requestBody` declares a body this module can't carry:
+   * either only in content type(s) it doesn't support (e.g.
+   * `multipart/form-data`, `application/json-patch+json`,
+   * `application/octet-stream`), or as `application/x-www-form-urlencoded`
+   * with a schema that isn't a flat object, which form encoding can't
+   * represent. Holds the content type the body was declared in. The caller
    * should not turn this route into a tool with a payload it can never
    * carry — see `fromOpenAPI.ts`.
    */
@@ -99,6 +102,7 @@ export function buildFlatSchema(
     wholeBodyKey,
   } = extractBodyProperties(
     route.method === "get" ? undefined : route.requestBody,
+    sharedDefs,
   );
 
   const properties: Record<string, OpenApiSchema> = {};
@@ -191,6 +195,16 @@ function childMode(key: string): WalkMode {
   return SCHEMA_MAP_KEYS.has(key) ? "schemaMap" : "schema";
 }
 
+function componentSchemaName(ref: string): string | undefined {
+  for (const prefix of ["#/components/schemas/", "#/$defs/"]) {
+    if (ref.startsWith(prefix)) {
+      return ref.slice(prefix.length);
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Picks the request body's content type and flattens its schema.
  *
@@ -208,13 +222,26 @@ function childMode(key: string): WalkMode {
  * "any JSON body" declaration): the content type itself is fine, there's
  * just nothing to flatten.
  *
- * A non-object body (array, bare `$ref` to a scalar/array, etc.) can't be
+ * A form-urlencoded body is very often declared as a bare `$ref` to a
+ * component schema rather than inline — FastAPI emits
+ * `#/components/schemas/Body_<operation>` for every form endpoint, and
+ * Box's OAuth token/refresh/revoke operations do the same. The document is
+ * bundled, not dereferenced (see `loadSpec.ts`), so that `$ref` is resolved
+ * here against `sharedDefs` before deciding whether the body is a flat
+ * object. Only the form path needs this: a JSON body that isn't a flat
+ * object falls back to a single whole-body property, which a `$ref`
+ * satisfies as-is.
+ *
+ * A non-object body (array, `$ref` to a scalar/array, etc.) can't be
  * form-urlencoded at all — form encoding is inherently flat key/value pairs
  * — so that combination is also reported as unsupported, rather than
  * `encodeFormBody` (requestBuilder.ts) silently sending an empty body for
  * data it has no way to represent.
  */
-function extractBodyProperties(requestBody: OpenApiRequestBody | undefined): {
+function extractBodyProperties(
+  requestBody: OpenApiRequestBody | undefined,
+  sharedDefs: Record<string, OpenApiSchema> | undefined,
+): {
   bodyEncoding?: "form" | "json";
   properties: Map<string, { required: boolean; schema: OpenApiSchema }>;
   unsupportedBodyContentType?: string;
@@ -243,15 +270,20 @@ function extractBodyProperties(requestBody: OpenApiRequestBody | undefined): {
   }
 
   const bodyEncoding: "form" | "json" = hasJson ? "json" : "form";
-  const schema = hasJson
+  const declaredSchema = hasJson
     ? content["application/json"]?.schema
     : content["application/x-www-form-urlencoded"]?.schema;
 
-  if (!schema) {
+  if (!declaredSchema) {
     // The content type is declared and supported; it just has no schema
     // (an unconstrained body) — nothing to flatten, but not unsupported.
     return { bodyEncoding, properties };
   }
+
+  const schema =
+    bodyEncoding === "form"
+      ? resolveComponentRef(declaredSchema, sharedDefs)
+      : declaredSchema;
 
   const schemaProperties = schema.properties as
     | Record<string, OpenApiSchema>
@@ -376,6 +408,36 @@ function normalizeNullable(
   }
 
   return rest;
+}
+
+/**
+ * Follows a bare `$ref` into `components.schemas` — or its rewritten
+ * `#/$defs/` form, which is what `sharedDefs` entries themselves carry —
+ * until it reaches a concrete schema. A dangling or cyclic reference is
+ * returned as-is rather than failing the whole conversion.
+ */
+function resolveComponentRef(
+  schema: OpenApiSchema,
+  sharedDefs: Record<string, OpenApiSchema> | undefined,
+): OpenApiSchema {
+  const seen = new Set<string>();
+  let current = schema;
+  let ref = current.$ref;
+
+  while (typeof ref === "string") {
+    const name = componentSchemaName(ref);
+    const target = name === undefined ? undefined : sharedDefs?.[name];
+
+    if (name === undefined || target === undefined || seen.has(name)) {
+      break;
+    }
+
+    seen.add(name);
+    current = target;
+    ref = current.$ref;
+  }
+
+  return current;
 }
 
 /**

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -26,9 +26,28 @@ const SCHEMA_MAP_KEYS = new Set([
  */
 const DATA_KEYS = new Set(["const", "default", "enum", "example", "examples"]);
 
+/**
+ * Request body content types this module knows how to flatten and encode.
+ * `application/json` wins when a route declares both.
+ */
+export const SUPPORTED_BODY_CONTENT_TYPES = [
+  "application/json",
+  "application/x-www-form-urlencoded",
+] as const;
+
 export interface FlatSchemaResult {
+  /** How the request body (if any properties were extracted) must be serialized. */
+  bodyEncoding?: "form" | "json";
   flatSchema: JsonSchemaObject;
   parameterMap: Record<string, ParameterMapping>;
+  /**
+   * Set when `route.requestBody` declares a body, but only in content
+   * type(s) this module doesn't support (e.g. `multipart/form-data`,
+   * `application/json-patch+json`, `application/octet-stream`). The caller
+   * should not turn this route into a tool with a payload it can never
+   * carry — see `fromOpenAPI.ts`.
+   */
+  unsupportedBodyContentType?: string;
   /**
    * Set when the request body's schema is not a flat object (e.g. an array,
    * or a bare non-object `$ref`) — the whole body is exposed as a single
@@ -73,7 +92,12 @@ export function buildFlatSchema(
     byName.set(param.name, list);
   }
 
-  const { properties: bodyProperties, wholeBodyKey } = extractBodyProperties(
+  const {
+    bodyEncoding,
+    properties: bodyProperties,
+    unsupportedBodyContentType,
+    wholeBodyKey,
+  } = extractBodyProperties(
     route.method === "get" ? undefined : route.requestBody,
   );
 
@@ -124,7 +148,13 @@ export function buildFlatSchema(
     flatSchema.$defs = usedDefs;
   }
 
-  return { flatSchema, parameterMap, wholeBodyKey };
+  return {
+    bodyEncoding,
+    flatSchema,
+    parameterMap,
+    unsupportedBodyContentType,
+    wholeBodyKey,
+  };
 }
 
 export function buildSharedDefs(
@@ -161,8 +191,33 @@ function childMode(key: string): WalkMode {
   return SCHEMA_MAP_KEYS.has(key) ? "schemaMap" : "schema";
 }
 
+/**
+ * Picks the request body's content type and flattens its schema.
+ *
+ * `application/json` wins if a route declares both it and
+ * `application/x-www-form-urlencoded` (a fixed preference, not declaration
+ * order — the latter isn't a reliable signal). A route whose body is only
+ * declared under a content type this module doesn't handle at all (e.g.
+ * `multipart/form-data`) reports `unsupportedBodyContentType` instead of
+ * silently returning an empty property map — that emptiness is exactly what
+ * a real Stripe/Twilio operation (both form-urlencoded-only) looked like
+ * before this function read anything but JSON, and it produced a tool with
+ * no way to carry its actual payload. A bare `content: {}` (no content
+ * types at all) still means "no body," not "unsupported" — and so does a
+ * supported content type with no `schema` at all (a legal, if unusual,
+ * "any JSON body" declaration): the content type itself is fine, there's
+ * just nothing to flatten.
+ *
+ * A non-object body (array, bare `$ref` to a scalar/array, etc.) can't be
+ * form-urlencoded at all — form encoding is inherently flat key/value pairs
+ * — so that combination is also reported as unsupported, rather than
+ * `encodeFormBody` (requestBuilder.ts) silently sending an empty body for
+ * data it has no way to represent.
+ */
 function extractBodyProperties(requestBody: OpenApiRequestBody | undefined): {
+  bodyEncoding?: "form" | "json";
   properties: Map<string, { required: boolean; schema: OpenApiSchema }>;
+  unsupportedBodyContentType?: string;
   wholeBodyKey?: string;
 } {
   const properties = new Map<
@@ -170,10 +225,32 @@ function extractBodyProperties(requestBody: OpenApiRequestBody | undefined): {
     { required: boolean; schema: OpenApiSchema }
   >();
 
-  const schema = requestBody?.content?.["application/json"]?.schema;
+  const content = requestBody?.content;
+
+  if (!content) {
+    return { properties };
+  }
+
+  const hasJson = "application/json" in content;
+  const hasForm = "application/x-www-form-urlencoded" in content;
+
+  if (!hasJson && !hasForm) {
+    const contentTypes = Object.keys(content);
+
+    return contentTypes.length > 0
+      ? { properties, unsupportedBodyContentType: contentTypes[0] }
+      : { properties };
+  }
+
+  const bodyEncoding: "form" | "json" = hasJson ? "json" : "form";
+  const schema = hasJson
+    ? content["application/json"]?.schema
+    : content["application/x-www-form-urlencoded"]?.schema;
 
   if (!schema) {
-    return { properties };
+    // The content type is declared and supported; it just has no schema
+    // (an unconstrained body) — nothing to flatten, but not unsupported.
+    return { bodyEncoding, properties };
   }
 
   const schemaProperties = schema.properties as
@@ -192,17 +269,24 @@ function extractBodyProperties(requestBody: OpenApiRequestBody | undefined): {
       });
     }
 
-    return { properties };
+    return { bodyEncoding, properties };
   }
 
-  // Non-object body (array, bare $ref to a scalar/array, etc.) — expose the
-  // whole thing as a single "body" property rather than flattening it.
+  if (bodyEncoding === "form") {
+    return {
+      properties,
+      unsupportedBodyContentType: "application/x-www-form-urlencoded",
+    };
+  }
+
+  // Non-object JSON body (array, bare $ref to a scalar/array, etc.) — expose
+  // the whole thing as a single "body" property rather than flattening it.
   properties.set("body", {
     required: requestBody?.required ?? false,
     schema,
   });
 
-  return { properties, wholeBodyKey: "body" };
+  return { bodyEncoding, properties, wholeBodyKey: "body" };
 }
 
 /**

--- a/src/openapi/types.ts
+++ b/src/openapi/types.ts
@@ -71,6 +71,16 @@ export interface FromOpenAPIOptions {
   name?: string;
 
   /**
+   * When `true`, an eligible `GET` operation becomes an MCP resource (no
+   * path/query parameters) or resource template (path and/or query
+   * parameters) instead of a tool. A `GET` with any `header`/`cookie`
+   * parameter, or any array-typed path/query parameter, stays a tool
+   * regardless — see docs/openapi.md "GET → resources".
+   * @default false
+   */
+  resources?: boolean;
+
+  /**
    * An existing `FastMCP` server to register the generated tools onto,
    * instead of creating a new one.
    */


### PR DESCRIPTION
## Summary

Two changes to `fromOpenAPI()`, both found by actually running the
benchmark suite's real specs through it rather than just schema-validating
the output:

**1. Form-urlencoded request bodies (bug fix)**

`extractBodyProperties` only ever read `content["application/json"]`. I
checked the actual specs in our own benchmark suite against that:

| Spec   | Ops with a body | `application/json` | form-urlencoded only |
|--------|-----------------:|--------------------:|----------------------:|
| Stripe | 588              | 0                    | 587                    |
| Twilio | 62               | 0                    | 62                     |
| Box    | 118              | 104                  | 3 (+10 other unsupported) |

Every Stripe and Twilio write operation was silently generated as a tool
with **zero body parameters** — no error, no warning, just an unusable
tool. The benchmark suite's assertions (tool count, unique names, "AJV
validates `{}`") didn't catch it, because an empty `properties: {}` schema
trivially passes all three.

Now:
- `application/json` and `application/x-www-form-urlencoded` bodies are
  both flattened (JSON preferred if a route declares both).
- A body declared only in a content type this module still can't handle
  (`multipart/form-data`, `application/json-patch+json`,
  `application/octet-stream`, ...) is **skipped**, not silently turned into
  a broken tool — `fromOpenAPI` logs one `console.warn` listing everything
  it skipped.
- The benchmark suite got a real regression assertion: for any non-GET tool
  whose route declares a body with real properties, the tool's schema must
  have *more* properties than the route's own parameter list. This is the
  check that should have caught the bug — it fails against the old code for
  every Stripe/Twilio operation and passes now.

**2. `resources: true` — GET → resource / resource template (new, opt-in)**

```ts
const server = await fromOpenAPI({
  spec: "https://petstore3.swagger.io/api/v3/openapi.json",
  include: (op) => op.tags.includes("pet"),
  resources: true,
});
// getPetById (GET /pet/{petId}) → resource template at
// openapi://getPetById/pet/{petId}, readable via client.readResource()
```

An eligible GET becomes a static resource (no parameters) or a resource template (path/query parameters), reusing the existing parameter-flattening and HTTP-execution logic unchanged — only the MCP primitive it's registered as differs. A GET stays a tool when it has any header/cookie parameter (can't be expressed in a resource URI) or any array-typed path/query parameter (OpenAPI's and RFC 6570's array representations don't match). No per-operation override; default is unchanged (resources defaults to false).

### Known limitations (unchanged from v1 except where noted)

* Form-urlencoded nested objects/arrays are JSON-stringified into a single value rather than expanded with bracket notation (Stripe's metadata[key]=value style) — correct for the flat scalar properties that make up the large majority of real form-encoded APIs.
* deepObject/spaceDelimited/pipeDelimited query styles, Swagger 2.0, response/outputSchema validation, and a CLI subcommand remain deferred.

### Test plan

* pnpm test — 40+ new/updated unit tests (form-urlencoded flattening, unsupported-content-type detection, form-body serialization, resource/resource-template eligibility and URI building)
* pnpm test:openapi — hardened benchmark suite passes against real Petstore/Box/Twilio/PostHog/Stripe specs + Slack rejection, confirming Stripe/Twilio operations now carry real body properties and every spec's eligible operations land in exactly one of tools/resources/resourceTemplates with no name collisions
* Live Petstore run: uploadImage (application/octet-stream) is now cleanly skipped with a warning instead of generating a broken tool
* pnpm run lint (prettier, eslint, tsc --noEmit) clean