### PR TITLE
fix(openapi): replace repeated path parameters

### DIFF
--- a/src/openapi/requestBuilder.test.ts
+++ b/src/openapi/requestBuilder.test.ts
@@ -106,6 +106,25 @@ test("executeRequest builds the URL, path substitution, query, headers, and JSON
   expect((calledInit!.headers as Headers).get("x-api-key")).toBe("secret");
 });
 
+test("executeRequest replaces every occurrence of a repeated path parameter", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(
+    async () => new Response("{}", { status: 200 }),
+  );
+
+  await executeRequest({
+    args: { id: "team/42" },
+    fetchImpl,
+    parameterMap: { id: { in: "path", name: "id" } },
+    route: route({ path: "/accounts/{id}/mirrors/{id}" }),
+    servers: [{ url: "https://api.example.com" }],
+  });
+
+  const [calledUrl] = fetchImpl.mock.calls[0]!;
+  expect(new URL(calledUrl).pathname).toBe(
+    "/accounts/team%2F42/mirrors/team%2F42",
+  );
+});
+
 test("a caller-supplied header overrides the generated content-type, case-insensitively", async () => {
   const fetchImpl = vi.fn<typeof fetch>(
     async () => new Response("{}", { status: 200 }),

--- a/src/openapi/requestBuilder.ts
+++ b/src/openapi/requestBuilder.ts
@@ -79,7 +79,7 @@ export async function executeRequest(
   let path = options.route.path;
 
   for (const [name, value] of Object.entries(pathParams)) {
-    path = path.replace(`{${name}}`, encodeURIComponent(value));
+    path = path.replaceAll(`{${name}}`, encodeURIComponent(value));
   }
 
   const url = new URL(baseUrl.replace(/\/$/, "") + path);


### PR DESCRIPTION
## Summary

- replace every occurrence of a repeated OpenAPI path parameter
- reuse the same encoded value for each occurrence
- add a regression covering repeated placeholders and reserved characters

The current single replacement leaves later occurrences such as `/accounts/{id}/mirrors/{id}` unresolved. Using `replaceAll` preserves the existing encoding behavior while substituting every occurrence.

## Validation

- all 20 `requestBuilder` tests pass
- type checking, ESLint and Prettier pass