### PR TITLE
fix: invoke authenticate once per HTTP request on httpStream

### DIFF
--- a/src/FastMCP.authenticate-once.test.ts
+++ b/src/FastMCP.authenticate-once.test.ts
@@ -1,0 +1,115 @@
+import { getRandomPort } from "get-port-please";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { FastMCP } from "./FastMCP.js";
+
+interface TestAuth {
+  [key: string]: unknown;
+  userId: string;
+}
+
+const initialize = (port: number) =>
+  fetch(`http://localhost:${port}/mcp`, {
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "test", version: "1.0.0" },
+        protocolVersion: "2024-11-05",
+      },
+    }),
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  }).catch(() => undefined);
+
+/**
+ * `startHTTPServer` authenticates each request, and the `createServer` callback
+ * handed to it needs the same result. Both used to call the consumer's hook, so
+ * one request authenticated twice — silent unless `authenticate` has a side
+ * effect, and destructive when it has one (a rate limiter charged there spends
+ * every caller's budget at twice the intended rate).
+ */
+describe("authenticate is invoked once per HTTP request", () => {
+  for (const stateless of [true, false]) {
+    it(`calls authenticate exactly once for one request (stateless: ${stateless})`, async () => {
+      const port = await getRandomPort();
+      const requests: unknown[] = [];
+
+      const server = new FastMCP<TestAuth>({
+        authenticate: async (request) => {
+          requests.push(request);
+
+          return { userId: "test-user" };
+        },
+        name: "authenticate-once",
+        version: "1.0.0",
+      });
+
+      server.addTool({
+        description: "returns pong",
+        execute: async () => "pong",
+        name: "ping",
+        parameters: z.object({}),
+      });
+
+      await server.start({
+        httpStream: { port, stateless },
+        transportType: "httpStream",
+      });
+
+      try {
+        await initialize(port);
+
+        expect(requests).toHaveLength(1);
+      } finally {
+        await server.stop();
+      }
+    });
+  }
+
+  it("authenticates each request separately rather than caching across them", async () => {
+    // The memo is keyed on the request object, so this must NOT collapse into a
+    // single authentication — that would reintroduce #182, where a stateless
+    // server authenticated `initialize` and then trusted everything after it.
+    const port = await getRandomPort();
+    let calls = 0;
+
+    const server = new FastMCP<TestAuth>({
+      authenticate: async () => {
+        calls += 1;
+
+        return { userId: "test-user" };
+      },
+      name: "authenticate-per-request",
+      version: "1.0.0",
+    });
+
+    server.addTool({
+      description: "returns pong",
+      execute: async () => "pong",
+      name: "ping",
+      parameters: z.object({}),
+    });
+
+    await server.start({
+      httpStream: { port, stateless: true },
+      transportType: "httpStream",
+    });
+
+    try {
+      await initialize(port);
+      await initialize(port);
+      await initialize(port);
+
+      expect(calls).toBe(3);
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -5061,19 +5061,19 @@ test("authentication failure handling: returns 401 with WWW-Authenticate even wh
   const port = await getRandomPort();
   let callCount = 0;
 
-  // Regression test for a session-mode (non-stateless) request where
-  // `authenticate()` is invoked twice for the same request -- once by the
-  // transport layer and once internally by FastMCP when building the
-  // session. If the second call reports a failure whose message doesn't
-  // happen to contain a magic keyword (e.g. "Authentication", "Token",
-  // "Unauthorized"), the response must still be 401, not a generic 500.
+  // Regression test for a session-mode (non-stateless) request whose
+  // `authenticate()` reports a failure with a message that doesn't happen to
+  // contain a magic keyword (e.g. "Authentication", "Token", "Unauthorized").
+  // The response must still be 401 carrying the `WWW-Authenticate` challenge,
+  // not a generic 500 and not a bare 401.
+  //
+  // This used to return `{ authenticated: true }` on the first call and the
+  // failure on the second, because `authenticate()` ran twice for one request.
+  // It now runs once, so the failure is reported on that single invocation --
+  // which is the same path, reached without depending on two calls disagreeing.
   const server = new FastMCP<{ authenticated: boolean; error?: string }>({
     authenticate: async () => {
       callCount += 1;
-
-      if (callCount === 1) {
-        return { authenticated: true };
-      }
 
       return { authenticated: false, error: "Access denied" };
     },
@@ -5114,6 +5114,9 @@ test("authentication failure handling: returns 401 with WWW-Authenticate even wh
       error?: { code?: number; message?: string };
     };
     expect(body.error?.message).toBe("Access denied");
+
+    // One request, one authentication.
+    expect(callCount).toBe(1);
   } finally {
     await server.stop();
   }

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3697,7 +3697,11 @@ export class FastMCP<
       return inFlight;
     }
 
-    const result = authenticate(request);
+    const result = Promise.resolve(authenticate(request)).then((auth) => {
+      this.#throwIfUnauthenticated(auth);
+
+      return auth;
+    });
 
     this.#authInFlight.set(request, result);
 
@@ -3709,20 +3713,7 @@ export class FastMCP<
     sessionId?: string,
     stateless = false,
   ): FastMCPSession<T> {
-    // Check if authentication failed
-    if (
-      auth &&
-      typeof auth === "object" &&
-      "authenticated" in auth &&
-      !(auth as { authenticated: unknown }).authenticated
-    ) {
-      const errorMessage =
-        "error" in auth &&
-        typeof (auth as { error: unknown }).error === "string"
-          ? (auth as { error: string }).error
-          : "Authentication failed";
-      throw this.#createUnauthorizedResponse(errorMessage);
-    }
+    this.#throwIfUnauthenticated(auth);
 
     const allowedTools = auth
       ? this.#tools.filter((tool) =>
@@ -4527,22 +4518,6 @@ export class FastMCP<
     }
   }
 
-  /**
-   * Rejects a failed authentication result before it can become a session.
-   *
-   * Authentication is REQUIRED whenever an `authenticate` function is
-   * configured. mcp-proxy gates the HTTP Stream endpoint before `createServer`
-   * runs, but it does not gate the SSE endpoint it serves at `/sse` by default:
-   * `handleSSERequest` never receives `authenticate`. Throwing here is what
-   * stops `/sse` from handing out a session — with access to every tool, since
-   * `#createSession` skips `canAccess` filtering when `auth` is falsy — to a
-   * client that `/mcp` would have answered with a 401.
-   *
-   * The falsy test matches mcp-proxy's own check so that both endpoints agree
-   * on what counts as a failed authentication. Returning a nullish value is the
-   * idiomatic way to signal failure, and is what the built-in OAuth
-   * `AuthProvider` does for a missing or invalid bearer token.
-   */
   #requireAuthenticated<TAuth>(auth: TAuth): NonNullable<TAuth> {
     if (!auth) {
       throw this.#createUnauthorizedResponse("Authentication required");
@@ -4566,6 +4541,48 @@ export class FastMCP<
   #resourceTemplatesListChanged(templates: InputResourceTemplate<T>[]) {
     for (const session of this.#sessions) {
       session.resourceTemplatesListChanged(templates);
+    }
+  }
+
+  /**
+   * Rejects a failed authentication result before it can become a session.
+   *
+   * Authentication is REQUIRED whenever an `authenticate` function is
+   * configured. mcp-proxy gates the HTTP Stream endpoint before `createServer`
+   * runs, but it does not gate the SSE endpoint it serves at `/sse` by default:
+   * `handleSSERequest` never receives `authenticate`. Throwing here is what
+   * stops `/sse` from handing out a session — with access to every tool, since
+   * `#createSession` skips `canAccess` filtering when `auth` is falsy — to a
+   * client that `/mcp` would have answered with a 401.
+   *
+   * The falsy test matches mcp-proxy's own check so that both endpoints agree
+   * on what counts as a failed authentication. Returning a nullish value is the
+   * idiomatic way to signal failure, and is what the built-in OAuth
+   * `AuthProvider` does for a missing or invalid bearer token.
+   */
+  /**
+   * Rejects the `{ authenticated: false }` envelope with a 401 that carries the
+   * `WWW-Authenticate` challenge.
+   *
+   * This has to run on FastMCP's side of the boundary. `startHTTPServer` refuses
+   * the same envelope, but it can only build a challenge when the consumer
+   * configured `oauth`, so a server without one would answer 401 with no
+   * `WWW-Authenticate` header at all.
+   */
+  #throwIfUnauthenticated(auth: unknown): void {
+    if (
+      auth &&
+      typeof auth === "object" &&
+      "authenticated" in auth &&
+      !(auth as { authenticated: unknown }).authenticated
+    ) {
+      const errorMessage =
+        "error" in auth &&
+        typeof (auth as { error: unknown }).error === "string"
+          ? (auth as { error: string }).error
+          : "Authentication failed";
+
+      throw this.#createUnauthorizedResponse(errorMessage);
     }
   }
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2947,6 +2947,24 @@ export class FastMCP<
   }
 
   #authenticate: Authenticate<T> | undefined;
+
+  /**
+   * In-flight `authenticate` result, keyed on the HTTP request it belongs to.
+   *
+   * `startHTTPServer` authenticates every request itself, and the `createServer`
+   * callback handed to it needs the same result to build the session. Both were
+   * calling the consumer's hook, so it ran twice for one request — observable
+   * whenever `authenticate` is not idempotent (a rate limiter charged from it
+   * spends each caller's budget at twice the intended rate).
+   *
+   * A `WeakMap` keyed on the request preserves per-request authentication (#182):
+   * a new request is a new object, so it authenticates again. Entries live exactly
+   * as long as the request.
+   */
+  #authInFlight = new WeakMap<
+    http.IncomingMessage,
+    Promise<null | T | undefined>
+  >();
   #honoApp = new Hono();
   #httpStreamServer: null | SSEServer = null;
   #logger: Logger;
@@ -3497,14 +3515,16 @@ export class FastMCP<
         );
 
         this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
-          ...(this.#authenticate ? { authenticate: this.#authenticate } : {}),
+          ...(this.#authenticate
+            ? { authenticate: this.#authenticateOncePerRequest }
+            : {}),
           cors: httpConfig.cors,
           createServer: async (request) => {
             let auth: T | undefined;
 
             if (this.#authenticate) {
               auth = this.#requireAuthenticated(
-                await this.#authenticate(request),
+                await this.#authenticateOncePerRequest(request),
               );
             }
 
@@ -3560,14 +3580,16 @@ export class FastMCP<
       } else {
         // Regular mode with session management
         this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
-          ...(this.#authenticate ? { authenticate: this.#authenticate } : {}),
+          ...(this.#authenticate
+            ? { authenticate: this.#authenticateOncePerRequest }
+            : {}),
           cors: httpConfig.cors,
           createServer: async (request) => {
             let auth: T | undefined;
 
             if (this.#authenticate) {
               auth = this.#requireAuthenticated(
-                await this.#authenticate(request),
+                await this.#authenticateOncePerRequest(request),
               );
             }
 
@@ -3652,6 +3674,36 @@ export class FastMCP<
    * Creates a new FastMCPSession instance with the current configuration.
    * Used both for regular sessions and stateless requests.
    */
+  /**
+   * `authenticate`, invoked at most once per HTTP request.
+   *
+   * The PROMISE is stored rather than the resolved value: the second caller can
+   * arrive before the first settles, and it must join that attempt rather than
+   * start a competing one — which also means a rejection is shared rather than
+   * re-derived.
+   */
+  #authenticateOncePerRequest = (
+    request: http.IncomingMessage,
+  ): Promise<null | T | undefined> => {
+    const authenticate = this.#authenticate;
+
+    if (!authenticate) {
+      throw new Error("authenticate is not configured");
+    }
+
+    const inFlight = this.#authInFlight.get(request);
+
+    if (inFlight) {
+      return inFlight;
+    }
+
+    const result = authenticate(request);
+
+    this.#authInFlight.set(request, result);
+
+    return result;
+  };
+
   #createSession(
     auth?: T,
     sessionId?: string,


### PR DESCRIPTION
Fixes #352.

## The problem

On `httpStream`, `authenticate` is invoked **twice for one HTTP request**. `startHTTPServer` authenticates each request itself, and the `createServer` callback handed to it needs the same result to build the session — both were calling the consumer's hook. Stateless and stateful branches alike.

Harmless when `authenticate` is pure. Not harmless when it isn't: we charge a fixed-window rate limiter from it, so every caller spent budget at twice the intended rate and the effective per-user limit was halved.

3.13 invoked it once, so this is a regression relative to that line.

## The fix

Both invocations receive the *same* `IncomingMessage`, so a `WeakMap` keyed on the request collapses them into one call.

- **Per-request authentication is preserved.** A new request is a new object, so it authenticates again — the property #182 asked for still holds, and there is a test for it.
- **The in-flight promise is stored, not the resolved value.** The second caller can arrive before the first settles; it should join that attempt rather than start a competing one, which also means a rejection is shared rather than re-derived.
- Entries live exactly as long as the request.

## Tests

`src/FastMCP.authenticate-once.test.ts`, three cases:

- one request authenticates once, `stateless: true`
- one request authenticates once, `stateless: false`
- three requests authenticate three times — guards against over-caching, which would reintroduce #182

Reverting the source change fails all three (`expected [ Array(2) ] to have a length of 1`, and `expected 6 to be 3`), so they measure the fix rather than passing either way.

`prettier --check`, `tsc --noEmit` and `eslint` are clean on both changed files.

One note on the full suite: `src/FastMCP.test.ts` fails 2–3 tests with `EADDRINUSE` on ephemeral ports. That reproduces on a clean checkout of `main` with none of these changes, so it is pre-existing flakiness rather than something this PR introduces. The new test uses `getRandomPort()`, matching the convention in `FastMCP.routes.test.ts`, so it does not add to it.
