### PR TITLE
fix(http): preserve multiple custom route cookies

### DIFF
--- a/src/FastMCP.routes.test.ts
+++ b/src/FastMCP.routes.test.ts
@@ -340,6 +340,36 @@ test("custom routes handle HTML responses", async () => {
   });
 });
 
+test("custom routes preserve multiple Set-Cookie response fields", async () => {
+  await runWithTestServer({
+    run: async ({ port }) => {
+      const response = await fetch(`http://localhost:${port}/cookies`);
+      expect(response.status).toBe(200);
+      expect(response.headers.getSetCookie()).toEqual([
+        "session=one; Path=/; HttpOnly",
+        "preference=two; Expires=Wed, 21 Oct 2037 07:28:00 GMT; Path=/",
+      ]);
+    },
+    server: async () => {
+      const server = new FastMCP({ name: "Test", version: "1.0.0" });
+      server.getApp().get(
+        "/cookies",
+        () =>
+          new Response("ok", {
+            headers: [
+              ["Set-Cookie", "session=one; Path=/; HttpOnly"],
+              [
+                "Set-Cookie",
+                "preference=two; Expires=Wed, 21 Oct 2037 07:28:00 GMT; Path=/",
+              ],
+            ],
+          }),
+      );
+      return server;
+    },
+  });
+});
+
 test("custom routes handle errors gracefully", async () => {
   await runWithTestServer({
     run: async ({ port }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3774,8 +3774,19 @@ export class FastMCP<
         if (!res.headersSent) {
           res.statusCode = honoResponse.status;
           honoResponse.headers.forEach((value, key) => {
+            // Fetch Headers exposes Set-Cookie through getSetCookie() because
+            // combining multiple cookies with a comma changes their meaning
+            // (notably when Expires itself contains a comma). Preserve each
+            // field as a distinct Node response header below.
+            if (key.toLowerCase() === "set-cookie") {
+              return;
+            }
             res.setHeader(key, value);
           });
+          const setCookies = honoResponse.headers.getSetCookie();
+          if (setCookies.length > 0) {
+            res.setHeader("Set-Cookie", setCookies);
+          }
 
           if (honoResponse.body) {
             const reader = honoResponse.body.getReader();


### PR DESCRIPTION
## Summary

- preserve every `Set-Cookie` value returned by a custom Hono route
- avoid collapsing cookies through repeated Node `setHeader` calls
- add a regression covering two cookies with distinct attributes

Hono keeps multiple cookies separately, but iterating its headers and calling `res.setHeader("set-cookie", value)` overwrites the earlier value. This change skips that header during the generic copy and assigns Hono's complete `getSetCookie()` array once.

## Validation

- regression receives only the second cookie on the parent commit and both cookies with this change
- 23 route tests pass
- full lint, type checking and JSR publish dry-run pass
