### PR TITLE
fix(progress): route tool progress through the request-scoped notifier

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -4158,6 +4158,95 @@ test("stateless mode works correctly", async () => {
   }
 });
 
+test("reports progress notifications in stateless HTTP mode", async () => {
+  const port = await getRandomPort();
+
+  const server = new FastMCP({
+    name: "Test server",
+    version: "1.0.0",
+  });
+
+  server.addTool({
+    description: "Test tool for progress in stateless mode",
+    execute: async (args, { reportProgress }) => {
+      await reportProgress({ progress: 0, total: 100 });
+      await reportProgress({ progress: 50, total: 100 });
+      await reportProgress({ progress: 100, total: 100 });
+
+      return String(args.a + args.b);
+    },
+    name: "add",
+    parameters: z.object({
+      a: z.number(),
+      b: z.number(),
+    }),
+  });
+
+  await server.start({
+    httpStream: {
+      port,
+      stateless: true,
+    },
+    transportType: "httpStream",
+  });
+
+  try {
+    const client = new Client(
+      {
+        name: "Test client",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://localhost:${port}/mcp`),
+    );
+
+    await client.connect(transport);
+
+    const progressCalls: Array<{ progress: number; total: number }> = [];
+
+    const onProgress = vi.fn((data) => {
+      progressCalls.push(data);
+    });
+
+    // Progress notifications have no relatedRequestId to attach to unless they're
+    // sent through the request-scoped notifier, and there's no standalone SSE
+    // stream to fall back to in stateless mode, so this used to be silently dropped.
+    const result = await client.callTool(
+      {
+        arguments: { a: 5, b: 7 },
+        name: "add",
+      },
+      undefined,
+      {
+        onprogress: onProgress,
+      },
+    );
+
+    expect(result.content).toEqual([
+      {
+        text: "12",
+        type: "text",
+      },
+    ]);
+
+    expect(onProgress).toHaveBeenCalledTimes(3);
+    expect(progressCalls).toEqual([
+      { progress: 0, total: 100 },
+      { progress: 50, total: 100 },
+      { progress: 100, total: 100 },
+    ]);
+
+    await client.close();
+  } finally {
+    await server.stop();
+  }
+});
+
 test("stateless mode does not warn when client capabilities are unavailable", async () => {
   const port = await getRandomPort();
   const logger = {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2596,7 +2596,11 @@ export class FastMCPSession<
             }
 
             try {
-              await this.#server.notification({
+              // Send via the request-scoped notifier so the SDK tags the message with
+              // this call's relatedRequestId. Without it, the notification has no request
+              // to attach to and falls back to the standalone GET SSE stream — which
+              // doesn't exist for stateless HTTP transports, so it's silently dropped.
+              await extra.sendNotification({
                 method: "notifications/progress",
                 params: {
                   ...progress,


### PR DESCRIPTION
## What's wrong

`reportProgress` sends `notifications/progress` via the low-level `this.#server.notification(...)`,
with no `relatedRequestId`. Under the stateless HTTP transport (`stateless: true`), this makes every
progress update silently disappear — no error, no warning, nothing on either side.

## Root cause

The `CallToolRequestSchema` handler in `src/FastMCP.ts` receives `(request, extra)` from the SDK.
`extra.sendNotification` is pre-bound by the SDK with `{ relatedRequestId: request.id }`, specifically
so a notification sent during a tool call is written to the same stream that will carry the eventual
tool result.

`reportProgress` bypasses that and calls `this.#server.notification({...})` directly. With no
`relatedRequestId`, the SDK's transport (`webStandardStreamableHttp.js`) treats the message as a
server-initiated notification and routes it to the *standalone* SSE stream — the one a client opens
with a bare `GET /mcp` to receive messages outside of any specific request.

In stateless mode there is no standalone stream: each request is handled by a fresh transport with no
session, and a bare GET has nothing to attach to. So the SDK looks up the standalone stream, finds
nothing, and just returns — the progress notification is gone.

The final tool result isn't affected, since responses are routed by `message.id`, a separate code path
from notification routing — so the bug is invisible unless you're specifically relying on progress
updates.

## The fix

Use `extra.sendNotification(...)` instead of `this.#server.notification(...)` in `reportProgress`. The
SDK then tags the message with this call's `relatedRequestId`, so it's written to the same stream as
the tool call itself rather than the (potentially nonexistent) standalone stream.

`streamContent` has the identical pattern and likely the same bug in stateless mode, but it's out of
scope for this PR — happy to follow up if useful.

## Tests

Added `"reports progress notifications in stateless HTTP mode"`, mirroring the existing
`"stateless mode works correctly"` test: starts a stateless HTTP server, calls a tool that reports
3 progress updates, asserts the client's `onprogress` callback receives all 3.

Confirmed this is a real regression test: reverting only the `FastMCP.ts` fix (keeping the test) fails
with `expected "vi.fn()" to be called 3 times, but got 0 times` — the exact shape of the bug. With the
fix, it passes.

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check` all clean.
- Full suite: 759/760 passing. The one failure
  (`authentication failure handling: should throw error when auth.authenticated is false`) is
  pre-existing and unrelated — confirmed it fails identically with this change removed.
