### PR TITLE
fix(edge): roll back failed session initialization

### DIFF
--- a/src/edge/WebStreamableHTTPServerTransport.test.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.test.ts
@@ -269,6 +269,82 @@ describe("WebStreamableHTTPServerTransport", () => {
     expect(onsessioninitialized).toHaveBeenCalledTimes(1);
   });
 
+  it("allows initialization to retry when onsessioninitialized rejects", async () => {
+    const sessionIdGenerator = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("failed-session")
+      .mockReturnValueOnce("retry-session");
+    const onsessioninitialized = vi
+      .fn<(sessionId: string) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("session registry unavailable"))
+      .mockResolvedValueOnce();
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      onsessioninitialized,
+      sessionIdGenerator,
+    });
+    await createServer().connect(transport);
+
+    await expect(
+      transport.handleRequest(createInitializeRequest("application/json")),
+    ).rejects.toThrow("session registry unavailable");
+    expect(transport.sessionId).toBeUndefined();
+
+    const retry = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    expect(retry.status).toBe(200);
+    await retry.json();
+    expect(transport.sessionId).toBe("retry-session");
+    expect(sessionIdGenerator).toHaveBeenCalledTimes(2);
+    expect(onsessioninitialized).toHaveBeenNthCalledWith(1, "failed-session");
+    expect(onsessioninitialized).toHaveBeenNthCalledWith(2, "retry-session");
+  });
+
+  it("does not let a late initialization failure clear a newer reused session id", async () => {
+    let rejectFirstInitialization: ((reason: Error) => void) | undefined;
+    let markFirstInitializationStarted: (() => void) | undefined;
+    const firstInitializationStarted = new Promise<void>((resolve) => {
+      markFirstInitializationStarted = resolve;
+    });
+    const firstInitialization = new Promise<void>((_resolve, reject) => {
+      rejectFirstInitialization = reject;
+    });
+    const onsessioninitialized = vi
+      .fn<(sessionId: string) => Promise<void>>()
+      .mockImplementationOnce(async () => {
+        markFirstInitializationStarted?.();
+        await firstInitialization;
+      })
+      .mockResolvedValueOnce();
+    const transport = new WebStreamableHTTPServerTransport({
+      enableJsonResponse: true,
+      onsessioninitialized,
+      sessionIdGenerator: () => "reused-session",
+    });
+    await createServer().connect(transport);
+
+    const staleInitialization = transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    await firstInitializationStarted;
+    const deleted = await transport.handleRequest(
+      createDeleteRequest("reused-session"),
+    );
+    expect(deleted.status).toBe(204);
+
+    const currentInitialization = await transport.handleRequest(
+      createInitializeRequest("application/json"),
+    );
+    expect(currentInitialization.status).toBe(200);
+    await currentInitialization.json();
+    expect(transport.sessionId).toBe("reused-session");
+
+    rejectFirstInitialization?.(new Error("stale registry failure"));
+    await expect(staleInitialization).rejects.toThrow("stale registry failure");
+    expect(transport.sessionId).toBe("reused-session");
+  });
+
   it("never echoes the active session id on a rejected request", async () => {
     const transport = new WebStreamableHTTPServerTransport({
       enableJsonResponse: true,

--- a/src/edge/WebStreamableHTTPServerTransport.ts
+++ b/src/edge/WebStreamableHTTPServerTransport.ts
@@ -106,6 +106,12 @@ export class WebStreamableHTTPServerTransport implements Transport {
   private _requestToStreamMapping = new Map<RequestId, StreamId>();
 
   private _sessionClosing = false;
+  /**
+   * Identifies the initialization attempt that currently owns `sessionId`.
+   * Session ids are caller-generated and may be reused, so comparing the id
+   * alone cannot keep a late callback from rolling back a newer session.
+   */
+  private _sessionGeneration = 0;
   private _standaloneSseStreamId = "_GET_stream";
   /**
    * Whether a client has held the standalone GET stream during this session.
@@ -162,6 +168,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
     // `onclose` is the only way a handler can tell which session ended. Flag
     // the teardown instead and clear the id once `onclose` has had it.
     this._sessionClosing = true;
+    this._sessionGeneration += 1;
     try {
       await this.teardownStreams();
     } finally {
@@ -361,6 +368,7 @@ export class WebStreamableHTTPServerTransport implements Transport {
     }
 
     this._sessionClosing = true;
+    this._sessionGeneration += 1;
     const closedSessionId = this.sessionId ?? "";
     this.sessionId = undefined;
     try {
@@ -586,8 +594,26 @@ export class WebStreamableHTTPServerTransport implements Transport {
 
     // Generate or validate session ID
     if (hasInitRequest && this.sessionIdGenerator) {
-      this.sessionId = this.sessionIdGenerator();
-      await this._onsessioninitialized?.(this.sessionId);
+      const generatedSessionId = this.sessionIdGenerator();
+      const sessionGeneration = ++this._sessionGeneration;
+      this.sessionId = generatedSessionId;
+      try {
+        await this._onsessioninitialized?.(generatedSessionId);
+        if (
+          this._sessionGeneration !== sessionGeneration ||
+          this.activeSessionId !== generatedSessionId
+        ) {
+          throw new Error("Session initialization was superseded");
+        }
+      } catch (error) {
+        if (
+          this._sessionGeneration === sessionGeneration &&
+          this.sessionId === generatedSessionId
+        ) {
+          this.sessionId = undefined;
+        }
+        throw error;
+      }
     } else if (requestSessionId) {
       if (
         this.sessionIdGenerator &&


### PR DESCRIPTION
## Summary

- remove a session when its initialization request rejects
- guard rollback by initialization generation so a late failure cannot delete a newer session reusing the same ID
- cover retry after failure and the late-failure/ABA case

The edge transport currently installs a session before initialization completes. A rejected initialization therefore leaves a stale session that blocks retry. A simple unconditional delete would introduce a second race: an older rejection could delete a replacement session. Tracking the initialization generation makes cleanup precise.

## Validation

- complete lint chain: Prettier, ESLint, TypeScript and JSR dry-run
- complete test suite: 61 files, 764 tests
