### PR TITLE
fix(auth): persist DCR clients before caching

### DIFF
--- a/src/auth/OAuthProxy.cimd.test.ts
+++ b/src/auth/OAuthProxy.cimd.test.ts
@@ -14,6 +14,7 @@ import type { AuthorizationParams, UpstreamTokenSet } from "./types.js";
 
 import { OAuthProxy, OAuthProxyError } from "./OAuthProxy.js";
 import { PKCEUtils } from "./utils/pkce.js";
+import { MemoryTokenStorage } from "./utils/tokenStore.js";
 
 const CLIENT_METADATA_URL = "https://client.example.com/client-metadata.json";
 const REDIRECT_URI = "http://127.0.0.1:33418/";
@@ -210,6 +211,28 @@ describe("OAuthProxy CIMD support", () => {
     expect(clientMetadataFetches).toHaveLength(1);
 
     proxy.destroy();
+  });
+
+  it("does not cache a CIMD client when durable persistence fails", async () => {
+    const tokenStorage = new MemoryTokenStorage();
+    const proxy = new OAuthProxy({
+      ...baseConfig,
+      enableCimd: true,
+      tokenStorage,
+    });
+    const fetchMock = mockFetchRouting(clientMetadataResponse);
+    vi.spyOn(tokenStorage, "save").mockRejectedValueOnce(
+      new Error("storage unavailable"),
+    );
+
+    await expect(proxy.authorize(buildAuthParams())).rejects.toThrow(
+      "storage unavailable",
+    );
+    await expect(proxy.authorize(buildAuthParams())).resolves.toBeDefined();
+    expect(clientMetadataFetchCount(fetchMock)).toBe(2);
+
+    proxy.destroy();
+    tokenStorage.destroy();
   });
 
   it("re-reads the metadata document once the cached resolution lapses", async () => {

--- a/src/auth/OAuthProxy.storage-persistence.test.ts
+++ b/src/auth/OAuthProxy.storage-persistence.test.ts
@@ -126,6 +126,29 @@ describe("OAuthProxy TokenStorage persistence", () => {
     );
   });
 
+  it("does not cache a DCR client when persistence fails", async () => {
+    const tokenStorage = createStorage();
+    const proxy = createProxy(tokenStorage);
+    let failedKey: string | undefined;
+
+    vi.spyOn(tokenStorage, "save").mockImplementationOnce(async (key) => {
+      failedKey = key;
+      throw new Error("storage unavailable");
+    });
+
+    await expect(
+      proxy.registerClient({ redirect_uris: [CALLBACK_URL] }),
+    ).rejects.toThrow("storage unavailable");
+
+    expect(failedKey).toMatch(/^client:/);
+    const clientId = failedKey?.slice("client:".length);
+    expect(clientId).toBeTruthy();
+
+    await expect(proxy.authorize(authParams(clientId!))).rejects.toMatchObject({
+      code: "invalid_client",
+    });
+  });
+
   it("completes authorize to callback to token exchange across shared-storage instances", async () => {
     // Given separate instances that share one TokenStorage backend.
     const tokenStorage = createStorage();

--- a/src/auth/OAuthProxy.ts
+++ b/src/auth/OAuthProxy.ts
@@ -686,8 +686,8 @@ export class OAuthProxy {
       registeredAt: new Date(),
     };
 
-    this.stateStore.cacheRegisteredClient(client);
     await this.stateStore.saveRegisteredClient(client);
+    this.stateStore.cacheRegisteredClient(client);
 
     // Return RFC 7591 compliant response with proxy-issued credentials.
     const response: DCRResponse = {
@@ -1580,8 +1580,8 @@ export class OAuthProxy {
     );
 
     if (resolved) {
-      this.stateStore.cacheRegisteredClient(resolved);
       await this.stateStore.saveRegisteredClient(resolved);
+      this.stateStore.cacheRegisteredClient(resolved);
     }
 
     return resolved;


### PR DESCRIPTION
## Summary

- persist dynamically registered OAuth clients before exposing them through the in-memory cache
- apply the same ordering to Client ID Metadata Document registrations
- cover failed durable writes in both registration paths

If storage rejects a new client record today, the client is already cached and remains usable for the lifetime of the process even though registration failed. Persisting first keeps the durable store and cache consistent: failed writes leave no ghost client, while successful registrations retain the existing behavior.

## Validation

- complete lint chain: Prettier, ESLint, TypeScript and JSR dry-run
- complete test suite: 61 files, 764 tests
