### PR TITLE
fix(http): authenticate once per httpStream request

### DIFF
--- a/src/FastMCP.httpstream-auth-once.test.ts
+++ b/src/FastMCP.httpstream-auth-once.test.ts
@@ -1,0 +1,115 @@
+import type http from "http";
+
+import { getRandomPort } from "get-port-please";
+import { expect, test, vi } from "vitest";
+import { z } from "zod";
+
+import { FastMCP } from "./FastMCP.js";
+
+/**
+ * On `httpStream`, FastMCP passes `authenticate` to mcp-proxy (which calls it
+ * once per request to gate the 401) AND re-calls it inside its own
+ * `createServer` callback to obtain the auth for the session. Both calls
+ * receive the identical `IncomingMessage`, so a single HTTP request was
+ * authenticated twice — a regression from 3.13 that halves the effective
+ * rate-limit budget of any non-idempotent `authenticate`.
+ *
+ * Reported by @aaronik in #352. A per-request memo keyed on the request object
+ * must collapse the two calls into exactly one real invocation while keeping
+ * per-request authentication (a new request is a new object).
+ */
+
+type Session = { userId: string };
+
+const initialize = (port: number, path = "/mcp") =>
+  fetch(`http://localhost:${port}${path}`, {
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        capabilities: {},
+        clientInfo: { name: "repro", version: "1.0.0" },
+        protocolVersion: "2024-11-05",
+      },
+    }),
+    headers: {
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+
+const startServer = async (
+  authenticate: (request: http.IncomingMessage) => Promise<Session>,
+  port: number,
+  stateless: boolean,
+) => {
+  const server = new FastMCP<Session>({
+    authenticate,
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  server.addTool({
+    description: "returns pong",
+    execute: async () => "pong",
+    name: "ping",
+    parameters: z.object({}),
+  });
+
+  await server.start({
+    httpStream: { port, stateless },
+    transportType: "httpStream",
+  });
+
+  return server;
+};
+
+for (const stateless of [true, false]) {
+  test(`authenticate runs exactly once per httpStream request (stateless: ${stateless})`, async () => {
+    const port = await getRandomPort();
+    const seen: http.IncomingMessage[] = [];
+    const authenticate = vi.fn(async (request: http.IncomingMessage) => {
+      seen.push(request);
+
+      return { userId: "repro" };
+    });
+    const server = await startServer(authenticate, port, stateless);
+
+    try {
+      const response = await initialize(port);
+      await response.text().catch(() => undefined);
+
+      // One HTTP request => one real authenticate invocation.
+      expect(authenticate).toHaveBeenCalledTimes(1);
+
+      // Any invocations that did happen were for the very same request object,
+      // proving this is one request authenticated once — not two requests.
+      for (const request of seen) {
+        expect(request).toBe(seen[0]);
+      }
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test(`authenticate runs once per request across distinct requests (stateless: ${stateless})`, async () => {
+    // The memo must be per-request, not per-server: two separate requests are
+    // two invocations, so per-request auth (and its rate-limiting side effects)
+    // is preserved.
+    const port = await getRandomPort();
+    const authenticate = vi.fn(async () => ({ userId: "repro" }));
+    const server = await startServer(authenticate, port, stateless);
+
+    try {
+      for (const response of [await initialize(port), await initialize(port)]) {
+        await response.text().catch(() => undefined);
+      }
+
+      expect(authenticate).toHaveBeenCalledTimes(2);
+    } finally {
+      await server.stop();
+    }
+  });
+}

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -5075,6 +5075,7 @@ test("authentication failure handling: returns 401 with WWW-Authenticate even wh
     oauth: {
       enabled: true,
       protectedResource: {
+        authorizationServers: ["https://auth.example.com"],
         resource: "mcp://test-server",
       },
     },

--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -5059,25 +5059,25 @@ test("authentication failure handling: should not create session for authenticat
 // See https://github.com/punkpeye/fastmcp/issues/180
 test("authentication failure handling: returns 401 with WWW-Authenticate even when the error message has no auth-related keywords", async () => {
   const port = await getRandomPort();
-  let callCount = 0;
 
-  // Regression test for a session-mode (non-stateless) request where
-  // `authenticate()` is invoked twice for the same request -- once by the
-  // transport layer and once internally by FastMCP when building the
-  // session. If the second call reports a failure whose message doesn't
-  // happen to contain a magic keyword (e.g. "Authentication", "Token",
-  // "Unauthorized"), the response must still be 401, not a generic 500.
+  // Regression test: an `authenticate()` that reports failure as
+  // `{ authenticated: false, error }` must yield a 401 (never a generic 500)
+  // whose message is surfaced verbatim, even when it contains none of the
+  // keywords (e.g. "Authentication", "Token", "Unauthorized") that
+  // transport-layer heuristics look for. mcp-proxy's per-request gate rejects
+  // the failure before the session is built, and with a protected-resource
+  // configured it emits the RFC 9728 `WWW-Authenticate: Bearer` challenge.
   const server = new FastMCP<{ authenticated: boolean; error?: string }>({
     authenticate: async () => {
-      callCount += 1;
-
-      if (callCount === 1) {
-        return { authenticated: true };
-      }
-
       return { authenticated: false, error: "Access denied" };
     },
     name: "Test server",
+    oauth: {
+      enabled: true,
+      protectedResource: {
+        resource: "mcp://test-server",
+      },
+    },
     version: "1.0.0",
   });
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3496,16 +3496,21 @@ export class FastMCP<
           `[FastMCP info] Starting server in stateless mode on HTTP Stream at ${protocol}://${httpConfig.host}:${httpConfig.port}${streamEndpoint}`,
         );
 
+        // Shared per-request memo: mcp-proxy's gating call and the
+        // `createServer` call below collapse into one real `authenticate`
+        // invocation per request (see `#memoizedAuthenticate`).
+        const authenticate = this.#authenticate
+          ? this.#memoizedAuthenticate()
+          : undefined;
+
         this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
-          ...(this.#authenticate ? { authenticate: this.#authenticate } : {}),
+          ...(authenticate ? { authenticate } : {}),
           cors: httpConfig.cors,
           createServer: async (request) => {
             let auth: T | undefined;
 
-            if (this.#authenticate) {
-              auth = this.#requireAuthenticated(
-                await this.#authenticate(request),
-              );
+            if (authenticate) {
+              auth = this.#requireAuthenticated(await authenticate(request));
             }
 
             // Extract session ID from headers
@@ -3559,16 +3564,21 @@ export class FastMCP<
         });
       } else {
         // Regular mode with session management
+        // Shared per-request memo: mcp-proxy's gating call and the
+        // `createServer` call below collapse into one real `authenticate`
+        // invocation per request (see `#memoizedAuthenticate`).
+        const authenticate = this.#authenticate
+          ? this.#memoizedAuthenticate()
+          : undefined;
+
         this.#httpStreamServer = await startHTTPServer<FastMCPSession<T>>({
-          ...(this.#authenticate ? { authenticate: this.#authenticate } : {}),
+          ...(authenticate ? { authenticate } : {}),
           cors: httpConfig.cors,
           createServer: async (request) => {
             let auth: T | undefined;
 
-            if (this.#authenticate) {
-              auth = this.#requireAuthenticated(
-                await this.#authenticate(request),
-              );
+            if (authenticate) {
+              auth = this.#requireAuthenticated(await authenticate(request));
             }
 
             // Extract session ID from headers
@@ -4305,6 +4315,52 @@ export class FastMCP<
       }
     }
   };
+
+  /**
+   * On `httpStream`, `authenticate` is handed to both mcp-proxy (which calls it
+   * once per request to gate the 401) and this server's own `createServer`
+   * callback (which calls it again to obtain the session auth). Both receive
+   * the identical `IncomingMessage`, so a single request would otherwise be
+   * authenticated twice — halving the effective budget of any non-idempotent
+   * `authenticate` (see #352).
+   *
+   * This wraps `#authenticate` in a per-request memo keyed on the request
+   * object, collapsing the two calls into one real invocation. The *promise* is
+   * cached (not the resolved value) so a second call that arrives before the
+   * first settles joins it rather than starting a competing attempt. Keys are
+   * the request objects themselves, so each request is authenticated exactly
+   * once, a distinct request is authenticated afresh, and entries are collected
+   * with their requests — nothing leaks across requests. A rejected or nullish
+   * result is cached as-is, so a failed authentication is never seen as a
+   * success by the second caller.
+   */
+  #memoizedAuthenticate(): Authenticate<T> {
+    const authenticate = this.#authenticate!;
+    const cache = new WeakMap<
+      http.IncomingMessage,
+      Promise<null | T | undefined>
+    >();
+
+    return (request: http.IncomingMessage) => {
+      // stdio passes `undefined`; there is nothing to key a memo on, and this
+      // path is httpStream-only anyway, so fall straight through.
+      if (!request) {
+        return authenticate(request);
+      }
+
+      const cached = cache.get(request);
+
+      if (cached) {
+        return cached;
+      }
+
+      const result = Promise.resolve(authenticate(request));
+
+      cache.set(request, result);
+
+      return result;
+    };
+  }
 
   /**
    * Converts Node.js IncomingMessage to Web Request for Hono


### PR DESCRIPTION
## Summary

Fixes #352. On `httpStream`, `authenticate` ran **twice per request**: `FastMCP` passes `authenticate: this.#authenticate` to mcp-proxy's `startHTTPServer` (called once to gate the 401) *and* re-calls `this.#authenticate(request)` inside its own `createServer` callback — both on the identical `IncomingMessage`. A 4.x regression vs 3.13 that halves the budget of any non-idempotent `authenticate` (e.g. a rate limiter). Present in both the stateless and session branches.

Fix (the reporter's suggested approach): a private `#memoizedAuthenticate()` wraps `#authenticate` in a per-request `WeakMap<IncomingMessage, Promise<result>>`, and both call sites receive the same reference, so the two invocations collapse to one real call per request. Keyed on the request object (distinct requests → distinct keys, GC'd with the request); the promise is cached so a failure stays a failure and can't be re-evaluated as success.

## Tests

New `FastMCP.httpstream-auth-once.test.ts` (counting `authenticate`, real `initialize` fetch, both `stateless` true/false): RED before (1→2 per request, 2→4 over two requests), GREEN after (4/4). Neighbours: sse-auth + session-id + session-context 15/15, and the auth-failure block 8/8. `tsc`/eslint/prettier clean.

**Note for review:** one pre-existing test (#180, "401 + WWW-Authenticate with a keyword-free message") was coupled to the double-call — its `authenticate` returned success on call #1 and failure on call #2, relying on the second call to reach `#createSession`. That double-call path never happened in production (a consistent `authenticate` was always gate-intercepted), so the old assertion validated a bug artifact. I kept all three assertions truthful via a consistent failure + an `oauth.protectedResource` config, so a keyword-free message still yields 401 + `Bearer` + the verbatim message through the real path.
