### PR TITLE
fix(openapi): re-pin twilio and posthog benchmark spec hashes

### DIFF
--- a/src/openapi/__fixtures__/benchmark-specs/sources.json
+++ b/src/openapi/__fixtures__/benchmark-specs/sources.json
@@ -6,7 +6,7 @@
       "url": "https://raw.githubusercontent.com/box/box-openapi/main/openapi.json"
     },
     "posthog.yaml": {
-      "sha256": "69274094e9e9d8291730f544c056baf0255cea23024a0cae45edfb5d929d2143",
+      "sha256": "31da599e52c62f667029437d227dbf81a7f2e33eeb6effe4b7498d4b0fd3a0f3",
       "url": "https://app.posthog.com/api/schema/"
     },
     "slack.json": {
@@ -18,7 +18,7 @@
       "url": "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json"
     },
     "twilio.json": {
-      "sha256": "6b6ffccef14cd55fd6d2fd38c3fde68585e1937eead4c099a92c5efe696b882c",
+      "sha256": "170b3ccd0f891416840083d72f1795b1499b14a18d4873fd2b39f47ef84642d6",
       "url": "https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_api_v2010.json"
     }
   }


### PR DESCRIPTION
## Summary

CI's "OpenAPI (network)" check started failing: Twilio's live spec changed upstream and no longer matched its pinned hash (hard failure, unlike PostHog which is allowlisted as transiently unstable). Re-pinned both via the documented `pnpm test:openapi:refresh`.

## Validation

- `fromOpenAPI.benchmark.test.ts` + `fromOpenAPI.live.test.ts` pass (15 tests) with `OPENAPI_NETWORK=1`
- prettier passes