### PR TITLE
chore(openapi): re-pin box and posthog benchmark spec hashes

### DIFF
--- a/src/openapi/__fixtures__/benchmark-specs/sources.json
+++ b/src/openapi/__fixtures__/benchmark-specs/sources.json
@@ -2,11 +2,11 @@
   "_comment": "Large real-world specs for fromOpenAPI.benchmark.test.ts. Not vendored (~20MB combined); fetched on demand by the benchmark and pinned by sha256 so a run is still reproducible. Re-pin with `pnpm test:openapi:refresh` when a spec legitimately changes upstream.",
   "specs": {
     "box.json": {
-      "sha256": "e6f5854703ec94fb2a27fc67a5e12db0e00d33c04a0a8959b992c1f87b98f542",
+      "sha256": "0f8794edec1caf44761777f791b36388ec997f4220233a1a0166712e0d3b0a06",
       "url": "https://raw.githubusercontent.com/box/box-openapi/main/openapi.json"
     },
     "posthog.yaml": {
-      "sha256": "0d814511997cd8f975869d93b26f19abc5844d744fa44375d7974ca60281986d",
+      "sha256": "69274094e9e9d8291730f544c056baf0255cea23024a0cae45edfb5d929d2143",
       "url": "https://app.posthog.com/api/schema/"
     },
     "slack.json": {


### PR DESCRIPTION
`box.json` drifted upstream on 09-03, turning `OpenAPI (network)` red on every open PR. `posthog.yaml` drifted too.

Re-pinned both via `pnpm test:openapi:refresh`. `pnpm test:openapi` passes 14/14 locally (~26s).