### PR TITLE
fix(openapi): replace repeated path parameters in resource templates

### DIFF
--- a/src/openapi/resourceMapping.test.ts
+++ b/src/openapi/resourceMapping.test.ts
@@ -151,3 +151,23 @@ test("a collision-suffixed flat key rewrites the specific path variable it repla
     "openapi://getItem/items/{id__path}{?id__query}",
   );
 });
+
+test("a collision-suffixed flat key rewrites every occurrence of a repeated path variable", () => {
+  // e.g. /accounts/{id}/mirrors/{id} where "id" also collides with a query
+  // param named "id" — buildFlatSchema would have suffixed the path one to
+  // "id__path". Both occurrences of {id} must be rewritten, not just the
+  // first.
+  const mapping = buildResourceMapping(
+    route({ path: "/accounts/{id}/mirrors/{id}" }),
+    "getMirror",
+    {
+      id__path: { in: "path", name: "id" },
+      id__query: { in: "query", name: "id" },
+    },
+    ["id__path"],
+  );
+  expect(mapping.kind).toBe("template");
+  expect((mapping as { uriTemplate: string }).uriTemplate).toBe(
+    "openapi://getMirror/accounts/{id__path}/mirrors/{id__path}{?id__query}",
+  );
+});

--- a/src/openapi/resourceMapping.ts
+++ b/src/openapi/resourceMapping.ts
@@ -43,7 +43,7 @@ export function buildResourceMapping(
   for (const [flatKey, mapping] of entries) {
     if (mapping.in === "path") {
       if (flatKey !== mapping.name) {
-        path = path.replace(`{${mapping.name}}`, `{${flatKey}}`);
+        path = path.replaceAll(`{${mapping.name}}`, `{${flatKey}}`);
       }
     } else {
       queryKeys.push(flatKey);


### PR DESCRIPTION
## Summary

Follow-up to #363, same bug in the resource-template path.

`buildResourceMapping` used `.replace()` to rename a collision-suffixed path parameter, so only the first occurrence of a repeated placeholder (e.g. `/accounts/{id}/mirrors/{id}`) got renamed — the second stayed as the stale, unmapped name. Switched to `.replaceAll()`, matching `requestBuilder.ts`.

## Validation

- added regression test for repeated + collision-suffixed path params
- all 10 `resourceMapping` tests pass
- full suite (764 tests), prettier, eslint, tsc all pass