### PR TITLE
fix: preserve additional properties in tool output schemas

### DIFF
--- a/src/FastMCP.output-schema.test.ts
+++ b/src/FastMCP.output-schema.test.ts
@@ -1,0 +1,98 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { expect, test } from "vitest";
+import { z } from "zod";
+
+import { FastMCP } from "./FastMCP.js";
+
+const callDiscoveredTool = async (
+  outputSchema: z.ZodType,
+  output: Record<string, unknown>,
+) => {
+  const server = new FastMCP({ name: "Inventory", version: "1.0.0" });
+  server.addTool({
+    execute: async () => output,
+    name: "getInventory",
+    outputSchema,
+  });
+
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "inventory-client", version: "1.0.0" });
+
+  try {
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+    // Discovery caches the advertised output schema for client-side validation.
+    const { tools } = await client.listTools();
+    const result = await client.callTool({ name: "getInventory" });
+    return { result, schema: tools[0].outputSchema };
+  } finally {
+    await client.close();
+    await server.stop();
+  }
+};
+
+test.each([
+  {
+    name: "a record",
+    output: { warehouse_a: 12, warehouse_b: 8 },
+    schema: z.record(z.string(), z.number()),
+  },
+  {
+    name: "a nested record",
+    output: { stock: { warehouse_a: 12, warehouse_b: 8 } },
+    schema: z.object({ stock: z.record(z.string(), z.number()) }),
+  },
+  {
+    name: "a loose object",
+    output: { product: "sprocket", warehouse_a: 12 },
+    schema: z.looseObject({ product: z.string() }),
+  },
+  {
+    name: "an object with a typed catchall",
+    output: { product: "sprocket", warehouse_a: 12 },
+    schema: z.object({ product: z.string() }).catchall(z.number()),
+  },
+])("accepts $name output after tools/list", async ({ output, schema }) => {
+  const { result } = await callDiscoveredTool(schema, output);
+
+  expect(result.isError).toBeFalsy();
+  expect(result.structuredContent).toEqual(output);
+});
+
+test("keeps strict output objects closed after tools/list", async () => {
+  const { result, schema } = await callDiscoveredTool(
+    z.strictObject({ warehouse_a: z.number() }),
+    { warehouse_a: 12 },
+  );
+
+  expect(schema?.additionalProperties).toBe(false);
+  expect(result.isError).toBeFalsy();
+  expect(result.structuredContent).toEqual({ warehouse_a: 12 });
+});
+
+test.each([
+  {
+    name: "an invalid record value",
+    output: { warehouse_a: "twelve" },
+    schema: z.record(z.string(), z.number()),
+  },
+  {
+    name: "an extra property in a strict object",
+    output: { warehouse_a: 12, warehouse_b: 8 },
+    schema: z.strictObject({ warehouse_a: z.number() }),
+  },
+])("rejects $name after tools/list", async ({ output, schema }) => {
+  const { result } = await callDiscoveredTool(schema, output);
+
+  expect(result.isError).toBe(true);
+  expect(result.content).toEqual([
+    {
+      text: expect.stringContaining("structured output validation failed"),
+      type: "text",
+    },
+  ]);
+});

--- a/src/FastMCP.ts
+++ b/src/FastMCP.ts
@@ -2546,9 +2546,9 @@ export class FastMCPSession<
                 }) as SDKTool["inputSchema"],
             name: tool.name,
             ...(tool.outputSchema && {
-              outputSchema: strictJsonSchema(
-                await toJsonSchema(tool.outputSchema),
-              ) as SDKTool["inputSchema"],
+              outputSchema: (await toJsonSchema(
+                tool.outputSchema,
+              )) as SDKTool["outputSchema"],
             }),
             // Pass through _meta for MCP ext-apps UI support (issue #229)
             ...(tool._meta && { _meta: tool._meta }),

--- a/src/jsonSchemaAdapter.test.ts
+++ b/src/jsonSchemaAdapter.test.ts
@@ -214,14 +214,12 @@ const withGreetServer = async (
   }
 };
 
-test("advertises the schema through tools/list, made strict like any other", async () => {
+test("advertises strict inputs and preserves the declared output schema", async () => {
   await withGreetServer(async (client) => {
     const { tools } = await client.listTools();
     const greet = tools.find((tool) => tool.name === "greet");
 
-    // The adapter's schema goes through the same strictJsonSchema pass every
-    // Zod or Valibot tool does, rather than being advertised raw — note the
-    // additionalProperties the input schema never specified.
+    // Input schemas still go through strictJsonSchema, including adapters.
     expect(greet?.inputSchema).toEqual({
       additionalProperties: false,
       properties: {
@@ -232,12 +230,12 @@ test("advertises the schema through tools/list, made strict like any other", asy
       type: "object",
     });
 
-    // outputSchema is converted by the same path, which is why it works at all
-    // — xsschema would otherwise reject the "json-schema" vendor and fail the
-    // whole listing.
-    expect(greet?.outputSchema).toMatchObject({
-      additionalProperties: false,
+    // Omitting additionalProperties allows extra output fields; keep that
+    // contract consistent with the adapter's runtime validation.
+    expect(greet?.outputSchema).toEqual({
+      properties: { greeting: { type: "string" } },
       required: ["greeting"],
+      type: "object",
     });
   });
 });

--- a/src/jsonSchemaAdapter.ts
+++ b/src/jsonSchemaAdapter.ts
@@ -50,9 +50,8 @@ type AjvValidateFunction = {
  * (and `ajv-formats` if you use `format` keywords) to use this. It is imported
  * on first validation, so servers that never call this pay nothing for it.
  *
- * Note that FastMCP applies the same strictness to every tool schema: objects
- * are advertised with `additionalProperties: false`, whatever the input schema
- * said.
+ * FastMCP advertises tool input objects with `additionalProperties: false`.
+ * Output schemas preserve the declared rules for additional properties.
  *
  * @example
  * ```ts


### PR DESCRIPTION
Closes #372.

A tool returning a warehouse-to-stock map can pass server-side validation and still fail at the client after `tools/list`. `strictJsonSchema` replaces the record's `additionalProperties: { type: "number" }` with `false`, so the advertised schema rejects every warehouse key.

Preserve the converted output schema when listing tools. This keeps record, nested record, loose-object, and catchall results consistent with runtime validation. Explicitly strict output objects stay closed, and invalid output values still produce tool errors. Input schema handling is unchanged.

Add seven regression cases that discover the tool before calling it, and update the JSON Schema adapter's listing test and documentation to reflect the output contract.

### Validation

- Full test suite (`vitest run`): 785 passed.
- OpenAPI benchmark and live tests (`OPENAPI_NETWORK=1 vitest run src/openapi/fromOpenAPI.benchmark.test.ts src/openapi/fromOpenAPI.live.test.ts`): 15 passed.
- Prettier, ESLint, TypeScript, ESM/CJS build, and JSR publish dry run passed.
- The four permissive-output regression cases fail on the unchanged base; all seven new cases pass with the fix.
- Ran the HTTP reproduction in #372 against both the unchanged base and the fix. The original fails after discovery; the fix returns the same inventory successfully before and after discovery.
