### PR TITLE
Emit WWW-Authenticate on 401 when authenticate() fails with no OAuth config

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4671,6 +4671,7 @@ test("authentication failure handling: should throw error when auth.authenticate
       error?: { code?: number; message?: string };
     };
     expect(body.error?.message).toContain("Invalid JWT token");
+    expect(response.headers.get("WWW-Authenticate")).toContain("Bearer");
   } finally {
     await server.stop();
   }

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3367,6 +3367,35 @@ export class FastMCP<
   }
 
   /**
+   * mcp-proxy only emits `WWW-Authenticate` on 401 when `oauth` is set.
+   * Custom `authenticate()` still needs that challenge with no OAuth metadata
+   * configured (RFC 7235). Pass an empty oauth object in that case so the
+   * header is present without advertising a resource_metadata URL that 404s.
+   */
+  #httpStreamOAuthConfig(): {
+    oauth?: {
+      protectedResource?: { resource: string };
+    };
+  } {
+    const resource = this.#options.oauth?.enabled
+      ? this.#options.oauth.protectedResource?.resource
+      : undefined;
+    if (resource) {
+      return {
+        oauth: {
+          protectedResource: {
+            resource,
+          },
+        },
+      };
+    }
+    if (this.#authenticate) {
+      return { oauth: {} };
+    }
+    return {};
+  }
+
+  /**
    * Starts the server.
    */
   public async start(
@@ -3525,16 +3554,7 @@ export class FastMCP<
           enableJsonResponse: httpConfig.enableJsonResponse,
           eventStore: httpConfig.eventStore,
           host: httpConfig.host,
-          ...(this.#options.oauth?.enabled &&
-          this.#options.oauth.protectedResource?.resource
-            ? {
-                oauth: {
-                  protectedResource: {
-                    resource: this.#options.oauth.protectedResource.resource,
-                  },
-                },
-              }
-            : {}),
+          ...this.#httpStreamOAuthConfig(),
           // In stateless mode, we don't track sessions
           onClose: async () => {
             // No session tracking in stateless mode
@@ -3591,16 +3611,7 @@ export class FastMCP<
           enableJsonResponse: httpConfig.enableJsonResponse,
           eventStore: httpConfig.eventStore,
           host: httpConfig.host,
-          ...(this.#options.oauth?.enabled &&
-          this.#options.oauth.protectedResource?.resource
-            ? {
-                oauth: {
-                  protectedResource: {
-                    resource: this.#options.oauth.protectedResource.resource,
-                  },
-                },
-              }
-            : {}),
+          ...this.#httpStreamOAuthConfig(),
           onClose: async (session) => {
             const sessionIndex = this.#sessions.indexOf(session);
 

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3367,35 +3367,6 @@ export class FastMCP<
   }
 
   /**
-   * mcp-proxy only emits `WWW-Authenticate` on 401 when `oauth` is set.
-   * Custom `authenticate()` still needs that challenge with no OAuth metadata
-   * configured (RFC 7235). Pass an empty oauth object in that case so the
-   * header is present without advertising a resource_metadata URL that 404s.
-   */
-  #httpStreamOAuthConfig(): {
-    oauth?: {
-      protectedResource?: { resource: string };
-    };
-  } {
-    const resource = this.#options.oauth?.enabled
-      ? this.#options.oauth.protectedResource?.resource
-      : undefined;
-    if (resource) {
-      return {
-        oauth: {
-          protectedResource: {
-            resource,
-          },
-        },
-      };
-    }
-    if (this.#authenticate) {
-      return { oauth: {} };
-    }
-    return {};
-  }
-
-  /**
    * Starts the server.
    */
   public async start(
@@ -4326,6 +4297,35 @@ export class FastMCP<
       }
     }
   };
+
+  /**
+   * mcp-proxy only emits `WWW-Authenticate` on 401 when `oauth` is set.
+   * Custom `authenticate()` still needs that challenge with no OAuth metadata
+   * configured (RFC 7235). Pass an empty oauth object in that case so the
+   * header is present without advertising a resource_metadata URL that 404s.
+   */
+  #httpStreamOAuthConfig(): {
+    oauth?: {
+      protectedResource?: { resource: string };
+    };
+  } {
+    const resource = this.#options.oauth?.enabled
+      ? this.#options.oauth.protectedResource?.resource
+      : undefined;
+    if (resource) {
+      return {
+        oauth: {
+          protectedResource: {
+            resource,
+          },
+        },
+      };
+    }
+    if (this.#authenticate) {
+      return { oauth: {} };
+    }
+    return {};
+  }
 
   /**
    * On `httpStream`, `authenticate` is handed to both mcp-proxy (which calls it


### PR DESCRIPTION
Fixes #357

mcp-proxy's per-request gate rejects `{ authenticated: false }` before FastMCP's own 401 helper runs. It only sets `WWW-Authenticate` when an `oauth` object is passed into `startHTTPServer`.

If `authenticate` is configured and OAuth metadata is not, pass `oauth: {}` so the 401 still includes `WWW-Authenticate: Bearer`. JSON-RPC `id` stays with mcp-proxy. The existing no-OAuth auth-failure test now asserts the header.
