### PR TITLE
fix(ping): enable the documented ping default for httpStream

### DIFF
--- a/src/FastMCP.test.ts
+++ b/src/FastMCP.test.ts
@@ -2301,6 +2301,30 @@ test("session does not overlap pings when the client is slow", async () => {
   });
 });
 
+test("session enables pings by default over httpStream", async () => {
+  await runWithTestServer({
+    run: async ({ client }) => {
+      const onPing = vi.fn().mockReturnValue({});
+
+      client.setRequestHandler(PingRequestSchema, onPing);
+
+      await delay(2000);
+
+      expect(onPing.mock.calls.length).toBeGreaterThanOrEqual(1);
+    },
+    server: async () => {
+      const server = new FastMCP({
+        name: "Test",
+        ping: {
+          intervalMs: 500,
+        },
+        version: "1.0.0",
+      });
+      return server;
+    },
+  });
+});
+
 test("completes prompt arguments", async () => {
   await runWithTestServer({
     run: async ({ client }) => {

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -1449,6 +1449,8 @@ export class FastMCPSession<
    */
   #subscriptions: Set<string> = new Set();
 
+  #transportType?: "httpStream" | "stdio";
+
   #utils?: ServerOptions<T>["utils"];
 
   constructor({
@@ -1504,6 +1506,7 @@ export class FastMCPSession<
     this.#sessionId = sessionId;
     this.#stateless = stateless;
     this.#streamKeepaliveConfig = streamKeepalive;
+    this.#transportType = transportType;
     this.#needsEventLoopFlush = transportType === "httpStream";
 
     if (tools.length) {
@@ -1649,7 +1652,7 @@ export class FastMCPSession<
       }
 
       if (this.#clientCapabilities) {
-        const pingConfig = this.#getPingConfig(transport);
+        const pingConfig = this.#getPingConfig();
 
         if (pingConfig.enabled) {
           this.#pingInterval = setInterval(async () => {
@@ -1919,21 +1922,16 @@ export class FastMCPSession<
           .join(", ");
   }
 
-  #getPingConfig(transport: Transport): {
+  #getPingConfig(): {
     enabled: boolean;
     intervalMs: number;
     logLevel: LoggingLevel;
   } {
     const pingConfig = this.#pingConfig || {};
 
-    let defaultEnabled = false;
-
-    if ("type" in transport) {
-      // Enable by default for SSE and HTTP streaming
-      if (transport.type === "httpStream") {
-        defaultEnabled = true;
-      }
-    }
+    // Enabled by default for httpStream, which also serves the SSE endpoint;
+    // disabled for stdio.
+    const defaultEnabled = this.#transportType === "httpStream";
 
     return {
       enabled:


### PR DESCRIPTION
`ping.enabled` is documented as defaulting to true for HTTP Stream and false for stdio, but the httpStream default was never actually being applied.

`#getPingConfig` tries to detect httpStream with `"type" in transport && transport.type === "httpStream"`, but the SDK's `Transport` interface doesn't have a `type` field and nothing in fastmcp, mcp-proxy or the SDK sets one. So this branch is never reached and ping stays disabled by default. The existing ping tests also set `enabled` explicitly, so this wasn't covered.

`FastMCPSession` already gets the transport type and uses it for `#needsEventLoopFlush`, so I stored it and used that to determine the ping default instead of checking the transport object. SSE isn't a separate transport type here, so `transportType === "httpStream"` covers both HTTP Stream and the `/sse` endpoint.

I added a test with an httpStream server using `ping: { intervalMs: 500 }` without setting `enabled`. On main it receives no pings, while with this change it does.

This does change the default behaviour for existing httpStream users who don't configure ping — they will start sending a ping every 5s. If the documented default is not intended and ping should stay disabled unless explicitly enabled, I'm also happy to change the docs instead and keep the current runtime behaviour. The main thing I wanted to fix here is the mismatch between the documented behaviour and the actual behaviour.