### PR TITLE
fix(auth): cancel CIMD response body on early-return paths

### DIFF
--- a/src/auth/utils/cimd.test.ts
+++ b/src/auth/utils/cimd.test.ts
@@ -163,6 +163,63 @@ describe("resolveCimdClient", () => {
     expect(client).toBeNull();
   });
 
+  it("cancels the response body on a non-2xx response", async () => {
+    let cancelled = false;
+    const body = new ReadableStream({
+      cancel() {
+        cancelled = true;
+      },
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode("ignored"));
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 404 })),
+    );
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+
+    expect(client).toBeNull();
+    // Node will not free the socket until the unread body is cancelled.
+    expect(cancelled).toBe(true);
+  });
+
+  it("cancels the response body when rejecting via Content-Length", async () => {
+    let cancelled = false;
+    const body = new ReadableStream({
+      cancel() {
+        cancelled = true;
+      },
+      pull() {
+        throw new Error("body should not be read");
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, {
+            headers: { "content-length": "999999" },
+            status: 200,
+          }),
+      ),
+    );
+
+    const client = await resolveCimdClient(
+      CLIENT_ID,
+      REDIRECT_URI,
+      alwaysAllow,
+    );
+
+    expect(client).toBeNull();
+    expect(cancelled).toBe(true);
+  });
+
   it("rejects a response body that is not valid JSON", async () => {
     mockFetchOnce("not json");
 

--- a/src/auth/utils/cimd.ts
+++ b/src/auth/utils/cimd.ts
@@ -6,8 +6,9 @@
  * of requiring a prior POST /oauth/register call.
  */
 
-import { cancelResponseBody } from "../../cancelResponseBody.js";
 import type { DCRClientMetadata, ProxyDCRClient } from "../types.js";
+
+import { cancelResponseBody } from "../../cancelResponseBody.js";
 
 const CIMD_FETCH_TIMEOUT_MS = 5000;
 

--- a/src/auth/utils/cimd.ts
+++ b/src/auth/utils/cimd.ts
@@ -6,6 +6,7 @@
  * of requiring a prior POST /oauth/register call.
  */
 
+import { cancelResponseBody } from "../../cancelResponseBody.js";
 import type { DCRClientMetadata, ProxyDCRClient } from "../types.js";
 
 const CIMD_FETCH_TIMEOUT_MS = 5000;
@@ -72,6 +73,7 @@ export async function resolveCimdClient(
   }
 
   if (!response.ok) {
+    await cancelResponseBody(response);
     return null;
   }
 
@@ -258,6 +260,7 @@ async function readBoundedText(response: Response): Promise<null | string> {
   const contentLength = response.headers.get("content-length");
 
   if (contentLength && Number(contentLength) > CIMD_MAX_RESPONSE_BYTES) {
+    await cancelResponseBody(response);
     return null;
   }
 


### PR DESCRIPTION
## Summary

`src/auth/utils/cimd.ts` leaked the `fetch` response body on two early-return paths — it was the only fetch site in the repo not calling `cancelResponseBody`, and didn't import it:
- `if (!response.ok) { return null; }` — returned without consuming/cancelling `response.body`.
- `readBoundedText` `if (contentLength && Number(contentLength) > CIMD_MAX_RESPONSE_BYTES) { return null; }` — returned before the body reader is created; body never cancelled.

Per `src/cancelResponseBody.ts`, Node won't free the socket until the body is consumed/cancelled, so a stream of failing CIMD lookups (reachable from the OAuth token/authorize endpoints via `resolveCimdClient()` for an HTTPS `client_id`, SEP-991) strands one socket each. Every other fetch site already guards this way (`DiscoveryDocumentCache.ts`, `FastMCP.ts` imageContent/audioContent).

Fix: `await cancelResponseBody(response)` before each early `return null`, matching the sibling convention.

## Tests

Two tests in `cimd.test.ts` with a `ReadableStream` body whose `cancel()` sets a flag: a non-2xx response and an over-`Content-Length` response both assert `resolveCimdClient` returns `null` and `body.cancel` was called. RED before, GREEN after. Full auth suite 315 pass; `tsc`/prettier clean.
