### PR TITLE
fix(resources): normalize embedded() results like resources/read

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -26,6 +26,7 @@ import {
   imageContent,
   SessionError,
   type TextContent,
+  UnexpectedStateError,
   UserError,
 } from "./FastMCP.js";
 import { getTestPort } from "./getTestPort.js";
@@ -1586,6 +1587,302 @@ test("embedded resources work with complex URI template patterns", async () => {
       return server;
     },
   });
+});
+
+test("embedded resources include text when a template load() returns an array", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {},
+          name: "get_doc",
+        }),
+      ).toEqual({
+        content: [
+          {
+            resource: {
+              mimeType: "text/plain",
+              text: "doc 7",
+              uri: "doc://7",
+            },
+            type: "resource",
+          },
+        ],
+      });
+    },
+
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addResourceTemplate({
+        arguments: [
+          {
+            name: "id",
+            required: true,
+          },
+        ],
+        async load(args) {
+          return [
+            {
+              text: `doc ${args.id}`,
+            },
+          ];
+        },
+        mimeType: "text/plain",
+        name: "Doc",
+        uriTemplate: "doc://{id}",
+      });
+
+      server.addTool({
+        description: "Get a doc",
+        execute: async () => {
+          return {
+            content: [
+              {
+                resource: await server.embedded("doc://7"),
+                type: "resource",
+              },
+            ],
+          };
+        },
+        name: "get_doc",
+        parameters: z.object({}),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("embedded resources use the mimeType from a template load() result", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {},
+          name: "get_doc",
+        }),
+      ).toEqual({
+        content: [
+          {
+            resource: {
+              mimeType: "text/markdown",
+              text: "doc 7",
+              uri: "doc://7",
+            },
+            type: "resource",
+          },
+        ],
+      });
+    },
+
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addResourceTemplate({
+        arguments: [
+          {
+            name: "id",
+            required: true,
+          },
+        ],
+        async load(args) {
+          return {
+            mimeType: "text/markdown",
+            text: `doc ${args.id}`,
+          };
+        },
+        mimeType: "text/plain",
+        name: "Doc",
+        uriTemplate: "doc://{id}",
+      });
+
+      server.addTool({
+        description: "Get a doc",
+        execute: async () => {
+          return {
+            content: [
+              {
+                resource: await server.embedded("doc://7"),
+                type: "resource",
+              },
+            ],
+          };
+        },
+        name: "get_doc",
+        parameters: z.object({}),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("embedded resources use the mimeType from a direct resource load() result", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {},
+          name: "get_readme",
+        }),
+      ).toEqual({
+        content: [
+          {
+            resource: {
+              mimeType: "text/markdown",
+              text: "# Readme",
+              uri: "file:///readme",
+            },
+            type: "resource",
+          },
+        ],
+      });
+    },
+
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addResource({
+        async load() {
+          return {
+            mimeType: "text/markdown",
+            text: "# Readme",
+          };
+        },
+        mimeType: "text/plain",
+        name: "Readme",
+        uri: "file:///readme",
+      });
+
+      server.addTool({
+        description: "Get the readme",
+        execute: async () => {
+          return {
+            content: [
+              {
+                resource: await server.embedded("file:///readme"),
+                type: "resource",
+              },
+            ],
+          };
+        },
+        name: "get_readme",
+        parameters: z.object({}),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("embedded resources use the uri from a load() result", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      expect(
+        await client.callTool({
+          arguments: {},
+          name: "get_readme",
+        }),
+      ).toEqual({
+        content: [
+          {
+            resource: {
+              mimeType: "text/plain",
+              text: "# Readme",
+              uri: "file:///readme@v2",
+            },
+            type: "resource",
+          },
+        ],
+      });
+    },
+
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        version: "1.0.0",
+      });
+
+      server.addResource({
+        async load() {
+          return {
+            text: "# Readme",
+            uri: "file:///readme@v2",
+          };
+        },
+        mimeType: "text/plain",
+        name: "Readme",
+        uri: "file:///readme",
+      });
+
+      server.addTool({
+        description: "Get the readme",
+        execute: async () => {
+          return {
+            content: [
+              {
+                resource: await server.embedded("file:///readme"),
+                type: "resource",
+              },
+            ],
+          };
+        },
+        name: "get_readme",
+        parameters: z.object({}),
+      });
+
+      return server;
+    },
+  });
+});
+
+test("embedded resources throw when load() returns an empty array", async () => {
+  const server = new FastMCP({
+    name: "Test",
+    version: "1.0.0",
+  });
+
+  server.addResource({
+    async load() {
+      return [];
+    },
+    mimeType: "text/plain",
+    name: "Readme",
+    uri: "file:///readme",
+  });
+
+  server.addResourceTemplate({
+    arguments: [
+      {
+        name: "id",
+        required: true,
+      },
+    ],
+    async load() {
+      return [];
+    },
+    mimeType: "text/plain",
+    name: "Doc",
+    uriTemplate: "doc://{id}",
+  });
+
+  await expect(server.embedded("file:///readme")).rejects.toThrow(
+    UnexpectedStateError,
+  );
+
+  await expect(server.embedded("doc://7")).rejects.toThrow(
+    UnexpectedStateError,
+  );
 });
 
 test("adds prompts", async () => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -3192,9 +3192,16 @@ export class FastMCP<
       const results = Array.isArray(result) ? result : [result];
       const firstResult = results[0];
 
+      if (!firstResult) {
+        throw new UnexpectedStateError(
+          `Resource returned no contents: ${uri}`,
+          { uri },
+        );
+      }
+
       const resourceData: ResourceContent["resource"] = {
-        mimeType: directResource.mimeType,
-        uri,
+        mimeType: firstResult.mimeType ?? directResource.mimeType,
+        uri: firstResult.uri ?? uri,
       };
 
       if ("text" in firstResult) {
@@ -3220,17 +3227,27 @@ export class FastMCP<
         params as ResourceTemplateArgumentsToObject<typeof template.arguments>,
       );
 
-      const resourceData: ResourceContent["resource"] = {
-        mimeType: template.mimeType,
-        uri,
-      };
+      const results = Array.isArray(result) ? result : [result];
+      const firstResult = results[0];
 
-      if ("text" in result) {
-        resourceData.text = result.text;
+      if (!firstResult) {
+        throw new UnexpectedStateError(
+          `Resource returned no contents: ${uri}`,
+          { uri },
+        );
       }
 
-      if ("blob" in result) {
-        resourceData.blob = result.blob;
+      const resourceData: ResourceContent["resource"] = {
+        mimeType: firstResult.mimeType ?? template.mimeType,
+        uri: firstResult.uri ?? uri,
+      };
+
+      if ("text" in firstResult) {
+        resourceData.text = firstResult.text;
+      }
+
+      if ("blob" in firstResult) {
+        resourceData.blob = firstResult.blob;
       }
 
       return resourceData; // The resource we're looking for


### PR DESCRIPTION
`server.embedded()` doesn't normalise `load()` results the way the `resources/read` handler does.

When a resource template's `load()` returns an array — which the type allow n and `resources/read` handles — `embedded()` tests `"text" in result` against the array itself, so neither `text` nor `blob` is ever set. A resource with neither field isn't valid `EmbeddedResource` content, so the whole `tools/call` response fails schema validation and the caller gets `MCP error -32602: Invalid input: expected string, received undefined`, pointing at the response shape rather than the resource that caused it.

Two smaller divergences alongside it: for both direct resources and templates, `embedded()` ignores the `mimeType` and `uri` set on the load result. `resources/read` uses `result.mimeType ?? resource.mimeType` and `result.uri ?? resource.uri`.

A `load()` returning no contents previously either threw a `TypeError` (direct resources) or produced an invalid embedded resource (templates); both now fail with the same explicit error.

This normalises array results and adds the `mimeType` and `uri` fallbacks in both branches. `embedded()` was added in #86 and array-returning `load()` in #123 two weeks later; the helper was never updated for it.

Five tests, all failing on main.
